### PR TITLE
mute when out of tab, add fade when muting/unmuting

### DIFF
--- a/src/components/layout/navbar-content.tsx
+++ b/src/components/layout/navbar-content.tsx
@@ -2,8 +2,9 @@
 
 import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { useCallback, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 
+import { useIsOnTab } from "@/hooks/use-is-on-tab"
 import { useSiteAudio } from "@/hooks/use-site-audio"
 import { CameraStateKeys, useCameraStore } from "@/store/app-store"
 import { cn } from "@/utils/cn"
@@ -29,10 +30,11 @@ interface NavbarContentProps {
 }
 
 export const NavbarContent = ({ links }: NavbarContentProps) => {
-  const router = useRouter()
   const setCameraState = useCameraStore((state) => state.setCameraState)
-  const { setVolumeMaster } = useSiteAudio()
   const [music, setMusic] = useState(true)
+  const { setVolumeMaster } = useSiteAudio()
+  const isOnTab = useIsOnTab()
+  const router = useRouter()
 
   const handleNavigation = useCallback(
     (route: string, cameraState: CameraStateKeys) => {
@@ -46,6 +48,14 @@ export const NavbarContent = ({ links }: NavbarContentProps) => {
     setVolumeMaster(music ? 0 : 1)
     setMusic(!music)
   }
+
+  useEffect(() => {
+    if (!isOnTab) {
+      setVolumeMaster(0)
+    } else {
+      setVolumeMaster(music ? 1 : 0)
+    }
+  }, [isOnTab, music, setVolumeMaster])
 
   return (
     <nav

--- a/src/hooks/use-is-on-tab.ts
+++ b/src/hooks/use-is-on-tab.ts
@@ -1,0 +1,18 @@
+import { useCallback, useEffect, useState } from "react"
+
+export const useIsOnTab = () => {
+  const [visibilityState, setVisibilityState] = useState(true)
+
+  const handleVisibilityChange = useCallback(() => {
+    setVisibilityState(document.visibilityState === "visible")
+  }, [])
+
+  useEffect(() => {
+    document.addEventListener("visibilitychange", handleVisibilityChange)
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange)
+    }
+  }, [handleVisibilityChange])
+
+  return visibilityState
+}

--- a/src/hooks/use-site-audio.ts
+++ b/src/hooks/use-site-audio.ts
@@ -1,5 +1,3 @@
-"use client"
-
 import { useCallback, useEffect, useState } from "react"
 import { create } from "zustand"
 
@@ -138,7 +136,15 @@ export function useSiteAudio(): SiteAudioHook {
   const setVolumeMaster = useCallback(
     (volume: number) => {
       if (!player) return
-      player.setVolume(volume)
+      const gainNode = player.masterOutput
+      const currentTime = player.audioContext.currentTime
+      const FADE_DURATION = 0.75
+
+      gainNode.gain.cancelScheduledValues(currentTime)
+      gainNode.gain.setValueAtTime(gainNode.gain.value, currentTime)
+      gainNode.gain.linearRampToValueAtTime(volume, currentTime + FADE_DURATION)
+
+      player.volume = volume
       _setVolumeMaster(volume)
     },
     [player]


### PR DESCRIPTION
Mute all audio when out of tab, and restore it (if the user had it unmuted) when coming back into the website.
Also, we have a small fade in/out when unmuting or muting the global audio