### PR TITLE
perf: reduce sanity cdn egress with image transforms and route-gated preload

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -17,6 +17,7 @@ const nextConfig: NextConfig = {
 
   images: {
     formats: ["image/avif", "image/webp"],
+    minimumCacheTTL: 31536000,
     remotePatterns: [
       {
         protocol: "https",

--- a/src/app/(site)/(pages)/(home)/brands.tsx
+++ b/src/app/(site)/(pages)/(home)/brands.tsx
@@ -13,7 +13,7 @@ export type Brand = {
 
 /** Convert Sanity client data to the Brand shape used by brand components. */
 function toBrand(client: SanityClient): Brand {
-  const img = getImageUrl(client.logo)
+  const img = getImageUrl(client.logo, { width: 320 })
   return {
     _id: client._id,
     _title: client.title,

--- a/src/app/(site)/(pages)/blog/featured.tsx
+++ b/src/app/(site)/(pages)/blog/featured.tsx
@@ -1,16 +1,14 @@
-import Image from "next/image"
 import Link from "next/link"
 
 import { PortableText } from "@/components/primitives/portable-text"
-import { getImageUrl } from "@/service/sanity/helpers"
+import { SanityImage } from "@/components/sanity-image"
 import { formatDate } from "@/utils/format-date"
 
 import { fetchFeaturedPost } from "./sanity"
 
 export async function Featured() {
   const post = await fetchFeaturedPost()
-
-  const heroImg = post ? getImageUrl(post.heroImage) : null
+  const heroImage = post?.heroImage
 
   return (
     <section className="grid-layout">
@@ -34,15 +32,11 @@ export async function Featured() {
 
               <div className="relative col-span-full my-auto aspect-[418/228] overflow-clip bg-brand-g2/20 after:absolute after:inset-0 after:border after:border-brand-w1/20 lg:col-span-3">
                 <div className="with-dots h-full w-full">
-                  {heroImg && (
-                    <Image
-                      src={heroImg.src}
-                      alt={heroImg.alt}
-                      width={heroImg.width || 418}
-                      height={heroImg.height || 228}
-                      className="h-full w-full object-cover"
-                    />
-                  )}
+                  <SanityImage
+                    image={heroImage}
+                    sourceWidth={640}
+                    className="h-full w-full object-cover"
+                  />
                 </div>
               </div>
               <h2 className="relative col-span-full py-1 text-f-h2-mobile text-brand-w2 lg:col-start-5 lg:col-end-8 lg:text-f-h2">

--- a/src/app/(site)/(pages)/careers/[slug]/job-content.tsx
+++ b/src/app/(site)/(pages)/careers/[slug]/job-content.tsx
@@ -1,11 +1,13 @@
 import { PortableText } from "@portabletext/react"
-import Image from "next/image"
 
 import { Sandbox } from "@/app/(site)/(pages)/post/[slug]/components/sandbox"
 import { ShikiCodeBlock } from "@/app/(site)/(pages)/post/[slug]/components/shiki-code-block"
 import { CustomTweet } from "@/app/(site)/(pages)/post/[slug]/components/tweet"
-import { getImageUrl } from "@/service/sanity/helpers"
-import type { PortableTextBlock, SanityImage } from "@/service/sanity/types"
+import { SanityImage } from "@/components/sanity-image"
+import type {
+  PortableTextBlock,
+  SanityImage as SanityImageData
+} from "@/service/sanity/types"
 import { cn } from "@/utils/cn"
 
 interface JobContentProps {
@@ -97,25 +99,24 @@ export const JobContent = ({ content }: JobContentProps) => (
               <ShikiCodeBlock files={value.files ?? []} />
             </div>
           ),
-          image: ({ value }: { value: SanityImage }) => {
-            const img = getImageUrl(value)
-            if (!img) return null
+          image: ({ value }: { value: SanityImageData }) => {
+            if (!value?.asset) return null
+            const { width, height } = value.asset.metadata.dimensions
             return (
               <div className="flex w-full flex-col gap-y-2">
                 <div
                   className="image relative aspect-video w-full overflow-hidden after:absolute after:inset-0 after:border after:border-brand-w1/20"
                   style={{
-                    aspectRatio: img.width
-                      ? `${img.width}/${img.height}`
-                      : "16/9"
+                    aspectRatio: width ? `${width}/${height}` : "16/9"
                   }}
                 >
                   <div className="with-dots grid h-full w-full place-items-center">
-                    <Image
-                      src={img.src}
+                    <SanityImage
+                      image={value}
                       fill
+                      sourceWidth={1200}
                       className="object-cover"
-                      alt={img.alt || "Job description image"}
+                      alt="Job description image"
                     />
                   </div>
                 </div>
@@ -129,10 +130,9 @@ export const JobContent = ({ content }: JobContentProps) => (
               quote?: PortableTextBlock[]
               author?: string
               role?: string
-              avatar?: SanityImage
+              avatar?: SanityImageData
             }
           }) => {
-            const avatarImg = getImageUrl(value.avatar)
             return (
               <div className="custom-block relative mb-4 flex gap-x-4">
                 <div className="flex w-full flex-col gap-y-2.5">
@@ -142,15 +142,13 @@ export const JobContent = ({ content }: JobContentProps) => (
                     </div>
                   )}
                   <div className="flex flex-wrap items-center gap-x-2">
-                    {avatarImg ? (
-                      <Image
-                        src={avatarImg.src}
-                        alt={avatarImg.alt || `Avatar for ${value.author}`}
-                        width={32}
-                        height={32}
-                        className="size-8 rounded-full object-cover"
-                      />
-                    ) : null}
+                    <SanityImage
+                      image={value.avatar}
+                      width={32}
+                      height={32}
+                      alt={`Avatar for ${value.author ?? ""}`}
+                      className="size-8 rounded-full object-cover"
+                    />
                     {value.author ? (
                       <p className="text-f-p-mobile text-brand-w2 lg:text-f-p">
                         {value.author}
@@ -196,31 +194,30 @@ export const JobContent = ({ content }: JobContentProps) => (
             value
           }: {
             value: {
-              images?: SanityImage[]
+              images?: SanityImageData[]
               caption?: string
             }
           }) => (
             <div className="flex w-full flex-col gap-y-2">
               <div className="grid grid-cols-2 gap-2">
                 {value.images?.map((image, index) => {
-                  const img = getImageUrl(image)
-                  if (!img) return null
+                  if (!image?.asset) return null
+                  const { width, height } = image.asset.metadata.dimensions
                   return (
                     <div
                       key={index}
                       className="image relative aspect-video w-full overflow-hidden after:absolute after:inset-0 after:border after:border-brand-w1/20"
                       style={{
-                        aspectRatio: img.width
-                          ? `${img.width}/${img.height}`
-                          : "16/9"
+                        aspectRatio: width ? `${width}/${height}` : "16/9"
                       }}
                     >
                       <div className="with-dots grid h-full w-full place-items-center">
-                        <Image
-                          src={img.src}
+                        <SanityImage
+                          image={image}
                           fill
+                          sourceWidth={800}
                           className="object-cover"
-                          alt={img.alt || "Gallery image"}
+                          alt="Gallery image"
                         />
                       </div>
                     </div>

--- a/src/app/(site)/(pages)/people/page.tsx
+++ b/src/app/(site)/(pages)/people/page.tsx
@@ -35,7 +35,7 @@ const About = async () => {
   if (!pageData) notFound()
 
   const peopleDisplay: PersonDisplay[] = people.map((p) => {
-    const img = p.image ? getImageUrl(p.image) : null
+    const img = p.image ? getImageUrl(p.image, { width: 600 }) : null
     return {
       title: p.title,
       department: p.department?.title ?? null,

--- a/src/app/(site)/(pages)/people/pre-open-positions.tsx
+++ b/src/app/(site)/(pages)/people/pre-open-positions.tsx
@@ -1,41 +1,36 @@
 import { PortableText } from "@portabletext/react"
-import Image from "next/image"
 
-import { getImageUrl } from "@/service/sanity/helpers"
+import { SanityImage } from "@/components/sanity-image"
 
 import type { PeoplePageData } from "./sanity"
 
 export const PreOpenPositions = ({ data }: { data: PeoplePageData }) => {
-  const sideA = getImageUrl(data.preOpenPositionsSideImages?.[0])
-  const sideB = getImageUrl(data.preOpenPositionsSideImages?.[1])
+  const sideA = data.preOpenPositionsSideImages?.[0]
+  const sideB = data.preOpenPositionsSideImages?.[1]
 
   return (
     <section className="grid-layout mb-18 lg:mb-48">
       <div className="col-span-full mb-4 text-pretty text-f-h4-mobile text-brand-w1 lg:col-start-9 lg:col-end-12 lg:mb-0 lg:text-f-h4">
         <PortableText value={data.preOpenPositionsText ?? []} />
       </div>
-      {sideA && (
+      {sideA?.asset && (
         <div className="with-dots col-span-2 h-full w-full object-cover lg:col-start-1 lg:col-end-5 lg:row-start-1 lg:h-fit">
           <div className="relative h-full after:pointer-events-none after:absolute after:inset-0 after:border after:border-brand-w1/20">
-            <Image
-              src={sideA.src}
-              alt={sideA.alt ?? ""}
-              width={sideA.width}
-              height={sideA.height}
+            <SanityImage
+              image={sideA}
+              sourceWidth={800}
               className="h-full w-full object-cover"
             />
           </div>
         </div>
       )}
 
-      {sideB && (
+      {sideB?.asset && (
         <div className="with-dots col-span-2 lg:col-start-5 lg:col-end-9 lg:row-start-1">
           <div className="relative after:pointer-events-none after:absolute after:inset-0 after:border after:border-brand-w1/20">
-            <Image
-              src={sideB.src}
-              alt={sideB.alt ?? ""}
-              width={sideB.width}
-              height={sideB.height}
+            <SanityImage
+              image={sideB}
+              sourceWidth={800}
               className="h-full w-full object-cover"
             />
           </div>

--- a/src/app/(site)/(pages)/people/values.tsx
+++ b/src/app/(site)/(pages)/people/values.tsx
@@ -1,7 +1,6 @@
 import { PortableText } from "@portabletext/react"
-import Image from "next/image"
 
-import { getImageUrl } from "@/service/sanity/helpers"
+import { SanityImage } from "@/components/sanity-image"
 import { cn } from "@/utils/cn"
 
 import type { ValueItem } from "./sanity"
@@ -10,8 +9,6 @@ export const Values = ({ data }: { data: ValueItem[] }) => (
   <section className="mb-18 lg:mb-48">
     <div className="grid-layout !gap-y-0">
       {data.map(({ _key, title, image, description }, idx) => {
-        const img = getImageUrl(image)
-
         return (
           <div
             key={_key ?? title}
@@ -49,14 +46,12 @@ export const Values = ({ data }: { data: ValueItem[] }) => (
                   {title}
                 </p>
                 <div className="col-span-full sm:col-span-2 lg:col-start-5 lg:col-end-9">
-                  {img && (
+                  {image?.asset && (
                     <div className="relative aspect-[6/6] w-full after:pointer-events-none after:absolute after:inset-0 after:border after:border-brand-w1/20 sm:col-span-1 md:col-span-2">
                       <div className="with-dots h-full w-full">
-                        <Image
-                          src={img.src}
-                          alt={img.alt ?? ""}
-                          width={img.width}
-                          height={img.height}
+                        <SanityImage
+                          image={image}
+                          sourceWidth={1000}
                           className="h-full w-full object-cover"
                         />
                       </div>

--- a/src/app/(site)/(pages)/post/[slug]/content.tsx
+++ b/src/app/(site)/(pages)/post/[slug]/content.tsx
@@ -1,8 +1,7 @@
 import { PortableText } from "@portabletext/react"
-import Image from "next/image"
 
-import { getImageUrl } from "@/service/sanity/helpers"
-import type { PortableTextBlock, SanityImage } from "@/service/sanity/types"
+import { SanityImage } from "@/components/sanity-image"
+import type { PortableTextBlock, SanityImage as SanityImageData } from "@/service/sanity/types"
 import { cn } from "@/utils/cn"
 
 import { Back } from "./back"
@@ -163,26 +162,25 @@ export const Content = ({ post }: ContentProps) => {
                   image: ({
                     value
                   }: {
-                    value: SanityImage & { caption?: string }
+                    value: SanityImageData & { caption?: string }
                   }) => {
-                    const img = getImageUrl(value)
-                    if (!img) return null
+                    if (!value?.asset) return null
+                    const { width, height } = value.asset.metadata.dimensions
                     return (
                       <div className="flex w-full flex-col gap-y-2">
                         <div
                           className="image relative aspect-video w-full overflow-hidden after:absolute after:inset-0 after:border after:border-brand-w1/20"
                           style={{
-                            aspectRatio: img.width
-                              ? `${img.width}/${img.height}`
-                              : "16/9"
+                            aspectRatio: width ? `${width}/${height}` : "16/9"
                           }}
                         >
                           <div className="with-dots grid h-full w-full place-items-center">
-                            <Image
-                              src={img.src}
+                            <SanityImage
+                              image={value}
                               fill
+                              sourceWidth={1200}
                               className="object-cover"
-                              alt={img.alt ?? "Blog image"}
+                              alt="Blog image"
                             />
                           </div>
                         </div>
@@ -201,10 +199,9 @@ export const Content = ({ post }: ContentProps) => {
                       quote?: PortableTextBlock[]
                       author?: string
                       role?: string
-                      avatar?: SanityImage
+                      avatar?: SanityImageData
                     }
                   }) => {
-                    const avatarImg = getImageUrl(value.avatar)
                     return (
                       <div className="custom-block relative mb-4 flex gap-x-4">
                         <div className="flex w-full flex-col gap-y-2.5">
@@ -214,17 +211,14 @@ export const Content = ({ post }: ContentProps) => {
                             </div>
                           )}
                           <div className="flex flex-wrap items-center gap-x-2">
-                            {avatarImg ? (
-                              <Image
-                                src={avatarImg.src}
-                                alt={
-                                  avatarImg.alt || `Avatar for ${value.author}`
-                                }
-                                width={32}
-                                height={32}
-                                className="size-8 rounded-full object-cover"
-                              />
-                            ) : null}
+                            <SanityImage
+                              image={value.avatar}
+                              width={32}
+                              height={32}
+                              alt={`Avatar for ${value.author ?? ""}`}
+                              className="size-8 rounded-full object-cover"
+                            />
+
                             {value.author ? (
                               <p className="text-f-p-mobile text-brand-w2 lg:text-f-p">
                                 {value.author}
@@ -289,31 +283,33 @@ export const Content = ({ post }: ContentProps) => {
                     value
                   }: {
                     value: {
-                      images?: SanityImage[]
+                      images?: SanityImageData[]
                       caption?: string
                     }
                   }) => (
                     <div className="flex w-full flex-col gap-y-2">
                       <div className="grid grid-cols-2 gap-2">
                         {value.images?.map((image, index) => {
-                          const img = getImageUrl(image)
-                          if (!img) return null
+                          if (!image?.asset) return null
+                          const { width, height } =
+                            image.asset.metadata.dimensions
                           return (
                             <div
                               key={index}
                               className="image relative aspect-video w-full overflow-hidden after:absolute after:inset-0 after:border after:border-brand-w1/20"
                               style={{
-                                aspectRatio: img.width
-                                  ? `${img.width}/${img.height}`
+                                aspectRatio: width
+                                  ? `${width}/${height}`
                                   : "16/9"
                               }}
                             >
                               <div className="with-dots grid h-full w-full place-items-center">
-                                <Image
-                                  src={img.src}
+                                <SanityImage
+                                  image={image}
                                   fill
+                                  sourceWidth={800}
                                   className="object-cover"
-                                  alt={img.alt || "Blog image"}
+                                  alt="Blog image"
                                 />
                               </div>
                             </div>

--- a/src/app/(site)/(pages)/post/[slug]/more.tsx
+++ b/src/app/(site)/(pages)/post/[slug]/more.tsx
@@ -1,10 +1,8 @@
 "use client"
 
-import Image from "next/image"
-
+import { SanityImage } from "@/components/sanity-image"
 import { Link } from "@/components/primitives/link"
 import { useMedia } from "@/hooks/use-media"
-import { getImageUrl } from "@/service/sanity/helpers"
 import { formatDate } from "@/utils/format-date"
 
 import type { RelatedPost } from "./sanity"
@@ -26,8 +24,6 @@ export const More = ({ posts }: MoreProps) => {
         <div className="flex flex-col divide-y divide-brand-g1/30">
           <div />
           {posts.map((post) => {
-            const heroImg = post.heroImage ? getImageUrl(post.heroImage) : null
-
             return (
               <div key={post._id} className="group relative">
                 <Link
@@ -38,21 +34,13 @@ export const More = ({ posts }: MoreProps) => {
                   <div className="with-diagonal-lines pointer-events-none !absolute -bottom-px -top-px left-0 right-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
 
                   <div className="relative h-[60px] w-[136px] overflow-clip after:absolute after:inset-0 after:border after:border-brand-w1/20">
-                    {heroImg && (
-                      <Image
-                        src={heroImg.src}
-                        alt={post.title}
-                        width={272}
-                        height={120}
-                        className="h-full w-full object-cover"
-                        {...(heroImg.blurDataURL
-                          ? {
-                              placeholder: "blur",
-                              blurDataURL: heroImg.blurDataURL
-                            }
-                          : {})}
-                      />
-                    )}
+                    <SanityImage
+                      image={post.heroImage}
+                      alt={post.title}
+                      width={272}
+                      height={120}
+                      className="h-full w-full object-cover"
+                    />
                   </div>
 
                   <div className="relative flex w-full justify-between gap-y-2">

--- a/src/app/(site)/(pages)/services/hero.tsx
+++ b/src/app/(site)/(pages)/services/hero.tsx
@@ -1,9 +1,8 @@
 "use client"
 
 import { PortableText } from "@portabletext/react"
-import Image from "next/image"
 
-import { getImageUrl } from "@/service/sanity/helpers"
+import { SanityImage } from "@/components/sanity-image"
 import { cn } from "@/utils/cn"
 
 import type { ServicesPageData } from "./sanity"
@@ -14,22 +13,19 @@ interface HeroProps {
 }
 
 export const Hero = ({ data, className }: HeroProps) => {
-  const heroImg = getImageUrl(data.heroImage)
+  const heroImage = data.heroImage
 
   return (
     <section className={cn("grid-layout !gap-y-4 lg:!gap-y-2", className)}>
       <h1 className="col-span-full text-f-h0-mobile text-brand-w2 lg:col-start-1 lg:col-end-6 lg:text-f-h0">
         Services
       </h1>
-      {heroImg && (
-        <Image
-          alt={heroImg.alt || "Services image"}
-          src={heroImg.src}
-          width={heroImg.width}
-          height={heroImg.height}
-          className="hidden lg:col-start-6 lg:col-end-9 lg:block"
-        />
-      )}
+      <SanityImage
+        image={heroImage}
+        alt={heroImage?.alt || "Services image"}
+        sourceWidth={720}
+        className="hidden lg:col-start-6 lg:col-end-9 lg:block"
+      />
       <div className="col-start-1 col-end-5 flex flex-col gap-4 text-f-h3-mobile text-brand-w2 lg:col-start-9 lg:col-end-13 lg:text-f-h4">
         {data.intro && <PortableText value={data.intro} />}
       </div>

--- a/src/app/(site)/(pages)/services/page.tsx
+++ b/src/app/(site)/(pages)/services/page.tsx
@@ -40,7 +40,7 @@ const ServicesPage = async () => {
   if (!data) notFound()
 
   const displayAwards: AwardDisplay[] = awards.map((award, index) => {
-    const cert = getImageUrl(award.certificate)
+    const cert = getImageUrl(award.certificate, { width: 400 })
     return {
       _id: award._id,
       title: award.title,

--- a/src/app/(site)/(pages)/services/testimonials.tsx
+++ b/src/app/(site)/(pages)/services/testimonials.tsx
@@ -2,11 +2,10 @@ import {
   PortableText,
   type PortableTextComponents
 } from "@portabletext/react"
-import Image from "next/image"
 import { memo } from "react"
 
 import { Link } from "@/components/primitives/link"
-import { getImageUrl } from "@/service/sanity/helpers"
+import { SanityImage } from "@/components/sanity-image"
 import { cn } from "@/utils/cn"
 
 import type { ServiceTestimonial } from "./sanity"
@@ -38,23 +37,19 @@ const RoleContent = ({ role }: { role: ServiceTestimonial["role"] }) => {
 
 const TestimonialAvatar = memo(
   ({ avatar }: { avatar: ServiceTestimonial["avatar"] }) => {
-    const img = getImageUrl(avatar)
-    if (!img) return null
+    if (!avatar?.asset) return null
 
     return (
       <div className="with-dots">
         <div className="after:pointer-events-none after:absolute after:inset-0 after:border after:border-brand-w1/20">
-          <Image
-            alt={img.alt || ""}
-            blurDataURL={img.blurDataURL}
+          <SanityImage
+            image={avatar}
+            sourceWidth={192}
+            alt=""
             className="size-16 lg:size-24"
             draggable={false}
-            height={img.height}
-            width={img.width}
-            placeholder="blur"
             quality={100}
             sizes="(max-width: 1024px) 192px, 288px"
-            src={img.src}
           />
         </div>
       </div>

--- a/src/app/(site)/(pages)/services/ventures.tsx
+++ b/src/app/(site)/(pages)/services/ventures.tsx
@@ -1,7 +1,5 @@
-import Image from "next/image"
-
 import { PortableText } from "@/components/primitives/portable-text"
-import { getImageUrl } from "@/service/sanity/helpers"
+import { SanityImage } from "@/components/sanity-image"
 
 import type { ServicesPageData } from "./sanity"
 
@@ -9,7 +7,7 @@ export const VenturesBanner = ({ data }: { data: ServicesPageData }) => {
   const venture = data.ventures[0]
   if (!venture) return null
 
-  const img = getImageUrl(venture.image)
+  const image = venture.image
 
   return (
     <div className="grid-layout -mb-6">
@@ -39,10 +37,10 @@ export const VenturesBanner = ({ data }: { data: ServicesPageData }) => {
         )}
       </div>
 
-      {img && (
+      {image?.asset && (
         <div className="with-dots col-span-full mt-8 lg:col-start-1 lg:col-end-12 lg:mt-18">
           <div className="relative after:pointer-events-none after:absolute after:inset-0 after:border after:border-brand-w1/20">
-            <Image width={img.width} height={img.height} src={img.src} alt="" />
+            <SanityImage image={image} sourceWidth={1600} alt="" />
           </div>
         </div>
       )}

--- a/src/app/(site)/(pages)/showcase/[slug]/gallery.tsx
+++ b/src/app/(site)/(pages)/showcase/[slug]/gallery.tsx
@@ -1,9 +1,7 @@
 "use client"
 
-import Image from "next/image"
-
+import { SanityImage } from "@/components/sanity-image"
 import { Video } from "@/components/primitives/video"
-import { getImageUrl } from "@/service/sanity/helpers"
 import { cn } from "@/utils/cn"
 
 import { useProjectContext } from "./context"
@@ -22,7 +20,6 @@ export function ProjectGallery({ entry }: { entry: ShowcaseProjectDetail }) {
       )}
     >
       {showcase?.map(({ image, video }, idx) => {
-        const img = getImageUrl(image)
         return (
           <div
             key={image?.asset?.url || video?.url || idx}
@@ -48,15 +45,11 @@ export function ProjectGallery({ entry }: { entry: ShowcaseProjectDetail }) {
                   className="h-full w-full object-cover"
                 />
               </div>
-            ) : img ? (
+            ) : image?.asset ? (
               <div className="with-dots h-full w-full after:absolute after:inset-0">
-                <Image
-                  src={img.src}
-                  width={img.width}
-                  height={img.height}
-                  alt={img.alt || ""}
-                  blurDataURL={img.blurDataURL}
-                  placeholder="blur"
+                <SanityImage
+                  image={image}
+                  sourceWidth={1600}
                   className="object-cover"
                   priority={idx <= 3}
                 />

--- a/src/app/(site)/(pages)/showcase/[slug]/info.tsx
+++ b/src/app/(site)/(pages)/showcase/[slug]/info.tsx
@@ -1,12 +1,10 @@
-import Image from "next/image"
-
 import { ExternalLinkIcon } from "@/components/icons/icons"
 import { Arrow } from "@/components/primitives/icons/arrow"
 import { InfoItem } from "@/components/primitives/info-item"
 import { Link } from "@/components/primitives/link"
 import { PortableText } from "@/components/primitives/portable-text"
 import { TextList } from "@/components/primitives/text-list"
-import { getImageUrl } from "@/service/sanity/helpers"
+import { SanityImage } from "@/components/sanity-image"
 
 import { Back } from "./back"
 import { Filters } from "./gallery-filter"
@@ -23,8 +21,6 @@ export const ProjectInfo = ({ entry }: ProjectInfoProps) => {
     typeof entry.caseStudy === "string"
       ? entry.caseStudy.replace(/\/$/, "")
       : null
-  const coverImg = getImageUrl(entry.cover)
-  const iconImg = getImageUrl(entry.icon)
 
   return (
     <div className="col-span-full row-start-1 flex h-full flex-col gap-4 lg:col-span-3 lg:row-start-auto xl:col-span-2">
@@ -41,12 +37,13 @@ export const ProjectInfo = ({ entry }: ProjectInfoProps) => {
             label="Client"
             value={
               <span className="flex min-w-0 items-center gap-0.75">
-                {iconImg ? (
+                {entry.icon?.asset ? (
                   <span className="relative size-3.5 shrink-0 overflow-hidden rounded-full border border-brand-w1/20 bg-brand-g2">
-                    <Image
-                      src={iconImg.src}
+                    <SanityImage
+                      image={entry.icon}
                       fill
-                      alt={iconImg.alt || entry.client?.title || "Client logo"}
+                      sourceWidth={64}
+                      alt={entry.client?.title || "Client logo"}
                     />
                   </span>
                 ) : null}
@@ -99,11 +96,11 @@ export const ProjectInfo = ({ entry }: ProjectInfoProps) => {
         </ul>
 
         <div className="relative aspect-video w-full overflow-hidden after:absolute after:inset-0 after:border after:border-brand-w1/20 lg:hidden">
-          {coverImg ? (
-            <Image
-              src={coverImg.src}
-              alt={coverImg.alt || ""}
+          {entry.cover?.asset ? (
+            <SanityImage
+              image={entry.cover}
               fill
+              sourceWidth={1200}
               className="with-dots relative object-cover"
             />
           ) : null}

--- a/src/app/(site)/(pages)/showcase/[slug]/related.tsx
+++ b/src/app/(site)/(pages)/showcase/[slug]/related.tsx
@@ -1,8 +1,6 @@
-import Image from "next/image"
-
 import { Arrow } from "@/components/primitives/icons/arrow"
 import { Link } from "@/components/primitives/link"
-import { getImageUrl } from "@/service/sanity/helpers"
+import { SanityImage } from "@/components/sanity-image"
 import { cn } from "@/utils/cn"
 
 import { fetchRelatedProjects } from "./sanity"
@@ -27,7 +25,6 @@ export const RelatedProjects = async ({
       <ul className="flex flex-col divide-y divide-brand-w1/20">
         <div />
         {projects.map((item) => {
-          const iconImg = getImageUrl(item.icon)
           return (
             <Link
               href={`/showcase/${item.slug}`}
@@ -36,14 +33,15 @@ export const RelatedProjects = async ({
               aria-label={`View ${item.title ?? "Untitled"}`}
             >
               <span className="flex items-center gap-1.75">
-                {iconImg ? (
+                {item.icon?.asset ? (
                   <span className="relative size-4.5 overflow-hidden rounded-full border border-brand-w1/20 bg-brand-g2">
-                    <Image
-                      src={iconImg.src}
+                    <SanityImage
+                      image={item.icon}
                       width={16}
                       height={16}
+                      sourceWidth={64}
                       className="object-cover"
-                      alt={iconImg.alt || "Client logo"}
+                      alt="Client logo"
                     />
                   </span>
                 ) : null}

--- a/src/app/(site)/(pages)/showcase/list.tsx
+++ b/src/app/(site)/(pages)/showcase/list.tsx
@@ -1,12 +1,11 @@
 import * as AccordionPrimitive from "@radix-ui/react-accordion"
 import { motion } from "motion/react"
-import Image from "next/image"
 import Link from "next/link"
 import { memo, useCallback, useState } from "react"
 
 import { Arrow } from "@/components/primitives/icons/arrow"
 import { Video } from "@/components/primitives/video"
-import { getImageUrl } from "@/service/sanity/helpers"
+import { SanityImage } from "@/components/sanity-image"
 import { cn } from "@/utils/cn"
 
 import type { ShowcaseProject } from "./sanity"
@@ -20,7 +19,6 @@ interface AccordionListItemProps {
 const AccordionListItem = memo(
   ({ project, index, disabled }: AccordionListItemProps) => {
     const [firstItemSeen, setFirstItemSeen] = useState(false)
-    const icon = getImageUrl(project.icon)
     return (
       <AccordionPrimitive.Item
         key={index}
@@ -48,12 +46,10 @@ const AccordionListItem = memo(
             )}
           >
             <div className="relative col-span-4 flex items-center gap-2 text-f-h3 text-brand-w2 transition-opacity duration-300">
-              {icon?.src ? (
-                <Image
-                  src={icon.src}
-                  alt={icon.alt ?? ""}
-                  width={icon.width}
-                  height={icon.height}
+              {project.icon?.asset ? (
+                <SanityImage
+                  image={project.icon}
+                  sourceWidth={64}
                   className="mb-px size-4.5 rounded-full border border-brand-w1/10"
                   priority
                 />
@@ -108,7 +104,6 @@ const AccordionListItem = memo(
               aria-label={`View ${project.title ?? "Untitled"}`}
             >
               {project.showcase?.map((item, imgIndex, array) => {
-                const img = getImageUrl(item.image)
                 const elementToRender = item.video ? (
                   <Video
                     key={imgIndex}
@@ -119,11 +114,11 @@ const AccordionListItem = memo(
                     className="h-full w-full object-cover"
                   />
                 ) : (
-                  <Image
+                  <SanityImage
                     key={imgIndex}
-                    src={img?.src ?? ""}
-                    alt={img?.alt ?? ""}
+                    image={item.image}
                     fill
+                    sourceWidth={1200}
                     sizes="(max-width: 1024px) 90vw, 15vw"
                     priority
                   />

--- a/src/components/blog/list/index.tsx
+++ b/src/components/blog/list/index.tsx
@@ -1,8 +1,7 @@
-import Image from "next/image"
 import Link from "next/link"
 
 import { fetchPosts } from "@/app/(site)/(pages)/blog/sanity"
-import { getImageUrl } from "@/service/sanity/helpers"
+import { SanityImage } from "@/components/sanity-image"
 import { formatDate } from "@/utils/format-date"
 
 export const BlogList = async ({ params }: { params: { slug: string[] } }) => {
@@ -11,8 +10,6 @@ export const BlogList = async ({ params }: { params: { slug: string[] } }) => {
   return (
     <div className="col-span-full flex flex-col gap-12 lg:gap-3">
       {posts.map((post) => {
-        const heroImg = getImageUrl(post.heroImage)
-
         return (
           <div
             key={post.slug}
@@ -26,16 +23,14 @@ export const BlogList = async ({ params }: { params: { slug: string[] } }) => {
               <div className="with-diagonal-lines pointer-events-none !absolute -bottom-px -top-px left-0 right-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
               <div className="relative col-span-full my-auto aspect-[418/228] w-full overflow-clip bg-brand-g2/20 after:absolute after:inset-0 after:border after:border-brand-w1/20 lg:col-span-2 lg:aspect-auto lg:h-[124px] lg:max-w-[276px]">
                 <div className="with-dots h-full w-full">
-                  {heroImg && (
-                    <Image
-                      src={heroImg.src}
-                      alt={heroImg.alt}
-                      fill
-                      sizes="(max-width: 1024px) 100vw, 276px"
-                      className="h-full w-full object-cover"
-                      quality={100}
-                    />
-                  )}
+                  <SanityImage
+                    image={post.heroImage}
+                    fill
+                    sourceWidth={552}
+                    sizes="(max-width: 1024px) 100vw, 276px"
+                    className="h-full w-full object-cover"
+                    quality={100}
+                  />
                 </div>
               </div>
               <p className="lg:col-span-[auto] relative col-span-full text-f-h3-mobile text-brand-w2 lg:col-start-5 lg:col-end-8 lg:text-f-h3">

--- a/src/components/sanity-image/index.tsx
+++ b/src/components/sanity-image/index.tsx
@@ -1,0 +1,44 @@
+import Image, { type ImageProps } from "next/image"
+
+import { buildSanityImageUrl } from "@/service/sanity/helpers"
+import type { SanityImage as SanityImageData } from "@/service/sanity/types"
+
+type Props = Omit<ImageProps, "src" | "alt"> & {
+  image: SanityImageData | null | undefined
+  alt?: string
+  /**
+   * Width of the variant to request from Sanity's CDN. Defaults to `2 × width`
+   * for retina headroom. Pass explicitly when using `fill` mode.
+   */
+  sourceWidth?: number
+}
+
+export function SanityImage(props: Props) {
+  const { image, alt, sourceWidth, blurDataURL, placeholder, ...rest } = props
+  if (!image?.asset) return null
+  const { asset } = image
+
+  const sw =
+    sourceWidth ??
+    (typeof rest.width === "number" ? rest.width * 2 : undefined)
+  const src = buildSanityImageUrl(asset.url, { width: sw })
+
+  const isFill = "fill" in rest && rest.fill === true
+  const dimensions = isFill
+    ? {}
+    : {
+        width: rest.width ?? asset.metadata.dimensions.width,
+        height: rest.height ?? asset.metadata.dimensions.height
+      }
+
+  return (
+    <Image
+      {...(rest as ImageProps)}
+      {...dimensions}
+      src={src}
+      alt={alt ?? image.alt ?? ""}
+      placeholder={placeholder ?? (asset.metadata.lqip ? "blur" : "empty")}
+      blurDataURL={blurDataURL ?? asset.metadata.lqip}
+    />
+  )
+}

--- a/src/hooks/use-preload-assets.ts
+++ b/src/hooks/use-preload-assets.ts
@@ -1,3 +1,4 @@
+import { useEffect } from "react"
 import { preload, PreloadOptions } from "react-dom"
 
 import { AssetsResult } from "@/components/assets-provider/fetch-assets"
@@ -205,6 +206,9 @@ const preloadAllAssets = (obj: any) => {
 
 export const usePreloadAssets = (assets: AssetsResult) => {
   const offscreenCanvasReady = useAppLoadingStore((s) => s.offscreenCanvasReady)
+  const isCanvasInPage = useAppLoadingStore((s) => s.isCanvasInPage)
 
-  if (offscreenCanvasReady) preloadAllAssets(assets)
+  useEffect(() => {
+    if (offscreenCanvasReady && isCanvasInPage) preloadAllAssets(assets)
+  }, [assets, offscreenCanvasReady, isCanvasInPage])
 }

--- a/src/service/sanity/client.ts
+++ b/src/service/sanity/client.ts
@@ -7,5 +7,6 @@ export const client = createClient({
   dataset,
   apiVersion,
   useCdn: true,
-  stega: { studioUrl: "/studio" }
+  stega:
+    process.env.NODE_ENV === "development" ? { studioUrl: "/studio" } : false
 })

--- a/src/service/sanity/helpers.ts
+++ b/src/service/sanity/helpers.ts
@@ -1,12 +1,33 @@
 import type { SanityImage } from "./types"
 
 /**
+ * Build a transformed Sanity CDN URL from an asset URL.
+ *
+ * `auto=format` and `fit=max` are always applied so Sanity returns AVIF/WebP
+ * (when the client supports it) and never upscales beyond the original asset.
+ */
+export function buildSanityImageUrl(
+  assetUrl: string,
+  opts?: { width?: number; quality?: number }
+): string {
+  const params = new URLSearchParams({ auto: "format", fit: "max" })
+  if (opts?.width) params.set("w", String(opts.width))
+  if (opts?.quality) params.set("q", String(opts.quality))
+  return `${assetUrl}?${params.toString()}`
+}
+
+/**
  * Converts a SanityImage (projected via `imageFragment`) into the flat shape
  * expected by Next.js `<Image>` and the codebase's existing image components.
  *
  * Returns `null` when the image asset is missing (e.g. unpublished reference).
+ * Prefer the `<SanityImage>` wrapper for rendering; this helper is for cases
+ * that need to read width/height/blur outside the render tree.
  */
-export function getImageUrl(image: SanityImage | null | undefined): {
+export function getImageUrl(
+  image: SanityImage | null | undefined,
+  opts?: { width?: number; quality?: number }
+): {
   src: string
   width: number
   height: number
@@ -17,7 +38,7 @@ export function getImageUrl(image: SanityImage | null | undefined): {
 
   const { asset, alt } = image
   return {
-    src: asset.url,
+    src: buildSanityImageUrl(asset.url, opts),
     width: asset.metadata.dimensions.width,
     height: asset.metadata.dimensions.height,
     blurDataURL: asset.metadata.lqip,


### PR DESCRIPTION
## Why

Post-PR-#398 (Sanity migration), the project's Sanity CDN traffic jumped from ~4K/day to ~76K/day with ~68 GB egress in a week against just ~9.7K page views. Root causes were eager video preloading, site-wide 3D-asset preloading on non-3D routes, and full-resolution image originals being shipped to every visitor.

This PR addresses the image and 3D-preload paths. Videos will be migrated to Mux and 3D assets to Cloudflare R2 in separate PRs.

## What

### `<SanityImage>` wrapper ([src/components/sanity-image/index.tsx](https://github.com/basementstudio/website-2k25/blob/mar/ecstatic-rosalind-1f918e/src/components/sanity-image/index.tsx))
A single component for rendering Sanity images. It:
- Appends `?auto=format&fit=max&w=N` to the Sanity asset URL so the CDN returns AVIF/WebP at the requested size (Vercel's optimizer then wraps a small pre-sized input instead of fetching the multi-MB original).
- Defaults `sourceWidth` to `2 × width` for retina, with an explicit override for `fill` mode.
- Auto-derives `width`/`height` from `asset.metadata.dimensions` so callers don't need to read into Sanity internals.
- Auto-wires `blurDataURL` from `asset.metadata.lqip` and defaults `placeholder="blur"` when an LQIP is present.
- Returns `null` when the image asset is missing.

### Migrated ~15 call sites
`featured.tsx`, `services/hero.tsx`, `post/content.tsx` (3 sites), `post/more.tsx`, `careers/job-content.tsx` (3 sites), `people/values.tsx`, `people/pre-open-positions.tsx`, `showcase/info.tsx` (2 sites), `showcase/related.tsx`, `showcase/list.tsx` (2 sites), `showcase/gallery.tsx`, `services/ventures.tsx`, `services/testimonials.tsx`, `blog/list/index.tsx`.

Brands, people, and services pages keep using `getImageUrl()` because they transform results into derived display shapes (`Brand`, `PersonDisplay`, `AwardDisplay`) passed downstream. They still benefit from `auto=format` via the helper.

### Route-gated 3D-asset preload ([use-preload-assets.ts:209](https://github.com/basementstudio/website-2k25/blob/mar/ecstatic-rosalind-1f918e/src/hooks/use-preload-assets.ts#L209))
`usePreloadAssets` now subscribes to `isCanvasInPage` from the loading store and only preloads when the 3D canvas actually mounts. Reuses the existing `BLACKLISTED_PATHS` source of truth in [content-wrapper.tsx](https://github.com/basementstudio/website-2k25/blob/mar/ecstatic-rosalind-1f918e/src/components/layout/content-wrapper.tsx) so no duplicate route logic. Routes that no longer preload 3D assets: `/post/*`, `/contact`, `/webby`, `/webby/es`, `/careers/[slug]`, `/showcase/[slug]`.

`preloadAllAssets()` is also moved into `useEffect` so the asset tree isn't walked on every render.

### `images.minimumCacheTTL: 31536000` ([next.config.ts:20](https://github.com/basementstudio/website-2k25/blob/mar/ecstatic-rosalind-1f918e/next.config.ts#L20))
Sanity URLs (and our other remote patterns) are content-addressed via SHA hashes, so a 1-year cache is safe — the URL changes whenever content changes. Cuts repeat optimizer fetches from Sanity to ~0.

### `stega` gated to dev ([client.ts:10](https://github.com/basementstudio/website-2k25/blob/mar/ecstatic-rosalind-1f918e/src/service/sanity/client.ts#L10))
Stega-encoded URLs added invisible metadata to every CMS-derived string in production and triggered extra revalidation. Visual Editing in preview wasn't in use, so dev-only is safe. If we ever want preview-mode editing, can switch to a `draftMode().isEnabled` gate.

## Expected impact

Based on the past-week traffic breakdown (Sanity dashboard):

| Bucket | Before | After |
|---|---|---|
| Image bandwidth | Original-resolution PNG/JPEG per logo (sometimes MB each) | AVIF/WebP at display width (KB each) |
| 3D asset preload | Every site route preloaded ~80–120 `.glb / .exr / .ktx2 / .mp3 / .wav` | Only 3D routes preload these |
| Per-render work | `preloadAllAssets()` walked the tree on every render | Walks once per asset/route change |
| Image cache misses | Vercel re-fetched originals every 60s | One year per content-addressed variant |
| Stega payload in prod | On every GROQ response | Dev only |

Videos (~60% of original egress) untouched here — addressed in the upcoming Mux migration.

## Test plan

- [ ] Load `/` — homepage brand logos render via Sanity transforms; check Network tab for `cdn.sanity.io/images/...?auto=format&fit=max&w=320` requests instead of raw originals.
- [ ] Load `/post/*` and `/contact` — confirm `<link rel="preload">` for `.glb / .exr / .ktx2` no longer present in `<head>`.
- [ ] Load `/` and `/showcase` — confirm 3D scene still mounts and basketball/3D assets still load when canvas is present.
- [ ] Spot-check a blog post page — inline `image` and `gridGallery` portable-text blocks render correctly with blur placeholder.
- [ ] Spot-check `/showcase/[slug]` — gallery images and project icon render correctly.
- [ ] Visual editing in Sanity Studio: confirm `/studio` still works (we did not touch presentation tool; stega is dev-only).