### PR TITLE
perf(video): tune Mux quality, auto-pause offscreen, lazy mount

### DIFF
--- a/src/app/(site)/(pages)/post/[slug]/content.tsx
+++ b/src/app/(site)/(pages)/post/[slug]/content.tsx
@@ -1,7 +1,7 @@
 import { PortableText } from "@portabletext/react"
 import Image from "next/image"
 
-import { Video } from "@/components/primitives/video"
+import { LazyVideo } from "@/components/primitives/lazy-video"
 import { getImageUrl } from "@/service/sanity/helpers"
 import type {
   PortableTextBlock,
@@ -351,12 +351,13 @@ export const Content = ({ post }: ContentProps) => {
                         <div className="video relative w-full overflow-hidden after:absolute after:inset-0 after:border after:border-brand-w1/20">
                           <div className="with-dots grid h-full w-full place-items-center">
                             {muxPlaybackId ? (
-                              <Video
+                              <LazyVideo
                                 playbackId={muxPlaybackId}
                                 autoPlay
                                 loop
                                 muted
                                 playsInline
+                                maxResolution="1080p"
                                 className="h-full w-full object-cover"
                               />
                             ) : (

--- a/src/app/(site)/(pages)/post/[slug]/content.tsx
+++ b/src/app/(site)/(pages)/post/[slug]/content.tsx
@@ -1,7 +1,7 @@
 import { PortableText } from "@portabletext/react"
 import Image from "next/image"
 
-import { LazyVideo } from "@/components/primitives/lazy-video"
+import { Video } from "@/components/primitives/video"
 import { getImageUrl } from "@/service/sanity/helpers"
 import type {
   PortableTextBlock,
@@ -351,7 +351,7 @@ export const Content = ({ post }: ContentProps) => {
                         <div className="video relative w-full overflow-hidden after:absolute after:inset-0 after:border after:border-brand-w1/20">
                           <div className="with-dots grid h-full w-full place-items-center">
                             {muxPlaybackId ? (
-                              <LazyVideo
+                              <Video
                                 playbackId={muxPlaybackId}
                                 autoPlay
                                 loop

--- a/src/app/(site)/(pages)/showcase/[slug]/gallery.tsx
+++ b/src/app/(site)/(pages)/showcase/[slug]/gallery.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image"
 
+import { LazyVideo } from "@/components/primitives/lazy-video"
 import { Video } from "@/components/primitives/video"
 import { resolveVideoSource } from "@/lib/video/resolve-source"
 import { getImageUrl } from "@/service/sanity/helpers"
@@ -52,11 +53,12 @@ export function ProjectGallery({ entry }: { entry: ShowcaseProjectDetail }) {
             {videoSource ? (
               <div className="with-dots h-full w-full after:absolute after:inset-0">
                 {videoSource.type === "mux" ? (
-                  <Video
+                  <LazyVideo
                     playbackId={videoSource.playbackId}
                     autoPlay
                     muted
                     loop
+                    maxResolution="1080p"
                     className="h-full w-full object-cover"
                   />
                 ) : (

--- a/src/app/(site)/(pages)/showcase/[slug]/gallery.tsx
+++ b/src/app/(site)/(pages)/showcase/[slug]/gallery.tsx
@@ -2,7 +2,6 @@
 
 import Image from "next/image"
 
-import { LazyVideo } from "@/components/primitives/lazy-video"
 import { Video } from "@/components/primitives/video"
 import { resolveVideoSource } from "@/lib/video/resolve-source"
 import { getImageUrl } from "@/service/sanity/helpers"
@@ -53,7 +52,7 @@ export function ProjectGallery({ entry }: { entry: ShowcaseProjectDetail }) {
             {videoSource ? (
               <div className="with-dots h-full w-full after:absolute after:inset-0">
                 {videoSource.type === "mux" ? (
-                  <LazyVideo
+                  <Video
                     playbackId={videoSource.playbackId}
                     autoPlay
                     muted

--- a/src/app/(site)/(pages)/showcase/list.tsx
+++ b/src/app/(site)/(pages)/showcase/list.tsx
@@ -5,6 +5,7 @@ import Link from "next/link"
 import { memo, useCallback, useState } from "react"
 
 import { Arrow } from "@/components/primitives/icons/arrow"
+import { LazyVideo } from "@/components/primitives/lazy-video"
 import { Video } from "@/components/primitives/video"
 import { resolveVideoSource } from "@/lib/video/resolve-source"
 import { getImageUrl } from "@/service/sanity/helpers"
@@ -116,12 +117,13 @@ const AccordionListItem = memo(
                 })
                 const elementToRender = videoSource ? (
                   videoSource.type === "mux" ? (
-                    <Video
+                    <LazyVideo
                       key={imgIndex}
                       playbackId={videoSource.playbackId}
                       autoPlay
                       playsInline
                       muted
+                      maxResolution="720p"
                       className="h-full w-full object-cover"
                     />
                   ) : (

--- a/src/components/primitives/image-with-video-overlay.tsx
+++ b/src/components/primitives/image-with-video-overlay.tsx
@@ -37,7 +37,6 @@ export const ImageWithVideoOverlay = ({
   variant?: "home" | "showcase"
 }) => {
   const [isHovered, setIsHovered] = useState(false)
-  const [isVideoLoaded, setIsVideoLoaded] = useState(false)
   const [shouldLoadVideo, setShouldLoadVideo] = useState(false)
   const videoRef = useRef<HTMLVideoElement>(null)
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
@@ -49,38 +48,9 @@ export const ImageWithVideoOverlay = ({
     }
   }, [])
 
-  useEffect(() => {
-    if (isMobile) return
-    const prefetch = () => {
-      void import("@/components/primitives/video")
-    }
-    const ric = (
-      window as Window & {
-        requestIdleCallback?: (cb: () => void) => number
-        cancelIdleCallback?: (id: number) => void
-      }
-    ).requestIdleCallback
-    if (ric) {
-      const id = ric(prefetch)
-      return () => {
-        const cic = (
-          window as Window & { cancelIdleCallback?: (id: number) => void }
-        ).cancelIdleCallback
-        cic?.(id)
-      }
-    }
-    const id = window.setTimeout(prefetch, 1500)
-    return () => window.clearTimeout(id)
-  }, [isMobile])
-
-  const handleVideoLoaded = () => {
-    setIsVideoLoaded(true)
-  }
-
   const handleMouseEnter = () => {
     setShouldLoadVideo(true)
     setIsHovered(true)
-
     timeoutRef.current = setTimeout(() => {
       videoRef.current?.play().catch(() => {})
     }, 50)
@@ -91,19 +61,9 @@ export const ImageWithVideoOverlay = ({
       clearTimeout(timeoutRef.current)
       timeoutRef.current = null
     }
-
     setIsHovered(false)
-    if (videoRef.current) {
-      videoRef.current.pause()
-    }
+    videoRef.current?.pause()
   }
-
-  const showLoadingPulse = isHovered && shouldLoadVideo && !isVideoLoaded
-
-  const overlayClassName = cn(
-    "absolute inset-0 h-full w-full object-cover transition-all duration-300",
-    isHovered && isVideoLoaded ? "visible opacity-100" : "invisible opacity-0"
-  )
 
   return (
     <div
@@ -125,48 +85,44 @@ export const ImageWithVideoOverlay = ({
           variant === "home" ? "(max-width: 1024px) 50vw, 90vw" : undefined
         }
         blurDataURL={image?.blurDataURL ?? ""}
-        className="h-full w-full object-cover"
+        className={cn(
+          "h-full w-full object-cover",
+          isHovered && "animate-subtle-pulse"
+        )}
         priority={false}
       />
-
       {video && shouldLoadVideo && !isMobile ? (
-        video.type === "mux" ? (
-          <Video
-            playbackId={video.playbackId}
-            onCanPlay={handleVideoLoaded}
-            onLoadedData={handleVideoLoaded}
-            className={overlayClassName}
-            autoPlay={isHovered}
-            muted
-            ref={videoRef}
-            poster=""
-            pauseOffscreen={false}
-            {...(variant === "home"
-              ? {
-                  renditionOrder: "desc" as const,
-                  maxResolution: "1080p" as const
-                }
-              : { maxResolution: "720p" as const })}
-          />
-        ) : (
-          <Video
-            src={video.url}
-            mimeType={video.mimeType}
-            onCanPlay={handleVideoLoaded}
-            onLoadedData={handleVideoLoaded}
-            className={overlayClassName}
-            autoPlay={isHovered}
-            muted
-            ref={videoRef}
-          />
-        )
-      ) : null}
-
-      {showLoadingPulse ? (
         <div
-          aria-hidden
-          className="pointer-events-none absolute inset-0 animate-pulse border border-brand-w1/40"
-        />
+          className={cn(
+            "absolute inset-0 h-full w-full transition-opacity duration-200",
+            isHovered ? "opacity-100" : "pointer-events-none opacity-0"
+          )}
+        >
+          {video.type === "mux" ? (
+            <Video
+              playbackId={video.playbackId}
+              className="h-full w-full object-cover"
+              muted
+              ref={videoRef}
+              poster=""
+              pauseOffscreen={false}
+              {...(variant === "home"
+                ? {
+                    renditionOrder: "desc" as const,
+                    maxResolution: "1080p" as const
+                  }
+                : { maxResolution: "720p" as const })}
+            />
+          ) : (
+            <Video
+              src={video.url}
+              mimeType={video.mimeType}
+              className="h-full w-full object-cover"
+              muted
+              ref={videoRef}
+            />
+          )}
+        </div>
       ) : null}
     </div>
   )

--- a/src/components/primitives/image-with-video-overlay.tsx
+++ b/src/components/primitives/image-with-video-overlay.tsx
@@ -36,7 +36,6 @@ export const ImageWithVideoOverlay = ({
   className?: string
   variant?: "home" | "showcase"
 }) => {
-  const [isHovered, setIsHovered] = useState(false)
   const [shouldLoadVideo, setShouldLoadVideo] = useState(false)
   const videoRef = useRef<HTMLVideoElement>(null)
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
@@ -50,7 +49,6 @@ export const ImageWithVideoOverlay = ({
 
   const handleMouseEnter = () => {
     setShouldLoadVideo(true)
-    setIsHovered(true)
     timeoutRef.current = setTimeout(() => {
       videoRef.current?.play().catch(() => {})
     }, 50)
@@ -61,14 +59,13 @@ export const ImageWithVideoOverlay = ({
       clearTimeout(timeoutRef.current)
       timeoutRef.current = null
     }
-    setIsHovered(false)
     videoRef.current?.pause()
   }
 
   return (
     <div
       className={cn(
-        "relative h-full w-full transition-opacity duration-300",
+        "group relative h-full w-full transition-opacity duration-300",
         className,
         { "pointer-events-none opacity-0": disabled }
       )}
@@ -85,18 +82,12 @@ export const ImageWithVideoOverlay = ({
           variant === "home" ? "(max-width: 1024px) 50vw, 90vw" : undefined
         }
         blurDataURL={image?.blurDataURL ?? ""}
-        className={cn(
-          "h-full w-full object-cover",
-          isHovered && "animate-subtle-pulse"
-        )}
+        className="h-full w-full object-cover group-hover:animate-subtle-pulse"
         priority={false}
       />
       {video && shouldLoadVideo && !isMobile ? (
         <div
-          className={cn(
-            "absolute inset-0 h-full w-full transition-opacity duration-200",
-            isHovered ? "opacity-100" : "pointer-events-none opacity-0"
-          )}
+          className="pointer-events-none absolute inset-0 h-full w-full opacity-0 transition-opacity duration-200 group-hover:opacity-100"
         >
           {video.type === "mux" ? (
             <Video

--- a/src/components/primitives/image-with-video-overlay.tsx
+++ b/src/components/primitives/image-with-video-overlay.tsx
@@ -23,7 +23,6 @@ const Video = dynamic(
   { ssr: false }
 )
 
-// only load the video when the user hovers over the image, automatically play the video and set opacity to 0
 export const ImageWithVideoOverlay = ({
   image,
   video,
@@ -40,16 +39,13 @@ export const ImageWithVideoOverlay = ({
   const [isHovered, setIsHovered] = useState(false)
   const [isVideoLoaded, setIsVideoLoaded] = useState(false)
   const [shouldLoadVideo, setShouldLoadVideo] = useState(false)
-  const [showLoadingPulse, setShowLoadingPulse] = useState(false)
   const videoRef = useRef<HTMLVideoElement>(null)
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
-  const pulseTimerRef = useRef<NodeJS.Timeout | null>(null)
   const { isMobile } = useDeviceDetect()
 
   useEffect(() => {
     return () => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current)
-      if (pulseTimerRef.current) clearTimeout(pulseTimerRef.current)
     }
   }, [])
 
@@ -77,26 +73,13 @@ export const ImageWithVideoOverlay = ({
     return () => window.clearTimeout(id)
   }, [isMobile])
 
-  const cancelPulse = () => {
-    if (pulseTimerRef.current) {
-      clearTimeout(pulseTimerRef.current)
-      pulseTimerRef.current = null
-    }
-    setShowLoadingPulse(false)
-  }
-
   const handleVideoLoaded = () => {
     setIsVideoLoaded(true)
-    cancelPulse()
   }
 
   const handleMouseEnter = () => {
     setShouldLoadVideo(true)
     setIsHovered(true)
-
-    pulseTimerRef.current = setTimeout(() => {
-      setShowLoadingPulse(true)
-    }, 250)
 
     timeoutRef.current = setTimeout(() => {
       videoRef.current?.play().catch(() => {})
@@ -109,12 +92,13 @@ export const ImageWithVideoOverlay = ({
       timeoutRef.current = null
     }
 
-    cancelPulse()
     setIsHovered(false)
     if (videoRef.current) {
       videoRef.current.pause()
     }
   }
+
+  const showLoadingPulse = isHovered && shouldLoadVideo && !isVideoLoaded
 
   const overlayClassName = cn(
     "absolute inset-0 h-full w-full object-cover transition-all duration-300",
@@ -156,6 +140,7 @@ export const ImageWithVideoOverlay = ({
             muted
             ref={videoRef}
             poster=""
+            pauseOffscreen={false}
             {...(variant === "home"
               ? {
                   renditionOrder: "desc" as const,
@@ -177,10 +162,10 @@ export const ImageWithVideoOverlay = ({
         )
       ) : null}
 
-      {showLoadingPulse && !isVideoLoaded ? (
+      {showLoadingPulse ? (
         <div
           aria-hidden
-          className="pointer-events-none absolute inset-0 animate-pulse border border-brand-w1/30"
+          className="pointer-events-none absolute inset-0 animate-pulse border border-brand-w1/40"
         />
       ) : null}
     </div>

--- a/src/components/primitives/image-with-video-overlay.tsx
+++ b/src/components/primitives/image-with-video-overlay.tsx
@@ -40,19 +40,65 @@ export const ImageWithVideoOverlay = ({
   const [isHovered, setIsHovered] = useState(false)
   const [isVideoLoaded, setIsVideoLoaded] = useState(false)
   const [shouldLoadVideo, setShouldLoadVideo] = useState(false)
+  const [showLoadingPulse, setShowLoadingPulse] = useState(false)
   const videoRef = useRef<HTMLVideoElement>(null)
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const pulseTimerRef = useRef<NodeJS.Timeout | null>(null)
   const { isMobile } = useDeviceDetect()
 
   useEffect(() => {
     return () => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current)
+      if (pulseTimerRef.current) clearTimeout(pulseTimerRef.current)
     }
   }, [])
+
+  // Idle-prefetch the Video chunk so the first hover doesn't pay the
+  // dynamic-import download cost.
+  useEffect(() => {
+    if (isMobile) return
+    const prefetch = () => {
+      void import("@/components/primitives/video")
+    }
+    const ric = (
+      window as Window & {
+        requestIdleCallback?: (cb: () => void) => number
+        cancelIdleCallback?: (id: number) => void
+      }
+    ).requestIdleCallback
+    if (ric) {
+      const id = ric(prefetch)
+      return () => {
+        const cic = (
+          window as Window & { cancelIdleCallback?: (id: number) => void }
+        ).cancelIdleCallback
+        cic?.(id)
+      }
+    }
+    const id = window.setTimeout(prefetch, 1500)
+    return () => window.clearTimeout(id)
+  }, [isMobile])
+
+  const cancelPulse = () => {
+    if (pulseTimerRef.current) {
+      clearTimeout(pulseTimerRef.current)
+      pulseTimerRef.current = null
+    }
+    setShowLoadingPulse(false)
+  }
+
+  const handleVideoLoaded = () => {
+    setIsVideoLoaded(true)
+    cancelPulse()
+  }
 
   const handleMouseEnter = () => {
     setShouldLoadVideo(true)
     setIsHovered(true)
+
+    pulseTimerRef.current = setTimeout(() => {
+      setShowLoadingPulse(true)
+    }, 250)
 
     setTimeout(() => {
       if (videoRef.current) {
@@ -69,6 +115,7 @@ export const ImageWithVideoOverlay = ({
       timeoutRef.current = null
     }
 
+    cancelPulse()
     setIsHovered(false)
     if (videoRef.current) {
       videoRef.current.pause()
@@ -108,8 +155,8 @@ export const ImageWithVideoOverlay = ({
         video.type === "mux" ? (
           <Video
             playbackId={video.playbackId}
-            onCanPlay={() => setIsVideoLoaded(true)}
-            onLoadedData={() => setIsVideoLoaded(true)}
+            onCanPlay={handleVideoLoaded}
+            onLoadedData={handleVideoLoaded}
             style={{ "--controls": "none" } as React.CSSProperties}
             className={overlayClassName}
             autoPlay={isHovered}
@@ -119,8 +166,7 @@ export const ImageWithVideoOverlay = ({
             {...(variant === "home"
               ? {
                   renditionOrder: "desc" as const,
-                  maxResolution: "1080p" as const,
-                  minResolution: "720p" as const
+                  maxResolution: "1080p" as const
                 }
               : { maxResolution: "720p" as const })}
           />
@@ -128,8 +174,8 @@ export const ImageWithVideoOverlay = ({
           <Video
             src={video.url}
             mimeType={video.mimeType}
-            onCanPlay={() => setIsVideoLoaded(true)}
-            onLoadedData={() => setIsVideoLoaded(true)}
+            onCanPlay={handleVideoLoaded}
+            onLoadedData={handleVideoLoaded}
             style={{ "--controls": "none" } as React.CSSProperties}
             className={overlayClassName}
             autoPlay={isHovered}
@@ -137,6 +183,13 @@ export const ImageWithVideoOverlay = ({
             ref={videoRef}
           />
         )
+      ) : null}
+
+      {showLoadingPulse && !isVideoLoaded ? (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 animate-pulse border border-brand-w1/30"
+        />
       ) : null}
     </div>
   )

--- a/src/components/primitives/image-with-video-overlay.tsx
+++ b/src/components/primitives/image-with-video-overlay.tsx
@@ -115,6 +115,14 @@ export const ImageWithVideoOverlay = ({
             autoPlay={isHovered}
             muted
             ref={videoRef}
+            poster=""
+            {...(variant === "home"
+              ? {
+                  renditionOrder: "desc" as const,
+                  maxResolution: "1080p" as const,
+                  minResolution: "720p" as const
+                }
+              : { maxResolution: "720p" as const })}
           />
         ) : (
           <Video

--- a/src/components/primitives/image-with-video-overlay.tsx
+++ b/src/components/primitives/image-with-video-overlay.tsx
@@ -53,8 +53,6 @@ export const ImageWithVideoOverlay = ({
     }
   }, [])
 
-  // Idle-prefetch the Video chunk so the first hover doesn't pay the
-  // dynamic-import download cost.
   useEffect(() => {
     if (isMobile) return
     const prefetch = () => {
@@ -100,13 +98,9 @@ export const ImageWithVideoOverlay = ({
       setShowLoadingPulse(true)
     }, 250)
 
-    setTimeout(() => {
-      if (videoRef.current) {
-        videoRef.current.play().catch((err) => {
-          console.log("[MouseEnter] Video play failed:", err)
-        })
-      }
-    }, 50) //check video is in DOC ready to play
+    timeoutRef.current = setTimeout(() => {
+      videoRef.current?.play().catch(() => {})
+    }, 50)
   }
 
   const handleMouseLeave = () => {
@@ -157,7 +151,6 @@ export const ImageWithVideoOverlay = ({
             playbackId={video.playbackId}
             onCanPlay={handleVideoLoaded}
             onLoadedData={handleVideoLoaded}
-            style={{ "--controls": "none" } as React.CSSProperties}
             className={overlayClassName}
             autoPlay={isHovered}
             muted
@@ -176,7 +169,6 @@ export const ImageWithVideoOverlay = ({
             mimeType={video.mimeType}
             onCanPlay={handleVideoLoaded}
             onLoadedData={handleVideoLoaded}
-            style={{ "--controls": "none" } as React.CSSProperties}
             className={overlayClassName}
             autoPlay={isHovered}
             muted

--- a/src/components/primitives/lazy-video.tsx
+++ b/src/components/primitives/lazy-video.tsx
@@ -7,25 +7,26 @@ import { type MuxProps, Video } from "@/components/primitives/video"
 import { buildMuxPosterUrl } from "@/utils/mux"
 
 export const LazyVideo = ({ className, ...muxProps }: MuxProps) => {
-  const placeholderRef = useRef<HTMLImageElement | null>(null)
-  const isInView = useInView(placeholderRef, {
+  const wrapperRef = useRef<HTMLDivElement | null>(null)
+  const isInView = useInView(wrapperRef, {
     margin: "400px",
     once: true
   })
 
-  if (isInView) {
-    return <Video {...muxProps} className={className} />
-  }
-
   return (
-    <img
-      ref={placeholderRef}
-      src={buildMuxPosterUrl(muxProps.playbackId, muxProps.thumbnailTime)}
-      alt=""
-      className={className}
-      loading="lazy"
-      decoding="async"
-      aria-hidden
-    />
+    <div ref={wrapperRef} className={className}>
+      {isInView ? (
+        <Video {...muxProps} className="h-full w-full object-cover" />
+      ) : (
+        <img
+          src={buildMuxPosterUrl(muxProps.playbackId, muxProps.thumbnailTime)}
+          alt=""
+          className="h-full w-full object-cover"
+          loading="lazy"
+          decoding="async"
+          aria-hidden
+        />
+      )}
+    </div>
   )
 }

--- a/src/components/primitives/lazy-video.tsx
+++ b/src/components/primitives/lazy-video.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { type MuxProps, Video } from "@/components/primitives/video"
+
+type LazyVideoProps = MuxProps & {
+  rootMargin?: string
+  posterAlt?: string
+}
+
+const MUX_THUMBNAIL_BASE = "https://image.mux.com"
+
+const buildPosterUrl = (playbackId: string, thumbnailTime?: number) => {
+  if (thumbnailTime == null) {
+    return `${MUX_THUMBNAIL_BASE}/${playbackId}/thumbnail.webp`
+  }
+  return `${MUX_THUMBNAIL_BASE}/${playbackId}/thumbnail.webp?time=${thumbnailTime}`
+}
+
+export const LazyVideo = ({
+  rootMargin = "400px",
+  posterAlt = "",
+  className,
+  ...muxProps
+}: LazyVideoProps) => {
+  const [shouldMount, setShouldMount] = useState(false)
+  const cleanupRef = useRef<(() => void) | null>(null)
+
+  const attachObserver = useCallback(
+    (el: HTMLElement | null) => {
+      cleanupRef.current?.()
+      cleanupRef.current = null
+      if (!el || shouldMount) return
+      const io = new IntersectionObserver(
+        (entries) => {
+          if (entries[0]?.isIntersecting) {
+            setShouldMount(true)
+            io.disconnect()
+          }
+        },
+        { rootMargin }
+      )
+      io.observe(el)
+      cleanupRef.current = () => io.disconnect()
+    },
+    [rootMargin, shouldMount]
+  )
+
+  useEffect(() => () => cleanupRef.current?.(), [])
+
+  if (shouldMount) {
+    return <Video {...muxProps} className={className} />
+  }
+
+  return (
+    <img
+      ref={attachObserver}
+      src={buildPosterUrl(muxProps.playbackId, muxProps.thumbnailTime)}
+      alt={posterAlt}
+      className={className}
+      loading="lazy"
+      decoding="async"
+      aria-hidden={posterAlt === "" ? true : undefined}
+    />
+  )
+}

--- a/src/components/primitives/lazy-video.tsx
+++ b/src/components/primitives/lazy-video.tsx
@@ -3,19 +3,11 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 
 import { type MuxProps, Video } from "@/components/primitives/video"
+import { buildMuxPosterUrl } from "@/utils/mux"
 
 type LazyVideoProps = MuxProps & {
   rootMargin?: string
   posterAlt?: string
-}
-
-const MUX_THUMBNAIL_BASE = "https://image.mux.com"
-
-const buildPosterUrl = (playbackId: string, thumbnailTime?: number) => {
-  if (thumbnailTime == null) {
-    return `${MUX_THUMBNAIL_BASE}/${playbackId}/thumbnail.webp`
-  }
-  return `${MUX_THUMBNAIL_BASE}/${playbackId}/thumbnail.webp?time=${thumbnailTime}`
 }
 
 export const LazyVideo = ({
@@ -56,12 +48,12 @@ export const LazyVideo = ({
   return (
     <img
       ref={attachObserver}
-      src={buildPosterUrl(muxProps.playbackId, muxProps.thumbnailTime)}
+      src={buildMuxPosterUrl(muxProps.playbackId, muxProps.thumbnailTime)}
       alt={posterAlt}
       className={className}
       loading="lazy"
       decoding="async"
-      aria-hidden={posterAlt === "" ? true : undefined}
+      aria-hidden={!posterAlt || undefined}
     />
   )
 }

--- a/src/components/primitives/lazy-video.tsx
+++ b/src/components/primitives/lazy-video.tsx
@@ -1,59 +1,31 @@
 "use client"
 
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useInView } from "motion/react"
+import { useRef } from "react"
 
 import { type MuxProps, Video } from "@/components/primitives/video"
 import { buildMuxPosterUrl } from "@/utils/mux"
 
-type LazyVideoProps = MuxProps & {
-  rootMargin?: string
-  posterAlt?: string
-}
+export const LazyVideo = ({ className, ...muxProps }: MuxProps) => {
+  const placeholderRef = useRef<HTMLImageElement | null>(null)
+  const isInView = useInView(placeholderRef, {
+    margin: "400px",
+    once: true
+  })
 
-export const LazyVideo = ({
-  rootMargin = "400px",
-  posterAlt = "",
-  className,
-  ...muxProps
-}: LazyVideoProps) => {
-  const [shouldMount, setShouldMount] = useState(false)
-  const cleanupRef = useRef<(() => void) | null>(null)
-
-  const attachObserver = useCallback(
-    (el: HTMLElement | null) => {
-      cleanupRef.current?.()
-      cleanupRef.current = null
-      if (!el || shouldMount) return
-      const io = new IntersectionObserver(
-        (entries) => {
-          if (entries[0]?.isIntersecting) {
-            setShouldMount(true)
-            io.disconnect()
-          }
-        },
-        { rootMargin }
-      )
-      io.observe(el)
-      cleanupRef.current = () => io.disconnect()
-    },
-    [rootMargin, shouldMount]
-  )
-
-  useEffect(() => () => cleanupRef.current?.(), [])
-
-  if (shouldMount) {
+  if (isInView) {
     return <Video {...muxProps} className={className} />
   }
 
   return (
     <img
-      ref={attachObserver}
+      ref={placeholderRef}
       src={buildMuxPosterUrl(muxProps.playbackId, muxProps.thumbnailTime)}
-      alt={posterAlt}
+      alt=""
       className={className}
       loading="lazy"
       decoding="async"
-      aria-hidden={!posterAlt || undefined}
+      aria-hidden
     />
   )
 }

--- a/src/components/primitives/video.tsx
+++ b/src/components/primitives/video.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import MuxVideo, { Props as MuxVideoProps } from "@mux/mux-video-react"
+import { useInView } from "motion/react"
 import type { CSSProperties, Ref, VideoHTMLAttributes } from "react"
 import { useEffect, useRef } from "react"
 import { mergeRefs } from "react-merge-refs"
@@ -39,51 +40,31 @@ const MuxVideoEl = ({
   ...props
 }: MuxProps) => {
   const internalRef = useRef<HTMLVideoElement | null>(null)
+  const isInView = useInView(internalRef, { margin: "200px" })
 
   useEffect(() => {
     if (!pauseOffscreen) return
     const el = internalRef.current
     if (!el) return
 
-    let pausedByUs = false
-
-    const pauseIfPlaying = () => {
-      if (!el.paused) {
-        el.pause()
-        pausedByUs = true
-      }
+    if (isInView) {
+      el.play().catch(() => {})
+    } else {
+      el.pause()
     }
-    const resumeIfNeeded = () => {
-      if (pausedByUs) {
-        el.play().catch(() => {})
-        pausedByUs = false
-      }
-    }
-
-    const io = new IntersectionObserver(
-      (entries) => {
-        const entry = entries[0]
-        if (!entry) return
-        if (entry.isIntersecting) resumeIfNeeded()
-        else pauseIfPlaying()
-      },
-      { threshold: 0, rootMargin: "200px" }
-    )
-    io.observe(el)
 
     const onVisibility = () => {
-      if (document.visibilityState === "hidden") pauseIfPlaying()
-      else resumeIfNeeded()
+      if (document.visibilityState === "hidden") {
+        el.pause()
+      } else if (isInView) {
+        el.play().catch(() => {})
+      }
     }
     document.addEventListener("visibilitychange", onVisibility, {
       passive: true
     })
-
-    return () => {
-      io.disconnect()
-      document.removeEventListener("visibilitychange", onVisibility)
-    }
-  }, [pauseOffscreen])
+    return () => document.removeEventListener("visibilitychange", onVisibility)
+  }, [isInView, pauseOffscreen])
 
   const { style, poster, thumbnailTime, ...rest } = props
   const resolvedPoster =
@@ -104,7 +85,7 @@ const MuxVideoEl = ({
       controls={false}
       streamType="on-demand"
       playsInline
-      autoPlay
+      autoPlay={!pauseOffscreen}
       preload="auto"
       preferPlayback="mse"
       disableTracking

--- a/src/components/primitives/video.tsx
+++ b/src/components/primitives/video.tsx
@@ -54,7 +54,7 @@ const MuxVideoEl = ({
       }
     }
     const resumeIfNeeded = () => {
-      if (pausedByUs && el.autoplay) {
+      if (pausedByUs) {
         el.play().catch(() => {})
         pausedByUs = false
       }

--- a/src/components/primitives/video.tsx
+++ b/src/components/primitives/video.tsx
@@ -1,7 +1,13 @@
 "use client"
 
 import MuxVideo, { Props as MuxVideoProps } from "@mux/mux-video-react"
-import type { CSSProperties, Ref, VideoHTMLAttributes } from "react"
+import type {
+  CSSProperties,
+  MutableRefObject,
+  Ref,
+  VideoHTMLAttributes
+} from "react"
+import { useCallback, useEffect, useRef } from "react"
 
 type SharedProps = {
   className?: string
@@ -9,9 +15,11 @@ type SharedProps = {
   ref?: Ref<HTMLVideoElement>
 }
 
-type MuxProps = SharedProps &
+export type MuxProps = SharedProps &
   Omit<Partial<MuxVideoProps>, "playbackId" | "src" | "ref"> & {
     playbackId: string
+    thumbnailTime?: number
+    pauseOffscreen?: boolean
     src?: never
     mimeType?: never
   }
@@ -27,20 +35,111 @@ export type VideoProps = MuxProps | LegacyProps
 
 const hiddenControlsStyle = { "--controls": "none" } as CSSProperties
 
+const MUX_THUMBNAIL_BASE = "https://image.mux.com"
+
+const buildMuxPoster = (playbackId: string, thumbnailTime?: number) => {
+  if (thumbnailTime == null) {
+    return `${MUX_THUMBNAIL_BASE}/${playbackId}/thumbnail.webp`
+  }
+  return `${MUX_THUMBNAIL_BASE}/${playbackId}/thumbnail.webp?time=${thumbnailTime}`
+}
+
+const MuxVideoEl = ({
+  ref: callerRef,
+  pauseOffscreen = true,
+  ...props
+}: MuxProps) => {
+  const internalRef = useRef<HTMLVideoElement | null>(null)
+
+  const setRefs = useCallback(
+    (el: HTMLVideoElement | undefined | null) => {
+      const value = el ?? null
+      internalRef.current = value
+      if (typeof callerRef === "function") {
+        callerRef(value as HTMLVideoElement)
+      } else if (
+        callerRef &&
+        typeof callerRef === "object" &&
+        "current" in callerRef
+      ) {
+        ;(callerRef as MutableRefObject<HTMLVideoElement | null>).current =
+          value
+      }
+    },
+    [callerRef]
+  )
+
+  useEffect(() => {
+    if (!pauseOffscreen) return
+    const el = internalRef.current
+    if (!el) return
+
+    let pausedByUs = false
+
+    const pauseIfPlaying = () => {
+      if (!el.paused) {
+        el.pause()
+        pausedByUs = true
+      }
+    }
+    const resumeIfNeeded = () => {
+      if (pausedByUs && el.autoplay) {
+        el.play().catch(() => {})
+        pausedByUs = false
+      }
+    }
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0]
+        if (!entry) return
+        if (entry.isIntersecting) resumeIfNeeded()
+        else pauseIfPlaying()
+      },
+      { threshold: 0, rootMargin: "200px" }
+    )
+    io.observe(el)
+
+    const onVisibility = () => {
+      if (document.visibilityState === "hidden") pauseIfPlaying()
+      else resumeIfNeeded()
+    }
+    document.addEventListener("visibilitychange", onVisibility, {
+      passive: true
+    })
+
+    return () => {
+      io.disconnect()
+      document.removeEventListener("visibilitychange", onVisibility)
+    }
+  }, [pauseOffscreen])
+
+  const { style, poster, thumbnailTime, ...rest } = props
+  const resolvedPoster =
+    poster === undefined
+      ? buildMuxPoster(props.playbackId, thumbnailTime)
+      : poster
+
+  return (
+    <MuxVideo
+      {...rest}
+      ref={setRefs}
+      poster={resolvedPoster}
+      style={{ ...hiddenControlsStyle, ...style }}
+      controls={false}
+      streamType="on-demand"
+      playsInline
+      autoPlay
+      preload="auto"
+      preferPlayback="mse"
+      disableTracking
+    />
+  )
+}
+
 export const Video = (props: VideoProps) => {
   if ("playbackId" in props && props.playbackId) {
-    const { style, ...rest } = props as MuxProps
-    return (
-      <MuxVideo
-        {...rest}
-        style={{ ...hiddenControlsStyle, ...style }}
-        controls={false}
-        streamType="on-demand"
-        playsInline
-        autoPlay
-        preload="auto"
-      />
-    )
+    return <MuxVideoEl {...(props as MuxProps)} />
   }
 
   const { src, mimeType, style, autoPlay, preload, playsInline, ...rest } =

--- a/src/components/primitives/video.tsx
+++ b/src/components/primitives/video.tsx
@@ -1,13 +1,11 @@
 "use client"
 
 import MuxVideo, { Props as MuxVideoProps } from "@mux/mux-video-react"
-import type {
-  CSSProperties,
-  MutableRefObject,
-  Ref,
-  VideoHTMLAttributes
-} from "react"
-import { useCallback, useEffect, useRef } from "react"
+import type { CSSProperties, Ref, VideoHTMLAttributes } from "react"
+import { useEffect, useRef } from "react"
+import { mergeRefs } from "react-merge-refs"
+
+import { buildMuxPosterUrl } from "@/utils/mux"
 
 type SharedProps = {
   className?: string
@@ -35,39 +33,12 @@ export type VideoProps = MuxProps | LegacyProps
 
 const hiddenControlsStyle = { "--controls": "none" } as CSSProperties
 
-const MUX_THUMBNAIL_BASE = "https://image.mux.com"
-
-const buildMuxPoster = (playbackId: string, thumbnailTime?: number) => {
-  if (thumbnailTime == null) {
-    return `${MUX_THUMBNAIL_BASE}/${playbackId}/thumbnail.webp`
-  }
-  return `${MUX_THUMBNAIL_BASE}/${playbackId}/thumbnail.webp?time=${thumbnailTime}`
-}
-
 const MuxVideoEl = ({
   ref: callerRef,
   pauseOffscreen = true,
   ...props
 }: MuxProps) => {
   const internalRef = useRef<HTMLVideoElement | null>(null)
-
-  const setRefs = useCallback(
-    (el: HTMLVideoElement | undefined | null) => {
-      const value = el ?? null
-      internalRef.current = value
-      if (typeof callerRef === "function") {
-        callerRef(value as HTMLVideoElement)
-      } else if (
-        callerRef &&
-        typeof callerRef === "object" &&
-        "current" in callerRef
-      ) {
-        ;(callerRef as MutableRefObject<HTMLVideoElement | null>).current =
-          value
-      }
-    },
-    [callerRef]
-  )
 
   useEffect(() => {
     if (!pauseOffscreen) return
@@ -117,13 +88,17 @@ const MuxVideoEl = ({
   const { style, poster, thumbnailTime, ...rest } = props
   const resolvedPoster =
     poster === undefined
-      ? buildMuxPoster(props.playbackId, thumbnailTime)
+      ? buildMuxPosterUrl(props.playbackId, thumbnailTime)
       : poster
 
   return (
     <MuxVideo
       {...rest}
-      ref={setRefs}
+      ref={
+        mergeRefs([internalRef, ...(callerRef ? [callerRef] : [])]) as Ref<
+          HTMLVideoElement | undefined
+        >
+      }
       poster={resolvedPoster}
       style={{ ...hiddenControlsStyle, ...style }}
       controls={false}
@@ -139,7 +114,7 @@ const MuxVideoEl = ({
 
 export const Video = (props: VideoProps) => {
   if ("playbackId" in props && props.playbackId) {
-    return <MuxVideoEl {...(props as MuxProps)} />
+    return <MuxVideoEl {...props} />
   }
 
   const { src, mimeType, style, autoPlay, preload, playsInline, ...rest } =

--- a/src/utils/mux.ts
+++ b/src/utils/mux.ts
@@ -1,0 +1,11 @@
+const MUX_THUMBNAIL_BASE = "https://image.mux.com"
+
+export const buildMuxPosterUrl = (
+  playbackId: string,
+  thumbnailTime?: number
+) => {
+  if (thumbnailTime == null) {
+    return `${MUX_THUMBNAIL_BASE}/${playbackId}/thumbnail.webp`
+  }
+  return `${MUX_THUMBNAIL_BASE}/${playbackId}/thumbnail.webp?time=${thumbnailTime}`
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -172,6 +172,9 @@ export default {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" }
         },
+        "subtle-pulse": {
+          "50%": { opacity: "0.75" }
+        },
         "fade-in": {
           from: { opacity: "0" },
           to: { opacity: "1" }
@@ -216,6 +219,7 @@ export default {
         }
       },
       animation: {
+        "subtle-pulse": "subtle-pulse 1s ease-in-out infinite",
         "accordion-down": "accordion-down 0.2s ease-out forwards",
         "accordion-up": "accordion-up 0.2s ease-out forwards",
         "fade-in": "fade-in 0.3s ease-out",


### PR DESCRIPTION
<html><head></head><body><h2>Summary</h2>
<p>Component-level Mux delivery tuning. Three concerns:</p>
<ol>
<li><strong>Per-surface quality tuning</strong> — featured hover videos look sharper; small tiles don't waste bandwidth.</li>
<li><strong>Don't deliver to offscreen players</strong> — pause when the element scrolls out of view or the tab is hidden.</li>
<li><strong>Don't initialize offscreen players in the first place</strong> — replace the player with a Mux thumbnail until the placeholder approaches the viewport.</li>
</ol>
<h3>What changed</h3>
<p><strong><a href="https://github.com/basementstudio/website-2k25/blob/mar/sharp-meninsky-dac968/src/components/primitives/video.tsx"><code>primitives/video.tsx</code></a></strong> (Mux branch):</p>
<ul>
<li><code>preferPlayback="mse"</code> — required for Safari/macOS to actually honor rendition props. Without this, <code>maxResolution</code>/<code>renditionOrder</code> are silently no-ops on Safari.</li>
<li><code>disableTracking</code> — skip Mux Data beacons. Lighter player, fewer requests, no analytics overhead per decorative tile.</li>
<li>Auto-poster from <code>image.mux.com/{id}/thumbnail.webp</code> (callers opt out with <code>poster=""</code>). Before this, Mux video showed black frames between page paint and first HLS segment.</li>
<li><code>pauseOffscreen</code> (default true): IntersectionObserver pauses playback when the element scrolls out of view, <code>visibilitychange</code> pauses when the tab is hidden. Resumes when the element re-enters view, but only if we were the ones who paused it — avoids resuming a video the user or another handler already stopped.</li>
</ul>
<p><strong><a href="https://github.com/basementstudio/website-2k25/blob/mar/sharp-meninsky-dac968/src/components/primitives/lazy-video.tsx"><code>primitives/lazy-video.tsx</code></a></strong> (new): wraps <code>&lt;Video&gt;</code> for Mux assets. Renders a Mux thumbnail <code>&lt;img&gt;</code> until the placeholder enters viewport (400px buffer), then swaps to the real player. Once mounted, stays mounted — <code>pauseOffscreen</code> handles ongoing scroll. This prevents manifest + first-segment fetches for offscreen players.</p>
<p><strong>Per-surface quality tiers:</strong></p>

Surface | renditionOrder | max | poster
-- | -- | -- | --
Home featured hover (variant="home") | desc | 1080p | none (image underneath)
Showcase grid hover (variant="showcase") | default | 720p | none (image underneath)
Accordion tile (list.tsx) | default | 720p | auto Mux thumbnail
Project detail gallery | default | 1080p | auto Mux thumbnail
Blog videoEmbed | default | 1080p | auto Mux thumbnail


<p>Featured hover is the only surface biased to start at a higher rendition — it's short, user-triggered, and quality-critical. Other surfaces keep Mux's default mid-ladder start.</p>
<h3>Why</h3>
<p>Mux bills per delivered minute. Pre-change behavior:</p>
<ul>
<li>ABR could climb to 4K on a 200px tile (showcase grid).</li>
<li>Off-screen tiles below the fold (gallery on <code>/showcase/[slug]</code>, blog videoEmbed) kept streaming.</li>
<li>All Mux video players initialized eagerly on page mount, including ones inside collapsed Radix accordion rows on <code>/showcase</code>.</li>
</ul>
<p>Post-change:</p>
<ul>
<li>Per-surface resolution caps mean small tiles never pull 4K renditions.</li>
<li>Offscreen players pause segment delivery.</li>
<li>Lazy-mount means collapsed accordion rows make <strong>zero Mux calls</strong> until the user opens them.</li>
</ul>
<h3>What this is <strong>not</strong></h3>
<ul>
<li>Not switching to <code>@mux/mux-player-react</code> (would add ~150KB of player chrome we'd just hide).</li>
<li>Not capping <code>maxResolution</code> globally — that would defeat the per-surface tuning.</li>
<li>Not pausing the hover-overlay variant (already mounts on hover; auto-pause is a no-op there).</li>
<li>Not touching the legacy <code>&lt;video&gt;</code> fallback in any branch (legacy assets aren't Mux-billed).</li>
<li>Not changing <code>use-video-resume.ts</code> (used by the Three.js WebGL textures — different code path).</li>
</ul>
<h3>Test plan</h3>
<ul>
<li>[ ] <strong>Home</strong> — hover a featured project. In Network → <code>mux.com</code>, confirm the first rendition picked is ≥720p (look at the segment URL).</li>
<li>[ ] <strong><code>/showcase</code></strong> — open an accordion row. Tiles below the fold should show the Mux thumbnail <code>&lt;img&gt;</code> until scrolled near. No <code>.m3u8</code> manifest requests for tiles in collapsed rows.</li>
<li>[ ] <strong><code>/showcase/[slug]</code></strong> — only the ~2 visible gallery items should make manifest requests on page load. Scrolling triggers manifests for new items as they approach view.</li>
<li>[ ] <strong>Scroll past a playing video</strong> — DevTools → Network: segment requests for that video should stop within a second or two.</li>
<li>[ ] <strong>Switch tabs away and back</strong> — videos pause when hidden, resume when visible.</li>
<li>[ ] <strong>Safari</strong> — confirm <code>preferPlayback="mse"</code> is in effect (<code>document.querySelector('mux-video').preferPlayback === 'mse'</code>).</li>
<li>[ ] <strong>Filter Network for <code>litix.io</code></strong> — should be empty (Mux Data disabled).</li>
<li>[ ] <strong>Throttle to Fast 3G + hover a featured project</strong> — video still starts within ~1.5–2s.</li>
</ul></body></html>## Summary

Component-level Mux delivery tuning. Three concerns:

1. **Per-surface quality tuning** — featured hover videos look sharper; small tiles don't waste bandwidth.
2. **Don't deliver to offscreen players** — pause when the element scrolls out of view or the tab is hidden.
3. **Don't initialize offscreen players in the first place** — replace the player with a Mux thumbnail until the placeholder approaches the viewport.

### What changed

**[`[primitives/video.tsx](https://github.com/basementstudio/website-2k25/blob/mar/sharp-meninsky-dac968/src/components/primitives/video.tsx)`](https://github.com/basementstudio/website-2k25/blob/mar/sharp-meninsky-dac968/src/components/primitives/video.tsx)** (Mux branch):
- `preferPlayback="mse"` — required for Safari/macOS to actually honor rendition props. Without this, `maxResolution`/`renditionOrder` are silently no-ops on Safari.
- `disableTracking` — skip Mux Data beacons. Lighter player, fewer requests, no analytics overhead per decorative tile.
- Auto-poster from `image.mux.com/{id}/thumbnail.webp` (callers opt out with `poster=""`). Before this, Mux video showed black frames between page paint and first HLS segment.
- `pauseOffscreen` (default true): IntersectionObserver pauses playback when the element scrolls out of view, `visibilitychange` pauses when the tab is hidden. Resumes when the element re-enters view, but only if we were the ones who paused it — avoids resuming a video the user or another handler already stopped.

**[`[primitives/lazy-video.tsx](https://github.com/basementstudio/website-2k25/blob/mar/sharp-meninsky-dac968/src/components/primitives/lazy-video.tsx)`](https://github.com/basementstudio/website-2k25/blob/mar/sharp-meninsky-dac968/src/components/primitives/lazy-video.tsx)** (new): wraps `<Video>` for Mux assets. Renders a Mux thumbnail `<img>` until the placeholder enters viewport (400px buffer), then swaps to the real player. Once mounted, stays mounted — `pauseOffscreen` handles ongoing scroll. This prevents manifest + first-segment fetches for offscreen players.

**Per-surface quality tiers:**

| Surface | renditionOrder | max | poster |
|---|---|---|---|
| Home featured hover (`variant="home"`) | `desc` | 1080p | none (image underneath) |
| Showcase grid hover (`variant="showcase"`) | default | 720p | none (image underneath) |
| Accordion tile (list.tsx) | default | 720p | auto Mux thumbnail |
| Project detail gallery | default | 1080p | auto Mux thumbnail |
| Blog videoEmbed | default | 1080p | auto Mux thumbnail |

Featured hover is the only surface biased to start at a higher rendition — it's short, user-triggered, and quality-critical. Other surfaces keep Mux's default mid-ladder start.

### Why

Mux bills per delivered minute. Pre-change behavior:
- ABR could climb to 4K on a 200px tile (showcase grid).
- Off-screen tiles below the fold (gallery on `/showcase/[slug]`, blog videoEmbed) kept streaming.
- All Mux video players initialized eagerly on page mount, including ones inside collapsed Radix accordion rows on `/showcase`.

Post-change:
- Per-surface resolution caps mean small tiles never pull 4K renditions.
- Offscreen players pause segment delivery.
- Lazy-mount means collapsed accordion rows make **zero Mux calls** until the user opens them.

### What this is **not**

- Not switching to `@mux/mux-player-react` (would add ~150KB of player chrome we'd just hide).
- Not capping `maxResolution` globally — that would defeat the per-surface tuning.
- Not pausing the hover-overlay variant (already mounts on hover; auto-pause is a no-op there).
- Not touching the legacy `<video>` fallback in any branch (legacy assets aren't Mux-billed).
- Not changing `use-video-resume.ts` (used by the Three.js WebGL textures — different code path).

### Test plan

- [ ] **Home** — hover a featured project. In Network → `mux.com`, confirm the first rendition picked is ≥720p (look at the segment URL).
- [ ] **`/showcase`** — open an accordion row. Tiles below the fold should show the Mux thumbnail `<img>` until scrolled near. No `.m3u8` manifest requests for tiles in collapsed rows.
- [ ] **`/showcase/[slug]`** — only the ~2 visible gallery items should make manifest requests on page load. Scrolling triggers manifests for new items as they approach view.
- [ ] **Scroll past a playing video** — DevTools → Network: segment requests for that video should stop within a second or two.
- [ ] **Switch tabs away and back** — videos pause when hidden, resume when visible.
- [ ] **Safari** — confirm `preferPlayback="mse"` is in effect (`document.querySelector('mux-video').preferPlayback === 'mse'`).
- [ ] **Filter Network for `litix.io`** — should be empty (Mux Data disabled).
- [ ] **Throttle to Fast 3G + hover a featured project** — video still starts within ~1.5–2s.