### PR TITLE
feat: serve markdown (.md) versions of blog posts for AI agents

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- Brief description of what this PR does -->
+
+## Changes
+
+- 
+
+## Checklist
+
+- [ ] `pnpm lint` passes
+- [ ] Tested locally in dev mode
+- [ ] No breaking changes (or documented in summary)

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ next-env.d.ts
 # million lint
 .million
 
+# tldr
+.tldrignore
+.tldr/
+
 # Sentry Config File
 .env.sentry-build-plugin
 

--- a/src/app/(site)/(pages)/post/[slug]/sanity.ts
+++ b/src/app/(site)/(pages)/post/[slug]/sanity.ts
@@ -36,7 +36,9 @@ export interface RelatedPost {
 // ---------------------------------------------------------------------------
 
 export async function fetchPostBySlug(
-  slug: string
+  slug: string,
+  /** Pass `published: true` for non-draft contexts (e.g. the `.md` endpoint) — disables stega so output isn't polluted with invisible chars. */
+  options?: { published?: boolean }
 ): Promise<PostDetail | null> {
   const query = /* groq */ `*[_type == "post" && slug.current == $slug][0]{
     _id,
@@ -78,7 +80,27 @@ export async function fetchPostBySlug(
   }`
   return sanityFetch<PostDetail | null>({
     query,
-    params: { slug }
+    params: { slug },
+    ...(options?.published ? { stega: false, perspective: "published" } : {})
+  })
+}
+
+export interface PostIndexEntry {
+  title: string
+  slug: string
+  date: string | null
+}
+
+export async function fetchAllPostsForIndex(): Promise<PostIndexEntry[]> {
+  const query = /* groq */ `*[_type == "post" && defined(slug.current)] | order(date desc){
+    title,
+    "slug": slug.current,
+    date
+  }`
+  return sanityFetch<PostIndexEntry[]>({
+    query,
+    stega: false,
+    perspective: "published"
   })
 }
 

--- a/src/app/api/post/[slug]/route.ts
+++ b/src/app/api/post/[slug]/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server"
+
+import { fetchPostBySlug } from "@/app/(site)/(pages)/post/[slug]/sanity"
+import { SITE_URL } from "@/lib/constants"
+import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
+
+const MD_HEADERS = {
+  "Content-Type": "text/markdown; charset=utf-8",
+  Vary: "Accept",
+  "X-Content-Type-Options": "nosniff"
+} as const
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug: rawSlug } = await params
+
+  // Only the `.md` form is served here; the proxy rewrites to this route.
+  if (!rawSlug.endsWith(".md")) return new NextResponse(null, { status: 404 })
+  const slug = rawSlug.slice(0, -3)
+
+  try {
+    const post = await fetchPostBySlug(slug, { published: true })
+    if (!post) {
+      return new NextResponse("# 404 Not Found\n", {
+        status: 404,
+        headers: MD_HEADERS
+      })
+    }
+
+    const parts: Array<string | null> = [
+      `# ${post.title}`,
+      "",
+      post.authors?.length
+        ? `**Author:** ${post.authors.map((a) => a.title).join(", ")}`
+        : null,
+      post.date
+        ? `**Published:** ${new Date(post.date).toLocaleDateString()}`
+        : null,
+      post.categories?.length
+        ? `**Categories:** ${post.categories.map((c) => c.title).join(", ")}`
+        : null,
+      "",
+      "---",
+      "",
+      portableTextToMarkdown(post.intro, { baseUrl: SITE_URL }),
+      "",
+      portableTextToMarkdown(post.content, { baseUrl: SITE_URL }),
+      "",
+      "---",
+      "",
+      `[View all content](${SITE_URL}/sitemap.md)`
+    ]
+
+    const markdown = parts.filter((part) => part !== null).join("\n")
+
+    return new NextResponse(markdown, { headers: MD_HEADERS })
+  } catch (error) {
+    console.error("Error building post markdown:", error)
+    return new NextResponse("# 500 Error\n\nFailed to build markdown.", {
+      status: 500,
+      headers: MD_HEADERS
+    })
+  }
+}

--- a/src/app/sitemap.md/route.ts
+++ b/src/app/sitemap.md/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server"
+
+import { fetchAllPostsForIndex } from "@/app/(site)/(pages)/post/[slug]/sanity"
+import { SITE_URL } from "@/lib/constants"
+
+export async function GET() {
+  try {
+    const posts = await fetchAllPostsForIndex()
+
+    const parts: string[] = ["# basement.studio — Content Index", ""]
+
+    if (posts.length > 0) {
+      parts.push("## Blog Posts", "")
+      for (const post of posts) {
+        parts.push(`- [${post.title}](${SITE_URL}/post/${post.slug}.md)`)
+      }
+      parts.push("")
+    }
+
+    return new NextResponse(parts.join("\n"), {
+      headers: {
+        "Content-Type": "text/markdown; charset=utf-8",
+        Vary: "Accept",
+        "X-Content-Type-Options": "nosniff"
+      }
+    })
+  } catch (error) {
+    console.error("Error building markdown sitemap:", error)
+    return new NextResponse("# 500 Error\n\nFailed to build content index.", {
+      status: 500,
+      headers: { "Content-Type": "text/markdown; charset=utf-8" }
+    })
+  }
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,2 @@
+/** Canonical production origin. No trailing slash. */
+export const SITE_URL = "https://basement.studio"

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,60 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+import { markdownRoutes } from "@/service/sanity/markdown-proxy.config"
+
+/**
+ * Serves a markdown version of content pages for AI agents / LLMs.
+ *
+ *   1. `/post/<slug>.md`                      → rewrite to the markdown route
+ *   2. `/post/<slug>` + `Accept: text/markdown` → rewrite (content negotiation)
+ *   3. `/post/<slug>` (HTML)                  → advertise the `.md` alternate
+ *
+ * Routes are declared in `markdown-proxy.config.ts`. The matcher below must be
+ * kept in sync with that registry (Next requires a static matcher literal).
+ */
+export function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl
+  const accept = request.headers.get("accept") ?? ""
+
+  // 1. `.md` suffix → markdown API route.
+  for (const route of markdownRoutes) {
+    const slug = route.mdRegex.exec(pathname)?.[1]
+    if (slug) return rewriteToApi(request, route.apiPath, slug)
+  }
+
+  // 2. HTML path + Accept: text/markdown → same markdown API route.
+  if (accept.includes("text/markdown")) {
+    for (const route of markdownRoutes) {
+      const slug = route.htmlRegex.exec(pathname)?.[1]
+      if (slug) return rewriteToApi(request, route.apiPath, slug)
+    }
+  }
+
+  // 3. HTML page request → advertise the markdown alternate so agents can find it.
+  for (const route of markdownRoutes) {
+    const slug = route.htmlRegex.exec(pathname)?.[1]
+    if (!slug) continue
+    const response = NextResponse.next()
+    const mdUrl = route.publicMdPath.replace("[slug]", slug)
+    response.headers.set(
+      "Link",
+      `<${mdUrl}>; rel="alternate"; type="text/markdown"`
+    )
+    response.headers.set("Vary", "Accept")
+    return response
+  }
+
+  return NextResponse.next()
+}
+
+function rewriteToApi(request: NextRequest, apiPath: string, slug: string) {
+  const url = request.nextUrl.clone()
+  url.pathname = apiPath.replace("[slug]", slug)
+  return NextResponse.rewrite(url)
+}
+
+export const config = {
+  // Static literal — Next can't analyze a matcher built from markdownRoutes.
+  // Add a line here when registering a new content type in markdown-proxy.config.ts.
+  matcher: ["/post/:path*"]
+}

--- a/src/service/sanity/markdown-proxy.config.ts
+++ b/src/service/sanity/markdown-proxy.config.ts
@@ -1,0 +1,25 @@
+export interface MarkdownRoute {
+  /** Matches the public `.md` URL, capturing the slug (group 1). */
+  mdRegex: RegExp
+  /** Matches the public HTML URL (no extension), capturing the slug (group 1). */
+  htmlRegex: RegExp
+  /** Internal API route template; `[slug]` is replaced with the captured slug. */
+  apiPath: string
+  /** Public `.md` URL template, used for the `Link` alternate header. */
+  publicMdPath: string
+}
+
+/**
+ * Content types that serve a markdown version for AI agents / LLMs.
+ * Add an entry here to enable the markdown proxy for a new type — and add a
+ * matching line to `config.matcher` in `proxy.ts` (Next can't analyze a
+ * matcher computed from this array).
+ */
+export const markdownRoutes: MarkdownRoute[] = [
+  {
+    mdRegex: /^\/post\/([^/]+)\.md$/,
+    htmlRegex: /^\/post\/([^/.]+)$/,
+    apiPath: "/api/post/[slug].md",
+    publicMdPath: "/post/[slug].md"
+  }
+]

--- a/src/service/sanity/portable-text-to-markdown.ts
+++ b/src/service/sanity/portable-text-to-markdown.ts
@@ -1,0 +1,264 @@
+import { getImageUrl } from "./helpers"
+import type { PortableTextBlock, SanityImage, SanityMuxVideo } from "./types"
+
+interface MarkDef {
+  _key: string
+  _type: string
+  href?: string
+}
+
+interface Span {
+  _type: "span"
+  text?: string
+  marks?: string[]
+}
+
+interface TextBlock {
+  _type: "block"
+  style?: string
+  listItem?: "bullet" | "number"
+  level?: number
+  children?: Span[]
+  markDefs?: MarkDef[]
+}
+
+interface CodeBlockValue {
+  files?: Array<{ title?: string; code?: string; language?: string }>
+}
+
+interface QuoteValue {
+  quote?: PortableTextBlock[]
+  author?: string
+  role?: string
+}
+
+interface SideNoteValue {
+  content?: PortableTextBlock[]
+}
+
+interface GalleryValue {
+  images?: SanityImage[]
+  caption?: string
+}
+
+interface VideoValue {
+  videoUrl?: string
+  muxVideo?: SanityMuxVideo | null
+  caption?: string
+}
+
+// Marks that are inline decorators rather than references into `markDefs`.
+const DECORATORS = new Set([
+  "strong",
+  "em",
+  "code",
+  "underline",
+  "strike-through"
+])
+
+interface Options {
+  /** Used to absolutize root-relative link hrefs (e.g. `/post/x` → `https://…/post/x`). */
+  baseUrl?: string
+}
+
+/**
+ * Converts Sanity Portable Text (including this project's custom blocks) into
+ * plain Markdown. Mirrors the block/mark coverage of the blog post renderer in
+ * `post/[slug]/content.tsx` so the `.md` output matches what readers see.
+ */
+export function portableTextToMarkdown(
+  blocks: PortableTextBlock[] | null | undefined,
+  opts?: Options
+): string {
+  if (!blocks?.length) return ""
+
+  const pieces: Array<{ isListItem: boolean; md: string }> = []
+  for (const block of blocks) {
+    const md = renderBlock(block, opts?.baseUrl)
+    if (md == null) continue
+    const isListItem =
+      block._type === "block" && Boolean((block as TextBlock).listItem)
+    pieces.push({ isListItem, md })
+  }
+
+  return pieces.reduce((acc, piece, i) => {
+    if (i === 0) return piece.md
+    const prev = pieces[i - 1]
+    // Keep consecutive list items tight; separate everything else by a blank line.
+    const sep = prev?.isListItem && piece.isListItem ? "\n" : "\n\n"
+    return acc + sep + piece.md
+  }, "")
+}
+
+function renderBlock(
+  block: PortableTextBlock,
+  baseUrl: string | undefined
+): string | null {
+  switch (block._type) {
+    case "block":
+      return renderTextBlock(block as unknown as TextBlock, baseUrl)
+    case "image":
+      return renderImage(block as unknown as SanityImage & { caption?: string })
+    case "gridGallery":
+      return renderGallery(block as unknown as GalleryValue)
+    case "quoteWithAuthor":
+      return renderQuote(block as unknown as QuoteValue, baseUrl)
+    case "sideNote":
+      return renderSideNote(block as unknown as SideNoteValue, baseUrl)
+    case "codeBlock":
+      return renderCodeBlock(block as unknown as CodeBlockValue)
+    case "videoEmbed":
+      return renderVideo(block as unknown as VideoValue)
+    case "tweetEmbed":
+      return renderTweet(block as unknown as { tweetId?: string })
+    case "codeSandbox":
+      return renderSandbox(block as unknown as { sandboxKey?: string })
+    default:
+      return null
+  }
+}
+
+function renderTextBlock(
+  block: TextBlock,
+  baseUrl: string | undefined
+): string | null {
+  const markDefs = block.markDefs ?? []
+  const text = (block.children ?? [])
+    .map((child) => serializeSpan(child, markDefs, baseUrl))
+    .join("")
+
+  if (!text.trim()) return null
+
+  if (block.listItem) {
+    const indent = "  ".repeat(Math.max(0, (block.level ?? 1) - 1))
+    const marker = block.listItem === "number" ? "1." : "-"
+    return `${indent}${marker} ${text}`
+  }
+
+  switch (block.style) {
+    case "h1":
+      return `# ${text}`
+    case "h2":
+      return `## ${text}`
+    case "h3":
+      return `### ${text}`
+    case "h4":
+      return `#### ${text}`
+    case "blockquote":
+      return blockquote(text)
+    default:
+      return text
+  }
+}
+
+function serializeSpan(
+  span: Span,
+  markDefs: MarkDef[],
+  baseUrl: string | undefined
+): string {
+  if (span._type !== "span") return ""
+  let text = span.text ?? ""
+  const marks = span.marks ?? []
+
+  // Inline code suppresses other formatting inside it, so apply it first.
+  if (marks.includes("code")) text = `\`${text}\``
+  if (marks.includes("strong")) text = `**${text}**`
+  if (marks.includes("em")) text = `*${text}*`
+
+  const linkKey = marks.find((mark) => !DECORATORS.has(mark))
+  if (linkKey) {
+    const def = markDefs.find((d) => d._key === linkKey)
+    if (def?.href) text = `[${text}](${absolutize(def.href, baseUrl)})`
+  }
+
+  return text
+}
+
+function renderImage(block: SanityImage & { caption?: string }): string | null {
+  const img = getImageUrl(block)
+  if (!img) return null
+  const alt = img.alt || block.caption || "Image"
+  let md = `![${alt}](${img.src})`
+  if (block.caption) md += `\n\n_${block.caption}_`
+  return md
+}
+
+function renderGallery(block: GalleryValue): string | null {
+  const parts = (block.images ?? [])
+    .map((image) => {
+      const img = getImageUrl(image)
+      return img ? `![${img.alt || "Image"}](${img.src})` : null
+    })
+    .filter((part): part is string => part !== null)
+
+  if (!parts.length) return null
+  let md = parts.join("\n\n")
+  if (block.caption) md += `\n\n_${block.caption}_`
+  return md
+}
+
+function renderQuote(
+  block: QuoteValue,
+  baseUrl: string | undefined
+): string | null {
+  const quoteMd = portableTextToMarkdown(block.quote, { baseUrl })
+  const attribution = [block.author, block.role].filter(Boolean).join(", ")
+  const inner = [quoteMd, attribution && `— ${attribution}`]
+    .filter(Boolean)
+    .join("\n\n")
+  return inner ? blockquote(inner) : null
+}
+
+function renderSideNote(
+  block: SideNoteValue,
+  baseUrl: string | undefined
+): string | null {
+  const contentMd = portableTextToMarkdown(block.content, { baseUrl })
+  const inner = ["**Note**", contentMd].filter(Boolean).join("\n\n")
+  return blockquote(inner)
+}
+
+function renderCodeBlock(block: CodeBlockValue): string | null {
+  const files = block.files ?? []
+  if (!files.length) return null
+  return files
+    .map((file) => {
+      const title = file.title ? `**${file.title}**\n\n` : ""
+      return `${title}\`\`\`${file.language ?? ""}\n${file.code ?? ""}\n\`\`\``
+    })
+    .join("\n\n")
+}
+
+function renderVideo(block: VideoValue): string | null {
+  const playbackId = block.muxVideo?.playbackId
+  const url = playbackId
+    ? `https://stream.mux.com/${playbackId}.m3u8`
+    : block.videoUrl
+  if (!url) return null
+  let md = `[${block.caption || "Watch video"}](${url})`
+  if (block.caption) md += `\n\n_${block.caption}_`
+  return md
+}
+
+function renderTweet(block: { tweetId?: string }): string | null {
+  if (!block.tweetId) return null
+  return `[View tweet](https://twitter.com/i/web/status/${block.tweetId})`
+}
+
+function renderSandbox(block: { sandboxKey?: string }): string | null {
+  if (!block.sandboxKey) return null
+  return `[Interactive code sandbox: ${block.sandboxKey}]`
+}
+
+function blockquote(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => (line ? `> ${line}` : ">"))
+    .join("\n")
+}
+
+function absolutize(href: string, baseUrl: string | undefined): string {
+  if (!baseUrl) return href
+  if (href.startsWith("/")) return `${baseUrl}${href}`
+  return href
+}


### PR DESCRIPTION
## Summary

Adds a markdown proxy so blog posts can be served as clean Markdown for AI agents / LLMs. A post is reachable at `/post/<slug>.md`, or at `/post/<slug>` with an `Accept: text/markdown` header (content negotiation). Regular browser requests are untouched and continue to render the HTML page, which now advertises the markdown alternate via a `Link` header for discoverability.

This is Phase 1 (blog posts only). The routing/conversion layers are built so other content types (projects, careers, singletons) plug in later via a per-type registry entry. Structurally aligned with the `basementstudio/basement-cli` markdown-proxy spec, with one intentional deviation: the proxy matcher is scoped to `/post/*` rather than a catch-all, to avoid touching the `/ingest` PostHog proxy and Sanity draft mode.

## Changes

- Add `src/proxy.ts` — config-driven middleware: rewrites `.md` URLs and `Accept: text/markdown` requests to the markdown route, and sets a `Link: rel="alternate"` header on HTML pages
- Add `src/service/sanity/markdown-proxy.config.ts` — route registry (one entry per content type)
- Add `src/service/sanity/portable-text-to-markdown.ts` — Portable Text to Markdown converter covering all custom blocks (code, image, gridGallery, quote, sideNote, video, tweet, sandbox), marks, lists and headings
- Add `src/app/api/post/[slug]/route.ts` — markdown route handler (fetches `published` + stega-disabled so output isn't polluted)
- Add `src/app/sitemap.md/route.ts` — markdown content index linked from each post
- Add `src/lib/constants.ts` — shared `SITE_URL`
- Extend `post/[slug]/sanity.ts` with a `published` fetch option and `fetchAllPostsForIndex()`
- Ignore tldr artifacts (`.tldrignore`, `.tldr/`) in `.gitignore`
- Add `.github/PULL_REQUEST_TEMPLATE.md`

## Checklist

- [x] ESLint clean on all files changed in this PR (repo-wide `pnpm lint` has ~185 pre-existing errors in untouched files; none in this branch)
- [x] Tested locally in dev mode — verified `.md` suffix, `Accept` negotiation, `Link` header on HTML, and 404 against real Sanity data
- [x] No breaking changes — additions only; HTML routes and existing fetches unchanged

## Known caveat

On the HTML page response, the middleware's `Vary: Accept` is overwritten by Next's own page-level `Vary` (router headers + `Accept-Encoding`). The markdown responses themselves carry `Vary: Accept` correctly. Only relevant for shared/CDN caching of the HTML page; matches the reference's behavior.
