### PR TITLE
feat: markdown (.md) versions for projects & open positions

### DIFF
--- a/src/app/(site)/(pages)/careers/[slug]/sanity.ts
+++ b/src/app/(site)/(pages)/careers/[slug]/sanity.ts
@@ -27,7 +27,9 @@ export interface CareerPosition {
 // ---------------------------------------------------------------------------
 
 export async function fetchCareerPosition(
-  slug: string
+  slug: string,
+  /** Pass `published: true` for non-draft contexts (e.g. the `.md` endpoint) — disables stega so output isn't polluted with invisible chars. */
+  options?: { published?: boolean }
 ): Promise<CareerPosition | null> {
   const query = /* groq */ `*[_type == "openPosition" && slug.current == $slug][0]{
     _id,
@@ -47,7 +49,27 @@ export async function fetchCareerPosition(
   }`
   return sanityFetch<CareerPosition | null>({
     query,
-    params: { slug }
+    params: { slug },
+    ...(options?.published ? { stega: false, perspective: "published" } : {})
+  })
+}
+
+export interface OpenPositionIndexEntry {
+  title: string
+  slug: string
+}
+
+export async function fetchAllOpenPositionsForIndex(): Promise<
+  OpenPositionIndexEntry[]
+> {
+  const query = /* groq */ `*[_type == "openPosition" && isOpen == true && defined(slug.current)] | order(title asc){
+    title,
+    "slug": slug.current
+  }`
+  return sanityFetch<OpenPositionIndexEntry[]>({
+    query,
+    stega: false,
+    perspective: "published"
   })
 }
 

--- a/src/app/(site)/(pages)/showcase/[slug]/sanity.ts
+++ b/src/app/(site)/(pages)/showcase/[slug]/sanity.ts
@@ -102,11 +102,33 @@ const relatedProjectsQuery = /* groq */ `
 // ---------------------------------------------------------------------------
 
 export async function fetchProjectBySlug(
-  slug: string
+  slug: string,
+  /** Pass `published: true` for non-draft contexts (e.g. the `.md` endpoint) — disables stega so output isn't polluted with invisible chars. */
+  options?: { published?: boolean }
 ): Promise<ShowcaseProjectDetail | null> {
   return sanityFetch<ShowcaseProjectDetail | null>({
     query: projectBySlugQuery,
-    params: { slug }
+    params: { slug },
+    ...(options?.published ? { stega: false, perspective: "published" } : {})
+  })
+}
+
+export interface ProjectIndexEntry {
+  title: string
+  slug: string
+  year: number | null
+}
+
+export async function fetchAllProjectsForIndex(): Promise<ProjectIndexEntry[]> {
+  const query = /* groq */ `*[_type == "project" && defined(slug.current)] | order(year desc, title asc){
+    title,
+    "slug": slug.current,
+    year
+  }`
+  return sanityFetch<ProjectIndexEntry[]>({
+    query,
+    stega: false,
+    perspective: "published"
   })
 }
 

--- a/src/app/api/careers/[slug]/route.ts
+++ b/src/app/api/careers/[slug]/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server"
+
+import { fetchCareerPosition } from "@/app/(site)/(pages)/careers/[slug]/sanity"
+import { SITE_URL } from "@/lib/constants"
+import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
+
+const MD_HEADERS = {
+  "Content-Type": "text/markdown; charset=utf-8",
+  Vary: "Accept",
+  "X-Content-Type-Options": "nosniff"
+} as const
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug: rawSlug } = await params
+
+  // Only the `.md` form is served here; the proxy rewrites to this route.
+  if (!rawSlug.endsWith(".md")) return new NextResponse(null, { status: 404 })
+  const slug = rawSlug.slice(0, -3)
+
+  try {
+    const position = await fetchCareerPosition(slug, { published: true })
+    // Closed positions 404 here too, mirroring the HTML page's `notFound()`.
+    if (!position || !position.isOpen) {
+      return new NextResponse("# 404 Not Found\n", {
+        status: 404,
+        headers: MD_HEADERS
+      })
+    }
+
+    const skills = position.applyFormSetup?.skills
+      ?.map((s) => s.title)
+      .filter(Boolean)
+
+    const parts: Array<string | null> = [
+      `# ${position.title}`,
+      "",
+      position.type ? `**Type:** ${position.type}` : null,
+      position.employmentType
+        ? `**Employment Type:** ${position.employmentType}`
+        : null,
+      position.location ? `**Location:** ${position.location}` : null,
+      position.applyUrl ? `**Apply:** ${position.applyUrl}` : null,
+      skills?.length ? `**Skills:** ${skills.join(", ")}` : null,
+      "",
+      "---",
+      "",
+      portableTextToMarkdown(position.jobDescription, { baseUrl: SITE_URL }),
+      "",
+      "---",
+      "",
+      `[View all content](${SITE_URL}/sitemap.md)`
+    ]
+
+    const markdown = parts.filter((part) => part !== null).join("\n")
+
+    return new NextResponse(markdown, { headers: MD_HEADERS })
+  } catch (error) {
+    console.error("Error building career position markdown:", error)
+    return new NextResponse("# 500 Error\n\nFailed to build markdown.", {
+      status: 500,
+      headers: MD_HEADERS
+    })
+  }
+}

--- a/src/app/api/showcase/[slug]/route.ts
+++ b/src/app/api/showcase/[slug]/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server"
+
+import { fetchProjectBySlug } from "@/app/(site)/(pages)/showcase/[slug]/sanity"
+import { SITE_URL } from "@/lib/constants"
+import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
+
+const MD_HEADERS = {
+  "Content-Type": "text/markdown; charset=utf-8",
+  Vary: "Accept",
+  "X-Content-Type-Options": "nosniff"
+} as const
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug: rawSlug } = await params
+
+  // Only the `.md` form is served here; the proxy rewrites to this route.
+  if (!rawSlug.endsWith(".md")) return new NextResponse(null, { status: 404 })
+  const slug = rawSlug.slice(0, -3)
+
+  try {
+    const project = await fetchProjectBySlug(slug, { published: true })
+    if (!project) {
+      return new NextResponse("# 404 Not Found\n", {
+        status: 404,
+        headers: MD_HEADERS
+      })
+    }
+
+    const clientLine = project.client
+      ? project.client.website
+        ? `**Client:** [${project.client.title}](${project.client.website})`
+        : `**Client:** ${project.client.title}`
+      : null
+
+    const parts: Array<string | null> = [
+      `# ${project.title}`,
+      "",
+      clientLine,
+      project.year ? `**Year:** ${project.year}` : null,
+      project.categories?.length
+        ? `**Categories:** ${project.categories.map((c) => c.title).join(", ")}`
+        : null,
+      project.projectWebsite ? `**Website:** ${project.projectWebsite}` : null,
+      project.caseStudy ? `**Case Study:** ${project.caseStudy}` : null,
+      project.people?.length
+        ? `**Team:** ${project.people
+            .map((p) =>
+              p.department ? `${p.title} (${p.department.title})` : p.title
+            )
+            .join(", ")}`
+        : null,
+      project.awards?.length
+        ? `**Awards:** ${project.awards.map((a) => a.title).join(", ")}`
+        : null,
+      "",
+      "---",
+      "",
+      portableTextToMarkdown(project.content, { baseUrl: SITE_URL }),
+      "",
+      "---",
+      "",
+      `[View all content](${SITE_URL}/sitemap.md)`
+    ]
+
+    const markdown = parts.filter((part) => part !== null).join("\n")
+
+    return new NextResponse(markdown, { headers: MD_HEADERS })
+  } catch (error) {
+    console.error("Error building project markdown:", error)
+    return new NextResponse("# 500 Error\n\nFailed to build markdown.", {
+      status: 500,
+      headers: MD_HEADERS
+    })
+  }
+}

--- a/src/app/sitemap.md/route.ts
+++ b/src/app/sitemap.md/route.ts
@@ -1,11 +1,17 @@
 import { NextResponse } from "next/server"
 
+import { fetchAllOpenPositionsForIndex } from "@/app/(site)/(pages)/careers/[slug]/sanity"
 import { fetchAllPostsForIndex } from "@/app/(site)/(pages)/post/[slug]/sanity"
+import { fetchAllProjectsForIndex } from "@/app/(site)/(pages)/showcase/[slug]/sanity"
 import { SITE_URL } from "@/lib/constants"
 
 export async function GET() {
   try {
-    const posts = await fetchAllPostsForIndex()
+    const [posts, projects, positions] = await Promise.all([
+      fetchAllPostsForIndex(),
+      fetchAllProjectsForIndex(),
+      fetchAllOpenPositionsForIndex()
+    ])
 
     const parts: string[] = ["# basement.studio — Content Index", ""]
 
@@ -13,6 +19,26 @@ export async function GET() {
       parts.push("## Blog Posts", "")
       for (const post of posts) {
         parts.push(`- [${post.title}](${SITE_URL}/post/${post.slug}.md)`)
+      }
+      parts.push("")
+    }
+
+    if (projects.length > 0) {
+      parts.push("## Projects", "")
+      for (const project of projects) {
+        parts.push(
+          `- [${project.title}](${SITE_URL}/showcase/${project.slug}.md)`
+        )
+      }
+      parts.push("")
+    }
+
+    if (positions.length > 0) {
+      parts.push("## Open Positions", "")
+      for (const position of positions) {
+        parts.push(
+          `- [${position.title}](${SITE_URL}/careers/${position.slug}.md)`
+        )
       }
       parts.push("")
     }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -56,5 +56,5 @@ function rewriteToApi(request: NextRequest, apiPath: string, slug: string) {
 export const config = {
   // Static literal — Next can't analyze a matcher built from markdownRoutes.
   // Add a line here when registering a new content type in markdown-proxy.config.ts.
-  matcher: ["/post/:path*"]
+  matcher: ["/post/:path*", "/showcase/:path*", "/careers/:path*"]
 }

--- a/src/service/sanity/markdown-proxy.config.ts
+++ b/src/service/sanity/markdown-proxy.config.ts
@@ -21,5 +21,17 @@ export const markdownRoutes: MarkdownRoute[] = [
     htmlRegex: /^\/post\/([^/.]+)$/,
     apiPath: "/api/post/[slug].md",
     publicMdPath: "/post/[slug].md"
+  },
+  {
+    mdRegex: /^\/showcase\/([^/]+)\.md$/,
+    htmlRegex: /^\/showcase\/([^/.]+)$/,
+    apiPath: "/api/showcase/[slug].md",
+    publicMdPath: "/showcase/[slug].md"
+  },
+  {
+    mdRegex: /^\/careers\/([^/]+)\.md$/,
+    htmlRegex: /^\/careers\/([^/.]+)$/,
+    apiPath: "/api/careers/[slug].md",
+    publicMdPath: "/careers/[slug].md"
   }
 ]


### PR DESCRIPTION
## Summary

Extends the markdown proxy (introduced for blog posts in #410) to the two
slug-based content types, so AI agents can fetch clean Markdown of these pages:

- **project** → `/showcase/[slug].md`
- **openPosition** → `/careers/[slug].md`

Each page is reachable via the `.md` suffix **or** `Accept: text/markdown`
content negotiation; the HTML page advertises the alternate via a `Link` header.
Browser requests are untouched and still render HTML. Follows the
basementstudio/basement-cli MARKDOWN-PROXY.md spec, keeping the existing
per-path matcher deviation (avoids intercepting `/ingest/*` and Sanity draft mode).

## Changes

- `showcase/[slug]/sanity.ts` — add `{ published }` option to `fetchProjectBySlug` (stega off) + `fetchAllProjectsForIndex`
- `careers/[slug]/sanity.ts` — add `{ published }` option to `fetchCareerPosition` (stega off) + `fetchAllOpenPositionsForIndex`
- `api/showcase/[slug]/route.ts`, `api/careers/[slug]/route.ts` — new markdown route handlers (title + metadata + portable text), closed positions 404 to mirror the HTML page
- `markdown-proxy.config.ts` — registry entries for both types
- `proxy.ts` — `/showcase/:path*` and `/careers/:path*` matcher lines
- `sitemap.md/route.ts` — Projects and Open Positions sections (parallel fetch)

Both `project.content` and `openPosition.jobDescription` are plain block arrays,
so `portable-text-to-markdown.ts` needed no changes.

## Checklist

- [x] `tsc --noEmit` clean (ignoring the 2 pre-existing `.jpg`-module errors)
- [x] `eslint` clean on all changed files (repo-wide `pnpm lint` has pre-existing errors in untouched files)
- [x] Tested locally in dev mode — for each type: `.md` (200 + `x-middleware-rewrite`), Accept negotiation (200), browser Accept (HTML + `Link` alternate), nonexistent `.md` (404); `/sitemap.md` lists all three sections
- [x] No breaking changes — browser/HTML requests untouched