### PR TITLE
feat: markdown (.md) versions for singleton pages

### DIFF
--- a/src/app/(site)/(pages)/(home)/sanity.ts
+++ b/src/app/(site)/(pages)/(home)/sanity.ts
@@ -103,9 +103,13 @@ const homepageQuery = /* groq */ `{
 // Fetch
 // ---------------------------------------------------------------------------
 
-export async function fetchHomepage(): Promise<HomepageData> {
+export async function fetchHomepage(
+  /** Pass `published: true` for non-draft contexts (e.g. the `.md` endpoint) — disables stega so output isn't polluted with invisible chars. */
+  options?: { published?: boolean }
+): Promise<HomepageData> {
   return sanityFetch<HomepageData>({
-    query: homepageQuery
+    query: homepageQuery,
+    ...(options?.published ? { stega: false, perspective: "published" } : {})
   })
 }
 

--- a/src/app/(site)/(pages)/people/sanity.ts
+++ b/src/app/(site)/(pages)/people/sanity.ts
@@ -106,15 +106,22 @@ const openPositionsQuery = /* groq */ `
 
 // Fetchers
 
-export async function fetchPeoplePage(): Promise<PeoplePageData | null> {
+export async function fetchPeoplePage(
+  /** Pass `published: true` for non-draft contexts (e.g. the `.md` endpoint) — disables stega so output isn't polluted with invisible chars. */
+  options?: { published?: boolean }
+): Promise<PeoplePageData | null> {
   return sanityFetch<PeoplePageData | null>({
-    query: peoplePageQuery
+    query: peoplePageQuery,
+    ...(options?.published ? { stega: false, perspective: "published" } : {})
   })
 }
 
-export async function fetchPeople(): Promise<PersonItem[]> {
+export async function fetchPeople(options?: {
+  published?: boolean
+}): Promise<PersonItem[]> {
   const result = await sanityFetch<PersonItem[] | null>({
-    query: peopleQuery
+    query: peopleQuery,
+    ...(options?.published ? { stega: false, perspective: "published" } : {})
   })
   return result ?? []
 }
@@ -126,9 +133,12 @@ export async function fetchValues(): Promise<ValueItem[]> {
   return result ?? []
 }
 
-export async function fetchOpenPositions(): Promise<OpenPositionItem[]> {
+export async function fetchOpenPositions(options?: {
+  published?: boolean
+}): Promise<OpenPositionItem[]> {
   const result = await sanityFetch<OpenPositionItem[] | null>({
-    query: openPositionsQuery
+    query: openPositionsQuery,
+    ...(options?.published ? { stega: false, perspective: "published" } : {})
   })
   return result ?? []
 }

--- a/src/app/(site)/(pages)/services/sanity.ts
+++ b/src/app/(site)/(pages)/services/sanity.ts
@@ -88,9 +88,13 @@ const testimonialQuery = /* groq */ `
 
 // Fetchers
 
-export async function fetchServicesPage(): Promise<ServicesPageData | null> {
+export async function fetchServicesPage(
+  /** Pass `published: true` for non-draft contexts (e.g. the `.md` endpoint) — disables stega so output isn't polluted with invisible chars. */
+  options?: { published?: boolean }
+): Promise<ServicesPageData | null> {
   return sanityFetch<ServicesPageData | null>({
-    query: servicesPageQuery
+    query: servicesPageQuery,
+    ...(options?.published ? { stega: false, perspective: "published" } : {})
   })
 }
 

--- a/src/app/(site)/(pages)/showcase/sanity.ts
+++ b/src/app/(site)/(pages)/showcase/sanity.ts
@@ -121,3 +121,31 @@ export async function fetchCategories(): Promise<ShowcaseCategory[]> {
     query: categoriesQuery
   })
 }
+
+export interface ShowcaseListEntry {
+  title: string
+  slug: string
+  client: string | null
+  year: number | null
+}
+
+const showcaseListForMarkdownQuery = /* groq */ `
+  *[_type == "showcasePage"][0].projects[]->{
+    title,
+    "slug": slug.current,
+    "client": client->title,
+    year
+  }
+`
+
+/** Curated showcase project list (title, slug, client, year) for the `/showcase.md` markdown page. */
+export async function fetchShowcaseListForMarkdown(): Promise<
+  ShowcaseListEntry[]
+> {
+  const projects = await sanityFetch<ShowcaseListEntry[] | null>({
+    query: showcaseListForMarkdownQuery,
+    stega: false,
+    perspective: "published"
+  })
+  return projects ?? []
+}

--- a/src/app/api/index.md/route.ts
+++ b/src/app/api/index.md/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from "next/server"
+
+import { fetchHomepage } from "@/app/(site)/(pages)/(home)/sanity"
+import { SITE_URL } from "@/lib/constants"
+import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
+
+const MD_HEADERS = {
+  "Content-Type": "text/markdown; charset=utf-8",
+  Vary: "Accept",
+  "X-Content-Type-Options": "nosniff"
+} as const
+
+export async function GET() {
+  try {
+    const { homepage } = await fetchHomepage({ published: true })
+    if (!homepage) {
+      return new NextResponse("# 404 Not Found\n", {
+        status: 404,
+        headers: MD_HEADERS
+      })
+    }
+
+    const featuredWork = homepage.featuredProjects?.length
+      ? homepage.featuredProjects
+          .map((item) => {
+            const label = item.title || item.project?.title || "Untitled"
+            const slug = item.project?.slug?.current
+            const link = slug
+              ? `[${label}](${SITE_URL}/showcase/${slug}.md)`
+              : label
+            return item.excerpt ? `- ${link} — ${item.excerpt}` : `- ${link}`
+          })
+          .join("\n")
+      : null
+
+    const capabilities = homepage.capabilities?.length
+      ? homepage.capabilities
+          .map((cap) => {
+            const lines = [`### ${cap.title}`]
+            if (cap.description) lines.push("", cap.description)
+            if (cap.subcategories?.length) {
+              lines.push("", ...cap.subcategories.map((s) => `- ${s.title}`))
+            }
+            return lines.join("\n")
+          })
+          .join("\n\n")
+      : null
+
+    const clients = homepage.clients?.length
+      ? homepage.clients
+          .map((c) => (c.website ? `[${c.title}](${c.website})` : c.title))
+          .join(", ")
+      : null
+
+    const parts: Array<string | null> = [
+      "# basement.studio",
+      "",
+      portableTextToMarkdown(homepage.introTitle, { baseUrl: SITE_URL }) ||
+        null,
+      "",
+      portableTextToMarkdown(homepage.introSubtitle, { baseUrl: SITE_URL }) ||
+        null,
+      "",
+      "---",
+      "",
+      featuredWork ? "## Selected Work" : null,
+      featuredWork ? "" : null,
+      featuredWork,
+      featuredWork ? "" : null,
+      "## What We Do",
+      "",
+      portableTextToMarkdown(homepage.capabilitiesIntro, {
+        baseUrl: SITE_URL
+      }) || null,
+      capabilities ? "" : null,
+      capabilities,
+      capabilities ? "" : null,
+      clients ? "## Clients" : null,
+      clients ? "" : null,
+      clients,
+      "",
+      "---",
+      "",
+      `[View all content](${SITE_URL}/sitemap.md)`
+    ]
+
+    const markdown = parts.filter((part) => part !== null).join("\n")
+
+    return new NextResponse(markdown, { headers: MD_HEADERS })
+  } catch (error) {
+    console.error("Error building homepage markdown:", error)
+    return new NextResponse("# 500 Error\n\nFailed to build markdown.", {
+      status: 500,
+      headers: MD_HEADERS
+    })
+  }
+}

--- a/src/app/api/people.md/route.ts
+++ b/src/app/api/people.md/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server"
+
+import {
+  fetchOpenPositions,
+  fetchPeople,
+  fetchPeoplePage
+} from "@/app/(site)/(pages)/people/sanity"
+import { SITE_URL } from "@/lib/constants"
+import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
+
+const MD_HEADERS = {
+  "Content-Type": "text/markdown; charset=utf-8",
+  Vary: "Accept",
+  "X-Content-Type-Options": "nosniff"
+} as const
+
+export async function GET() {
+  try {
+    const [page, people, positions] = await Promise.all([
+      fetchPeoplePage({ published: true }),
+      fetchPeople({ published: true }),
+      fetchOpenPositions({ published: true })
+    ])
+
+    if (!page) {
+      return new NextResponse("# 404 Not Found\n", {
+        status: 404,
+        headers: MD_HEADERS
+      })
+    }
+
+    const team = people.length
+      ? people
+          .map((person) => {
+            const detail = [person.role, person.department?.title]
+              .filter(Boolean)
+              .join(", ")
+            return detail
+              ? `- **${person.title}** — ${detail}`
+              : `- **${person.title}**`
+          })
+          .join("\n")
+      : null
+
+    const openPositions = positions.filter((p) => p.isOpen)
+    const openPositionsList = openPositions.length
+      ? openPositions
+          .map((p) => {
+            const detail = [p.type, p.location].filter(Boolean).join(", ")
+            const link = `[${p.title}](${SITE_URL}/careers/${p.slug}.md)`
+            return detail ? `- ${link} — ${detail}` : `- ${link}`
+          })
+          .join("\n")
+      : null
+
+    const parts: Array<string | null> = [
+      `# ${page.title || "People"}`,
+      "",
+      portableTextToMarkdown(page.subheading1, { baseUrl: SITE_URL }) || null,
+      "",
+      portableTextToMarkdown(page.subheading2, { baseUrl: SITE_URL }) || null,
+      "",
+      "---",
+      "",
+      team ? "## Team" : null,
+      team ? "" : null,
+      team,
+      team ? "" : null,
+      portableTextToMarkdown(page.preOpenPositionsText, {
+        baseUrl: SITE_URL
+      }) || null,
+      openPositionsList ? "" : null,
+      openPositionsList ? "## Open Positions" : null,
+      openPositionsList ? "" : null,
+      openPositionsList,
+      "",
+      "---",
+      "",
+      `[View all content](${SITE_URL}/sitemap.md)`
+    ]
+
+    const markdown = parts.filter((part) => part !== null).join("\n")
+
+    return new NextResponse(markdown, { headers: MD_HEADERS })
+  } catch (error) {
+    console.error("Error building people markdown:", error)
+    return new NextResponse("# 500 Error\n\nFailed to build markdown.", {
+      status: 500,
+      headers: MD_HEADERS
+    })
+  }
+}

--- a/src/app/api/services.md/route.ts
+++ b/src/app/api/services.md/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from "next/server"
+
+import { fetchServicesPage } from "@/app/(site)/(pages)/services/sanity"
+import { SITE_URL } from "@/lib/constants"
+import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
+
+const MD_HEADERS = {
+  "Content-Type": "text/markdown; charset=utf-8",
+  Vary: "Accept",
+  "X-Content-Type-Options": "nosniff"
+} as const
+
+export async function GET() {
+  try {
+    const services = await fetchServicesPage({ published: true })
+    if (!services) {
+      return new NextResponse("# 404 Not Found\n", {
+        status: 404,
+        headers: MD_HEADERS
+      })
+    }
+
+    const serviceCategories = services.serviceCategories?.length
+      ? services.serviceCategories
+          .map((cat) =>
+            [
+              `### ${cat.title}`,
+              "",
+              portableTextToMarkdown(cat.description, { baseUrl: SITE_URL })
+            ]
+              .filter(Boolean)
+              .join("\n")
+          )
+          .join("\n\n")
+      : null
+
+    const ventures = services.ventures?.length
+      ? services.ventures
+          .map((venture) =>
+            [
+              `### ${venture.title}`,
+              "",
+              portableTextToMarkdown(venture.content, { baseUrl: SITE_URL })
+            ]
+              .filter(Boolean)
+              .join("\n")
+          )
+          .join("\n\n")
+      : null
+
+    const parts: Array<string | null> = [
+      "# Services",
+      "",
+      portableTextToMarkdown(services.intro, { baseUrl: SITE_URL }) || null,
+      "",
+      "---",
+      "",
+      serviceCategories ? "## What We Offer" : null,
+      serviceCategories ? "" : null,
+      serviceCategories,
+      serviceCategories ? "" : null,
+      ventures ? "## Ventures" : null,
+      ventures ? "" : null,
+      ventures,
+      "",
+      "---",
+      "",
+      `[View all content](${SITE_URL}/sitemap.md)`
+    ]
+
+    const markdown = parts.filter((part) => part !== null).join("\n")
+
+    return new NextResponse(markdown, { headers: MD_HEADERS })
+  } catch (error) {
+    console.error("Error building services markdown:", error)
+    return new NextResponse("# 500 Error\n\nFailed to build markdown.", {
+      status: 500,
+      headers: MD_HEADERS
+    })
+  }
+}

--- a/src/app/api/showcase.md/route.ts
+++ b/src/app/api/showcase.md/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server"
+
+import { fetchShowcaseListForMarkdown } from "@/app/(site)/(pages)/showcase/sanity"
+import { SITE_URL } from "@/lib/constants"
+
+const MD_HEADERS = {
+  "Content-Type": "text/markdown; charset=utf-8",
+  Vary: "Accept",
+  "X-Content-Type-Options": "nosniff"
+} as const
+
+export async function GET() {
+  try {
+    const projects = await fetchShowcaseListForMarkdown()
+
+    const list = projects
+      .map((project) => {
+        const detail = [project.client, project.year].filter(Boolean).join(", ")
+        const link = `[${project.title}](${SITE_URL}/showcase/${project.slug}.md)`
+        return detail ? `- ${link} — ${detail}` : `- ${link}`
+      })
+      .join("\n")
+
+    const parts: Array<string | null> = [
+      "# Showcase",
+      "",
+      "Selected projects by basement.studio.",
+      list ? "" : null,
+      list || null,
+      "",
+      "---",
+      "",
+      `[View all content](${SITE_URL}/sitemap.md)`
+    ]
+
+    const markdown = parts.filter((part) => part !== null).join("\n")
+
+    return new NextResponse(markdown, { headers: MD_HEADERS })
+  } catch (error) {
+    console.error("Error building showcase markdown:", error)
+    return new NextResponse("# 500 Error\n\nFailed to build markdown.", {
+      status: 500,
+      headers: MD_HEADERS
+    })
+  }
+}

--- a/src/app/sitemap.md/route.ts
+++ b/src/app/sitemap.md/route.ts
@@ -15,6 +15,16 @@ export async function GET() {
 
     const parts: string[] = ["# basement.studio — Content Index", ""]
 
+    parts.push(
+      "## Pages",
+      "",
+      `- [Home](${SITE_URL}/index.md)`,
+      `- [Services](${SITE_URL}/services.md)`,
+      `- [People](${SITE_URL}/people.md)`,
+      `- [Showcase](${SITE_URL}/showcase.md)`,
+      ""
+    )
+
     if (posts.length > 0) {
       parts.push("## Blog Posts", "")
       for (const post of posts) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -16,26 +16,31 @@ export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
   const accept = request.headers.get("accept") ?? ""
 
+  // Slug-based routes capture the slug in group 1; singletons match with no
+  // group. `match[1]` is therefore the slug or `undefined` for singletons.
+
   // 1. `.md` suffix → markdown API route.
   for (const route of markdownRoutes) {
-    const slug = route.mdRegex.exec(pathname)?.[1]
-    if (slug) return rewriteToApi(request, route.apiPath, slug)
+    const match = route.mdRegex.exec(pathname)
+    if (match) return rewriteToApi(request, route.apiPath, match[1])
   }
 
   // 2. HTML path + Accept: text/markdown → same markdown API route.
   if (accept.includes("text/markdown")) {
     for (const route of markdownRoutes) {
-      const slug = route.htmlRegex.exec(pathname)?.[1]
-      if (slug) return rewriteToApi(request, route.apiPath, slug)
+      const match = route.htmlRegex.exec(pathname)
+      if (match) return rewriteToApi(request, route.apiPath, match[1])
     }
   }
 
   // 3. HTML page request → advertise the markdown alternate so agents can find it.
   for (const route of markdownRoutes) {
-    const slug = route.htmlRegex.exec(pathname)?.[1]
-    if (!slug) continue
+    const match = route.htmlRegex.exec(pathname)
+    if (!match) continue
     const response = NextResponse.next()
-    const mdUrl = route.publicMdPath.replace("[slug]", slug)
+    const mdUrl = match[1]
+      ? route.publicMdPath.replace("[slug]", match[1])
+      : route.publicMdPath
     response.headers.set(
       "Link",
       `<${mdUrl}>; rel="alternate"; type="text/markdown"`
@@ -47,14 +52,30 @@ export function proxy(request: NextRequest) {
   return NextResponse.next()
 }
 
-function rewriteToApi(request: NextRequest, apiPath: string, slug: string) {
+function rewriteToApi(
+  request: NextRequest,
+  apiPath: string,
+  slug: string | undefined
+) {
   const url = request.nextUrl.clone()
-  url.pathname = apiPath.replace("[slug]", slug)
+  url.pathname = slug ? apiPath.replace("[slug]", slug) : apiPath
   return NextResponse.rewrite(url)
 }
 
 export const config = {
   // Static literal — Next can't analyze a matcher built from markdownRoutes.
   // Add a line here when registering a new content type in markdown-proxy.config.ts.
-  matcher: ["/post/:path*", "/showcase/:path*", "/careers/:path*"]
+  matcher: [
+    "/post/:path*",
+    "/showcase/:path*",
+    "/careers/:path*",
+    // Singleton pages (no slug): both the HTML path and its `.md` form.
+    "/",
+    "/index.md",
+    "/services",
+    "/services.md",
+    "/people",
+    "/people.md",
+    "/showcase.md"
+  ]
 }

--- a/src/service/sanity/markdown-proxy.config.ts
+++ b/src/service/sanity/markdown-proxy.config.ts
@@ -1,9 +1,18 @@
 export interface MarkdownRoute {
-  /** Matches the public `.md` URL, capturing the slug (group 1). */
+  /**
+   * Matches the public `.md` URL. Slug-based types capture the slug in group 1;
+   * singletons match with no capture group.
+   */
   mdRegex: RegExp
-  /** Matches the public HTML URL (no extension), capturing the slug (group 1). */
+  /**
+   * Matches the public HTML URL (no extension). Slug-based types capture the
+   * slug in group 1; singletons match with no capture group.
+   */
   htmlRegex: RegExp
-  /** Internal API route template; `[slug]` is replaced with the captured slug. */
+  /**
+   * Internal API route template. For slug-based types `[slug]` is replaced with
+   * the captured slug; for singletons it's used verbatim.
+   */
   apiPath: string
   /** Public `.md` URL template, used for the `Link` alternate header. */
   publicMdPath: string
@@ -33,5 +42,30 @@ export const markdownRoutes: MarkdownRoute[] = [
     htmlRegex: /^\/careers\/([^/.]+)$/,
     apiPath: "/api/careers/[slug].md",
     publicMdPath: "/careers/[slug].md"
+  },
+  // Singletons — no slug. The homepage HTML form is the site root (`/`).
+  {
+    mdRegex: /^\/index\.md$/,
+    htmlRegex: /^\/$/,
+    apiPath: "/api/index.md",
+    publicMdPath: "/index.md"
+  },
+  {
+    mdRegex: /^\/services\.md$/,
+    htmlRegex: /^\/services$/,
+    apiPath: "/api/services.md",
+    publicMdPath: "/services.md"
+  },
+  {
+    mdRegex: /^\/people\.md$/,
+    htmlRegex: /^\/people$/,
+    apiPath: "/api/people.md",
+    publicMdPath: "/people.md"
+  },
+  {
+    mdRegex: /^\/showcase\.md$/,
+    htmlRegex: /^\/showcase$/,
+    apiPath: "/api/showcase.md",
+    publicMdPath: "/showcase.md"
   }
 ]


### PR DESCRIPTION
## Summary

> **Stacked on #417** (Part A — slug-based types). Base is `feat/markdown-proxy-slug-types`; retarget to `main` once #417 merges. The diff here is Part B only.

Extends the markdown proxy to the four singleton pages so AI agents can fetch
clean Markdown of them. Singletons have no slug and no single `content` field,
so each route hand-composes its markdown from the page's scattered fields:

- **homepage** → `/index.md` (also `/` + `Accept: text/markdown`)
- **servicesPage** → `/services.md`
- **peoplePage** → `/people.md`
- **showcasePage** → `/showcase.md`

The homepage layout (field selection + order) was reviewed and signed off before
implementation.

## Single code path for slug + singleton routes

`proxy.ts` previously keyed off the captured slug (`exec(pathname)?.[1]`). It now
keys off the match itself, so a regex with **no capture group** (singleton) matches
just as well; `match[1]` is the slug or `undefined`. `rewriteToApi` uses `apiPath`
verbatim when there's no slug. No separate `singletonRoutes` array — one registry,
one loop.

## Changes

- `proxy.ts` — optional-slug handling + matcher lines (`/`, `/index.md`, `/services`, `/services.md`, `/people`, `/people.md`, `/showcase.md`)
- `markdown-proxy.config.ts` — four singleton registry entries (no capture group; homepage HTML form is the site root `/`)
- `api/index.md`, `api/services.md`, `api/people.md`, `api/showcase.md` — new route handlers, each composing markdown from its singleton's fields
- `(home)`, `services`, `people` fetchers — `{ published }` option (stega off); `showcase` fetcher — lightweight `fetchShowcaseListForMarkdown` (published)
- `sitemap.md/route.ts` — Pages section linking the four singleton `.md` pages

### Layout per page
- **Home**: intro title/subtitle → Selected Work (featured projects linked to their `.md` + excerpt) → What We Do (capabilities w/ descriptions + subcategories) → Clients (names linked to websites when available)
- **Services**: intro → What We Offer (service categories) → Ventures
- **People**: subheadings → Team (name — role, department) → Open Positions (linked to careers `.md`)
- **Showcase**: curated project list linked to each project's `.md` (client, year)

Interactive/visual pages with no meaningful prose (`/contact`, `/lab`, `/basketball`, `/doom`) are intentionally skipped.

## Checklist

- [x] `tsc --noEmit` clean (ignoring the 2 pre-existing `.jpg`-module errors)
- [x] `eslint` clean on all changed files (repo-wide `pnpm lint` has pre-existing errors in untouched files)
- [x] Tested locally in dev mode — each singleton: `.md` (200 + `x-middleware-rewrite`), Accept negotiation (200 + rewrite), browser Accept (HTML 200 + `Link` alternate). Verified `/` advertises `</index.md>`. Regression-checked that Part A slug routes (`/showcase/<slug>.md`, `/careers/<slug>.md`, `/post/<slug>.md`) still work and that `/showcase/<slug>` Link still points to the slug `.md` (not the singleton).
- [x] No breaking changes — browser/HTML requests untouched