### PR TITLE
feat(studio): searchable collection panes with thumbnails and draft badges

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@react-three/uikit-default": "1.0.60",
     "@sanity/client": "^7.20.0",
     "@sanity/image-url": "^2.0.3",
+    "@sanity/ui": "3.1.14",
     "@sanity/vision": "^5.18.0",
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.48.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       '@sanity/image-url':
         specifier: ^2.0.3
         version: 2.0.3
+      '@sanity/ui':
+        specifier: 3.1.14
+        version: 3.1.14(@emotion/is-prop-valid@1.4.0)(react-dom@19.0.1(react@19.0.1))(react-is@19.2.6)(react@19.0.1)(styled-components@6.4.1(css-to-react-native@3.2.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1))
       '@sanity/vision':
         specifier: ^5.18.0
         version: 5.18.0(@babel/runtime@7.29.2)(@codemirror/lint@6.8.4)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.0.1(react@19.0.1))(react-is@19.2.6)(react@19.0.1)(sanity@5.18.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@oclif/core@4.10.3)(@sanity/cli-core@1.2.1(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@20.0.0)(jiti@2.6.1)(terser@5.37.0)(yaml@2.8.3))(@types/node@20.0.0)(@types/react-dom@19.0.0)(@types/react@19.0.0)(immer@11.1.8)(jiti@2.6.1)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(styled-components@6.4.1(css-to-react-native@3.2.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1))(terser@5.37.0)(ts-toolbelt@9.6.0)(typescript@5.8.2))(styled-components@6.4.1(css-to-react-native@3.2.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1))
@@ -13410,7 +13413,7 @@ snapshots:
       '@juggle/resize-observer': 3.4.0
       '@sanity/color': 3.0.6
       '@sanity/icons': 3.7.4(react@19.0.1)
-      csstype: 3.1.3
+      csstype: 3.2.3
       motion: 12.38.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
       react: 19.0.1
       react-compiler-runtime: 1.0.0(react@19.0.1)
@@ -13428,7 +13431,7 @@ snapshots:
       '@juggle/resize-observer': 3.4.0
       '@sanity/color': 3.0.6
       '@sanity/icons': 3.7.4(react@19.2.4)
-      csstype: 3.1.3
+      csstype: 3.2.3
       motion: 12.38.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-compiler-runtime: 1.0.0(react@19.2.4)

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -19,6 +19,7 @@ import {
   UsersIcon
 } from "@phosphor-icons/react/dist/ssr"
 import { visionTool } from "@sanity/vision"
+import type { ComponentType } from "react"
 import { defineConfig } from "sanity"
 import { presentationTool } from "sanity/presentation"
 import type { StructureBuilder } from "sanity/structure"
@@ -29,6 +30,7 @@ import { muxInput } from "sanity-plugin-mux-input"
 import { dataset, projectId } from "./sanity/env"
 import { resolve } from "./sanity/presentation/resolve"
 import { schemaTypes } from "./sanity/schemas"
+import { CollectionPane } from "./sanity/studio/collection-pane"
 import { createConfirmPublishAction } from "./sanity/studio/confirm-publish-action"
 
 const isProd = process.env.NODE_ENV === "production"
@@ -46,6 +48,43 @@ const singletonTypes = new Set([
 ])
 
 const singletonActions = new Set(["publish", "discardChanges", "restore"])
+
+// A searchable, live, draft-badged list pane for a multi-document collection.
+// Replaces S.documentTypeListItem with the custom CollectionPane while keeping
+// "Create new" and normal document editing intents working.
+function collectionPane(
+  S: StructureBuilder,
+  schemaType: string,
+  title: string,
+  icon: ComponentType
+) {
+  return S.listItem()
+    .title(title)
+    .icon(icon)
+    .child(
+      S.component()
+        .id(`collection-${schemaType}`)
+        .title(title)
+        .component(CollectionPane)
+        .options({ schemaType })
+        .canHandleIntent(
+          (intentName, params) =>
+            (intentName === "edit" || intentName === "create") &&
+            params.type === schemaType
+        )
+        .menuItems([
+          S.menuItem()
+            .title("Create new")
+            .icon(icon)
+            .intent({ type: "create", params: { type: schemaType } })
+        ])
+        .child((childId: string) =>
+          S.document()
+            .schemaType(schemaType)
+            .documentId(childId.replace(/^drafts\./, ""))
+        )
+    )
+}
 
 function structure(S: StructureBuilder) {
   return S.list()
@@ -122,21 +161,16 @@ function structure(S: StructureBuilder) {
           S.list()
             .title("Content")
             .items([
-              S.documentTypeListItem("post")
-                .title("Blog Posts")
-                .icon(FileTextIcon),
-              S.documentTypeListItem("postCategory")
-                .title("Post Categories")
-                .icon(TagIcon),
-              S.documentTypeListItem("project")
-                .title("Projects")
-                .icon(StackIcon),
-              S.documentTypeListItem("projectCategory")
-                .title("Project Categories")
-                .icon(TagIcon),
-              S.documentTypeListItem("labProject")
-                .title("Lab Projects")
-                .icon(LightningIcon)
+              collectionPane(S, "post", "Blog Posts", FileTextIcon),
+              collectionPane(S, "postCategory", "Post Categories", TagIcon),
+              collectionPane(S, "project", "Projects", StackIcon),
+              collectionPane(
+                S,
+                "projectCategory",
+                "Project Categories",
+                TagIcon
+              ),
+              collectionPane(S, "labProject", "Lab Projects", LightningIcon)
             ])
         ),
 
@@ -148,18 +182,12 @@ function structure(S: StructureBuilder) {
           S.list()
             .title("Company")
             .items([
-              S.documentTypeListItem("client")
-                .title("Clients")
-                .icon(BriefcaseIcon),
-              S.documentTypeListItem("person").title("People").icon(UserIcon),
-              S.documentTypeListItem("department")
-                .title("Departments")
-                .icon(SquaresFourIcon),
-              S.documentTypeListItem("award").title("Awards").icon(StarIcon),
-              S.documentTypeListItem("testimonial")
-                .title("Testimonials")
-                .icon(HeartIcon),
-              S.documentTypeListItem("value").title("Values").icon(TagIcon)
+              collectionPane(S, "client", "Clients", BriefcaseIcon),
+              collectionPane(S, "person", "People", UserIcon),
+              collectionPane(S, "department", "Departments", SquaresFourIcon),
+              collectionPane(S, "award", "Awards", StarIcon),
+              collectionPane(S, "testimonial", "Testimonials", HeartIcon),
+              collectionPane(S, "value", "Values", TagIcon)
             ])
         ),
 
@@ -171,9 +199,7 @@ function structure(S: StructureBuilder) {
           S.list()
             .title("Careers")
             .items([
-              S.documentTypeListItem("openPosition")
-                .title("Open Positions")
-                .icon(BriefcaseIcon)
+              collectionPane(S, "openPosition", "Open Positions", BriefcaseIcon)
             ])
         ),
 

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -66,7 +66,7 @@ function collectionPane(
         .id(`collection-${schemaType}`)
         .title(title)
         .component(CollectionPane)
-        .options({ schemaType })
+        .options({ schemaType, icon })
         .canHandleIntent(
           (intentName, params) =>
             (intentName === "edit" || intentName === "create") &&

--- a/sanity/studio/collection-pane.tsx
+++ b/sanity/studio/collection-pane.tsx
@@ -9,7 +9,7 @@ import {
   Text,
   TextInput
 } from "@sanity/ui"
-import { useEffect, useRef, useState } from "react"
+import { type ComponentType, useEffect, useRef, useState } from "react"
 import { type SanityClient, useClient } from "sanity"
 import { usePaneRouter } from "sanity/structure"
 
@@ -19,7 +19,9 @@ interface CollectionItem {
   _id: string
   _originalId?: string
   title?: string | null
+  slug?: string | null
   subtitle?: string | null
+  imageUrl?: string | null
 }
 
 // `_originalId` is prefixed `drafts.` when an unpublished edit exists, so it's
@@ -29,11 +31,27 @@ const isDraftItem = (item: CollectionItem) =>
 
 const normalizeId = (id: string) => id.replace(/^drafts\./, "")
 
+// Slug shown as a path; everything else (role, client) is a plain subtitle.
+const getSubtitle = (item: CollectionItem) =>
+  item.slug ? `/${item.slug}` : (item.subtitle ?? null)
+
+const THUMB_SIZE = 35
+
+// `imageUrl` coalesces the common thumbnail fields across our document types
+// (heroImage for posts, cover for projects, image/logo/avatar elsewhere).
 const PROJECTION = `{
   _id,
   _originalId,
   "title": coalesce(title, name, "Untitled"),
-  "subtitle": coalesce(slug.current, role, client->title)
+  "slug": slug.current,
+  "subtitle": coalesce(role, client->title),
+  "imageUrl": coalesce(
+    heroImage.asset->url,
+    cover.asset->url,
+    image.asset->url,
+    logo.asset->url,
+    avatar.asset->url
+  )
 }`
 
 const sortByTitle = (items: CollectionItem[]) =>
@@ -48,6 +66,7 @@ interface CollectionPaneProps {
 // structure via S.component() — see sanity.config.ts.
 export function CollectionPane({ options }: CollectionPaneProps) {
   const schemaType = options?.schemaType as string
+  const FallbackIcon = options?.icon as ComponentType<{ size?: number }>
 
   const [items, setItems] = useState<CollectionItem[]>([])
   const [loading, setLoading] = useState(true)
@@ -113,6 +132,7 @@ export function CollectionPane({ options }: CollectionPaneProps) {
     ? sorted.filter(
         (item) =>
           item.title?.toLowerCase().includes(term) ||
+          item.slug?.toLowerCase().includes(term) ||
           item.subtitle?.toLowerCase().includes(term)
       )
     : sorted
@@ -151,6 +171,7 @@ export function CollectionPane({ options }: CollectionPaneProps) {
                 item={item}
                 ChildLink={ChildLink}
                 isActive={normalizeId(item._id) === activeChildId}
+                FallbackIcon={FallbackIcon}
               />
             ))}
           </Stack>
@@ -160,46 +181,89 @@ export function CollectionPane({ options }: CollectionPaneProps) {
   )
 }
 
+interface ThumbnailProps {
+  imageUrl?: string | null
+  FallbackIcon?: ComponentType<{ size?: number }>
+}
+
+const Thumbnail = ({ imageUrl, FallbackIcon }: ThumbnailProps) => (
+  <Box
+    style={{
+      width: THUMB_SIZE,
+      height: THUMB_SIZE,
+      flexShrink: 0,
+      borderRadius: 3,
+      overflow: "hidden",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      background: "var(--card-muted-bg-color)",
+      color: "var(--card-muted-fg-color)"
+    }}
+  >
+    {imageUrl ? (
+      // Sanity CDN URL with crop params — plain img is correct inside Studio
+      // (not a Next.js render context).
+      <img
+        src={`${imageUrl}?w=${THUMB_SIZE * 2}&h=${THUMB_SIZE * 2}&fit=crop&auto=format`}
+        alt=""
+        width={THUMB_SIZE}
+        height={THUMB_SIZE}
+        style={{ width: "100%", height: "100%", objectFit: "cover" }}
+      />
+    ) : FallbackIcon ? (
+      <FallbackIcon size={18} />
+    ) : null}
+  </Box>
+)
+
 interface ItemRowProps {
   item: CollectionItem
   ChildLink: ReturnType<typeof usePaneRouter>["ChildLink"]
   isActive: boolean
+  FallbackIcon?: ComponentType<{ size?: number }>
 }
 
-const ItemRow = ({ item, ChildLink, isActive }: ItemRowProps) => (
-  <ChildLink childId={normalizeId(item._id)}>
-    <Card
-      as="div"
-      padding={3}
-      radius={0}
-      pressed={isActive}
-      tone={isActive ? "primary" : "default"}
-      style={{
-        cursor: "pointer",
-        display: "block",
-        ...(isActive && {
-          backgroundColor: "var(--card-badge-primary-bg-color)",
-          color: "var(--card-badge-primary-fg-color)"
-        })
-      }}
-    >
-      <Stack space={2}>
-        <Flex align="center" gap={2}>
-          <Text size={1} weight="medium">
-            {item.title ?? "Untitled"}
-          </Text>
-          {isDraftItem(item) && (
-            <Badge fontSize={0} mode="outline" tone="caution">
-              Draft
-            </Badge>
-          )}
+const ItemRow = ({ item, ChildLink, isActive, FallbackIcon }: ItemRowProps) => {
+  const subtitle = getSubtitle(item)
+  return (
+    <ChildLink childId={normalizeId(item._id)}>
+      <Card
+        as="div"
+        padding={3}
+        radius={0}
+        pressed={isActive}
+        tone={isActive ? "primary" : "default"}
+        style={{
+          cursor: "pointer",
+          display: "block",
+          ...(isActive && {
+            backgroundColor: "var(--card-badge-primary-bg-color)",
+            color: "var(--card-badge-primary-fg-color)"
+          })
+        }}
+      >
+        <Flex align="center" gap={3}>
+          <Thumbnail imageUrl={item.imageUrl} FallbackIcon={FallbackIcon} />
+          <Stack space={2} flex={1}>
+            <Flex align="center" gap={2}>
+              <Text size={1} weight="medium">
+                {item.title ?? "Untitled"}
+              </Text>
+              {isDraftItem(item) && (
+                <Badge fontSize={0} mode="outline" tone="caution">
+                  Draft
+                </Badge>
+              )}
+            </Flex>
+            {subtitle && (
+              <Text size={0} muted>
+                {subtitle}
+              </Text>
+            )}
+          </Stack>
         </Flex>
-        {item.subtitle && (
-          <Text size={0} muted>
-            {item.subtitle}
-          </Text>
-        )}
-      </Stack>
-    </Card>
-  </ChildLink>
-)
+      </Card>
+    </ChildLink>
+  )
+}

--- a/sanity/studio/collection-pane.tsx
+++ b/sanity/studio/collection-pane.tsx
@@ -1,0 +1,205 @@
+import { MagnifyingGlassIcon } from "@phosphor-icons/react/dist/ssr"
+import {
+  Badge,
+  Box,
+  Card,
+  Flex,
+  Spinner,
+  Stack,
+  Text,
+  TextInput
+} from "@sanity/ui"
+import { useEffect, useRef, useState } from "react"
+import { type SanityClient, useClient } from "sanity"
+import { usePaneRouter } from "sanity/structure"
+
+import { apiVersion } from "../env"
+
+interface CollectionItem {
+  _id: string
+  _originalId?: string
+  title?: string | null
+  subtitle?: string | null
+}
+
+// `_originalId` is prefixed `drafts.` when an unpublished edit exists, so it's
+// our signal that the document has pending changes.
+const isDraftItem = (item: CollectionItem) =>
+  !!item._originalId?.startsWith("drafts.")
+
+const normalizeId = (id: string) => id.replace(/^drafts\./, "")
+
+const PROJECTION = `{
+  _id,
+  _originalId,
+  "title": coalesce(title, name, "Untitled"),
+  "subtitle": coalesce(slug.current, role, client->title)
+}`
+
+const sortByTitle = (items: CollectionItem[]) =>
+  [...items].sort((a, b) => (a.title ?? "").localeCompare(b.title ?? ""))
+
+interface CollectionPaneProps {
+  options?: Record<string, unknown>
+}
+
+// Searchable, live-updating list pane for a single document type, with a
+// "Draft" badge for documents that have unpublished edits. Wired into the desk
+// structure via S.component() — see sanity.config.ts.
+export function CollectionPane({ options }: CollectionPaneProps) {
+  const schemaType = options?.schemaType as string
+
+  const [items, setItems] = useState<CollectionItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [query, setQuery] = useState("")
+
+  const baseClient = useClient({ apiVersion })
+  // Pinned to drafts so the list reflects in-progress edits and the badge.
+  const clientRef = useRef<SanityClient | null>(null)
+  if (!clientRef.current) {
+    clientRef.current = baseClient.withConfig({ perspective: "drafts" })
+  }
+  const client = clientRef.current
+
+  const { ChildLink, routerPanesState, groupIndex } = usePaneRouter()
+  const activeChildId = routerPanesState[groupIndex + 1]?.[0]?.id ?? null
+
+  useEffect(() => {
+    if (!schemaType) return
+
+    setLoading(true)
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+
+    const fetchItems = () => {
+      client
+        .fetch<CollectionItem[]>(`*[_type == $type] ${PROJECTION}`, {
+          type: schemaType
+        })
+        .then((data) => {
+          if (cancelled) return
+          setItems(data)
+          setLoading(false)
+        })
+        .catch(() => {
+          if (!cancelled) setLoading(false)
+        })
+    }
+
+    fetchItems()
+
+    // Refetch (debounced) on every mutation of this type to stay live.
+    const subscription = client
+      .listen(
+        `*[_type == $type]`,
+        { type: schemaType },
+        { visibility: "query", events: ["mutation"], includeResult: false }
+      )
+      .subscribe(() => {
+        clearTimeout(timer)
+        timer = setTimeout(fetchItems, 300)
+      })
+
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+      subscription.unsubscribe()
+    }
+  }, [schemaType, client])
+
+  const term = query.toLowerCase().trim()
+  const sorted = sortByTitle(items)
+  const filtered = term
+    ? sorted.filter(
+        (item) =>
+          item.title?.toLowerCase().includes(term) ||
+          item.subtitle?.toLowerCase().includes(term)
+      )
+    : sorted
+
+  return (
+    <Flex direction="column" style={{ height: "100%" }}>
+      <Box padding={3}>
+        <TextInput
+          icon={MagnifyingGlassIcon}
+          placeholder="Filter…"
+          value={query}
+          onChange={(e) => setQuery(e.currentTarget.value)}
+          clearButton={!!query}
+          onClear={() => setQuery("")}
+        />
+      </Box>
+      <Box style={{ borderBottom: "1px solid var(--card-border-color)" }} />
+      <Box style={{ flex: 1, overflowY: "auto" }}>
+        {loading && (
+          <Flex justify="center" padding={4}>
+            <Spinner />
+          </Flex>
+        )}
+        {!loading && filtered.length === 0 && (
+          <Flex padding={4} justify="center">
+            <Text muted size={1}>
+              {term ? "No matches found" : "Nothing here yet"}
+            </Text>
+          </Flex>
+        )}
+        {!loading && filtered.length > 0 && (
+          <Stack>
+            {filtered.map((item) => (
+              <ItemRow
+                key={item._id}
+                item={item}
+                ChildLink={ChildLink}
+                isActive={normalizeId(item._id) === activeChildId}
+              />
+            ))}
+          </Stack>
+        )}
+      </Box>
+    </Flex>
+  )
+}
+
+interface ItemRowProps {
+  item: CollectionItem
+  ChildLink: ReturnType<typeof usePaneRouter>["ChildLink"]
+  isActive: boolean
+}
+
+const ItemRow = ({ item, ChildLink, isActive }: ItemRowProps) => (
+  <ChildLink childId={normalizeId(item._id)}>
+    <Card
+      as="div"
+      padding={3}
+      radius={0}
+      pressed={isActive}
+      tone={isActive ? "primary" : "default"}
+      style={{
+        cursor: "pointer",
+        display: "block",
+        ...(isActive && {
+          backgroundColor: "var(--card-badge-primary-bg-color)",
+          color: "var(--card-badge-primary-fg-color)"
+        })
+      }}
+    >
+      <Stack space={2}>
+        <Flex align="center" gap={2}>
+          <Text size={1} weight="medium">
+            {item.title ?? "Untitled"}
+          </Text>
+          {isDraftItem(item) && (
+            <Badge fontSize={0} mode="outline" tone="caution">
+              Draft
+            </Badge>
+          )}
+        </Flex>
+        {item.subtitle && (
+          <Text size={0} muted>
+            {item.subtitle}
+          </Text>
+        )}
+      </Stack>
+    </Card>
+  </ChildLink>
+)


### PR DESCRIPTION
Stacked on #419 (merge that first).

Replaces the default document lists for **Content**, **Company** and
**Careers** with a `CollectionPane`: filter/search, live updates, a **Draft**
badge for unpublished edits, a thumbnail (hero/cover/image/logo/avatar, falls
back to the type icon), and a `/slug` subtitle. `Create new` and document
editing still work via `menuItems` + `canHandleIntent`.

Adds `@sanity/ui` (already transitive via `sanity`).

## Verification
- `tsc`/`eslint`/`prettier` clean; `/studio` boots with no console errors.
- On the desk: list filters live, edits refresh in ~300ms, Draft badge shows,
  thumbnails render, "Create new" works.
