### PR TITLE
feat(aeo): machine view for the blog — /ai/blog index and per-post /ai/post pages

### DIFF
--- a/src/app/ai/blog/page.tsx
+++ b/src/app/ai/blog/page.tsx
@@ -1,0 +1,128 @@
+import type { Metadata } from "next"
+import { toPlainText } from "next-sanity"
+
+import {
+  fetchCategoriesNonEmpty,
+  fetchFeaturedPost,
+  fetchPosts
+} from "@/app/(site)/(canvas)/(content)/blog/sanity"
+import { Field, linkClass, Section } from "@/app/ai/components"
+import { truncateDescription } from "@/utils/seo"
+
+export const metadata: Metadata = {
+  title: "Blog machine view",
+  description:
+    "Plain-text index of every basement.studio blog post for AI agents, crawlers, and humans who prefer it raw.",
+  // The human blog is the canonical index; this page is a styled mirror.
+  alternates: { canonical: "https://basement.studio/blog" }
+}
+
+const MachineBlogPage = async () => {
+  const [featuredPost, { posts, total }, categories] = await Promise.all([
+    fetchFeaturedPost(),
+    fetchPosts(),
+    fetchCategoriesNonEmpty()
+  ])
+
+  // The no-category posts query intentionally skips the newest post (the blog
+  // renders it separately as featured) — merge it back in here.
+  const allPosts = [featuredPost, ...posts].filter(
+    (post): post is NonNullable<typeof post> => post !== null
+  )
+
+  const excerpt = featuredPost?.intro?.length
+    ? truncateDescription(toPlainText(featuredPost.intro))
+    : ""
+
+  return (
+    <main className="mx-auto flex w-full max-w-2xl flex-col gap-8 px-4 pb-24 pt-12 text-f-p-mobile uppercase text-machine-base lg:text-f-p">
+      <header className="flex flex-col gap-4">
+        <nav
+          aria-label="Machine index"
+          className="flex flex-wrap gap-x-4 gap-y-1"
+        >
+          <a href="/ai" className={linkClass}>
+            /ai
+          </a>
+          <span className="text-machine-dim">::</span>
+          <span className="text-machine-dim">blog</span>
+        </nav>
+        <h1 className="text-machine-bright">basement.studio :: blog index</h1>
+        <p className="text-machine-dim">
+          # every post from the basement blog, machine-readable. append .md to
+          any post url for raw markdown.
+        </p>
+        <dl className="flex flex-col gap-1">
+          <Field label="posts">{total}</Field>
+          {categories.length ? (
+            <Field label="categories">
+              {categories.map((category) => `[${category.title}]`).join(" ")}
+            </Field>
+          ) : null}
+          <Field label="human">
+            <a href="/blog" className={linkClass}>
+              /blog
+            </a>
+          </Field>
+        </dl>
+      </header>
+
+      {featuredPost ? (
+        <Section title="featured">
+          <p>
+            {featuredPost.date ? (
+              <span className="text-machine-dim">
+                {featuredPost.date.split("T")[0]}{" "}
+              </span>
+            ) : null}
+            <a href={`/ai/post/${featuredPost.slug}`} className={linkClass}>
+              {featuredPost.title}
+            </a>
+          </p>
+          {excerpt ? <p>{excerpt}</p> : null}
+        </Section>
+      ) : null}
+
+      <Section title="all_writing">
+        <ul className="flex flex-col gap-1">
+          {allPosts.map((post) => (
+            <li key={post._id}>
+              {"- "}
+              {post.date ? (
+                <span className="text-machine-dim">
+                  {post.date.split("T")[0]}{" "}
+                </span>
+              ) : null}
+              <a href={`/ai/post/${post.slug}`} className={linkClass}>
+                {post.title}
+              </a>
+              {post.categories?.length ? (
+                <span className="text-machine-dim">
+                  {" "}
+                  {post.categories
+                    .map((category) => `[${category.title}]`)
+                    .join(" ")}
+                </span>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      </Section>
+
+      <footer className="flex flex-col gap-1 text-machine-dim">
+        <p>
+          <a href="/ai" className={linkClass}>
+            back to machine index
+          </a>{" "}
+          ·{" "}
+          <a href="/blog" className={linkClass}>
+            read as human
+          </a>
+        </p>
+        <p>/* EOF */</p>
+      </footer>
+    </main>
+  )
+}
+
+export default MachineBlogPage

--- a/src/app/ai/components.tsx
+++ b/src/app/ai/components.tsx
@@ -1,0 +1,38 @@
+// Shared building blocks for the machine-view pages (/ai and its sub-pages):
+// terminal-styled section rules, key-value rows, and the common link style.
+
+export const linkClass =
+  "underline underline-offset-4 transition-colors hover:text-machine-bright"
+
+export const Section = ({
+  title,
+  children
+}: {
+  title: string
+  children: React.ReactNode
+}) => (
+  <section className="flex w-full flex-col gap-3">
+    <h2 className="w-full overflow-hidden whitespace-nowrap text-machine-dim">
+      {`── ${title.toUpperCase()} ${"─".repeat(80)}`}
+    </h2>
+    {children}
+  </section>
+)
+
+/** `label ....... value` key-value row; mono font keeps the dots aligned. */
+export const Field = ({
+  label,
+  children
+}: {
+  label: string
+  children: React.ReactNode
+}) => (
+  <div className="flex">
+    <dt className="shrink-0 whitespace-pre text-machine-dim">
+      {`${label} `.padEnd(15, ".")}{" "}
+    </dt>
+    {/* min-w-0 + anywhere wrapping: unbroken values (URLs) must not push the
+        page wider than the viewport on small screens. */}
+    <dd className="min-w-0 [overflow-wrap:anywhere]">{children}</dd>
+  </div>
+)

--- a/src/app/ai/page.tsx
+++ b/src/app/ai/page.tsx
@@ -14,6 +14,8 @@ import { COMPANY_FACTS, formatFactList } from "@/lib/company-facts"
 import { fetchOrganizationData } from "@/service/sanity/organization"
 import type { PortableTextBlock } from "@/service/sanity/types"
 
+import { Field, linkClass, Section } from "./components"
+
 export const metadata: Metadata = {
   title: "Machine view",
   description:
@@ -35,7 +37,8 @@ const NAV_LINKS = [
   { href: "/services", label: "services" },
   { href: "/showcase", label: "showcase" },
   { href: "/people", label: "people" },
-  { href: "/blog", label: "blog" },
+  // The blog stays in the machine format — it has its own machine index.
+  { href: "/ai/blog", label: "blog" },
   { href: "/lab", label: "lab" },
   { href: "/contact", label: "contact" }
 ]
@@ -49,42 +52,6 @@ const AGENT_RESOURCES = [
   { href: "/people.md", label: "people.md" },
   { href: "/showcase.md", label: "showcase.md" }
 ]
-
-const linkClass =
-  "underline underline-offset-4 transition-colors hover:text-machine-bright"
-
-const Section = ({
-  title,
-  children
-}: {
-  title: string
-  children: React.ReactNode
-}) => (
-  <section className="flex w-full flex-col gap-3">
-    <h2 className="w-full overflow-hidden whitespace-nowrap text-machine-dim">
-      {`── ${title.toUpperCase()} ${"─".repeat(80)}`}
-    </h2>
-    {children}
-  </section>
-)
-
-/** `label ....... value` key-value row; mono font keeps the dots aligned. */
-const Field = ({
-  label,
-  children
-}: {
-  label: string
-  children: React.ReactNode
-}) => (
-  <div className="flex">
-    <dt className="shrink-0 whitespace-pre text-machine-dim">
-      {`${label} `.padEnd(15, ".")}{" "}
-    </dt>
-    {/* min-w-0 + anywhere wrapping: unbroken values (URLs) must not push the
-        page wider than the viewport on small screens. */}
-    <dd className="min-w-0 [overflow-wrap:anywhere]">{children}</dd>
-  </div>
-)
 
 const plainText = (blocks: PortableTextBlock[] | null) =>
   blocks?.length ? toPlainText(blocks) : ""
@@ -148,7 +115,7 @@ const AiPage = async () => {
         <nav aria-label="Site index" className="flex flex-wrap gap-x-4 gap-y-1">
           {NAV_LINKS.map((link) => (
             <a key={link.href} href={link.href} className={linkClass}>
-              /{link.label === "home" ? "" : link.label}
+              {link.href}
             </a>
           ))}
         </nav>
@@ -294,12 +261,18 @@ const AiPage = async () => {
                     {post.date.split("T")[0]}{" "}
                   </span>
                 ) : null}
-                <a href={`/post/${post.slug}.md`} className={linkClass}>
+                <a href={`/ai/post/${post.slug}`} className={linkClass}>
                   {post.title}
                 </a>
               </li>
             ))}
           </ul>
+          <p className="text-machine-dim">
+            #{" "}
+            <a href="/ai/blog" className={linkClass}>
+              full archive: /ai/blog
+            </a>
+          </p>
         </Section>
       ) : null}
 

--- a/src/app/ai/post/[slug]/machine-code-block.module.css
+++ b/src/app/ai/post/[slug]/machine-code-block.module.css
@@ -1,0 +1,50 @@
+/* Phosphor syntax theme: no hues, just a brightness ramp on the machine
+   palette — bright for keywords/functions, pale for literals, dim for
+   comments/punctuation. Variables consumed by the shiki css-variables theme
+   in machine-code-block.tsx. */
+.content {
+  overflow-x: auto;
+  overflow-y: auto;
+  /* Show 40 lines (plus the pre's 16px vertical padding), scroll the rest.
+     The em value approximates 40 line-boxes for browsers without `lh`. */
+  max-height: 61em;
+  max-height: calc(40 * 1lh + 16px);
+  scrollbar-width: thin;
+  scrollbar-color: theme("colors.machine.dim") transparent;
+  color: theme("colors.machine.base");
+  --machine-color-text: theme("colors.machine.base");
+  --machine-foreground: theme("colors.machine.base");
+  --machine-background: transparent;
+  --machine-token-keyword: theme("colors.machine.bright");
+  --machine-token-function: theme("colors.machine.bright");
+  --machine-token-constant: theme("colors.machine.bright");
+  --machine-token-tag: theme("colors.machine.bright");
+  --machine-token-link: theme("colors.machine.bright");
+  --machine-token-string: theme("colors.codeblock.do");
+  --machine-token-string-expression: theme("colors.codeblock.do");
+  --machine-token-parameter: theme("colors.machine.base");
+  --machine-token-comment: theme("colors.machine.dim");
+  --machine-token-punctuation: theme("colors.machine.dim");
+}
+
+.content :global(pre) {
+  margin: 0;
+  padding: 8px 0;
+  background: transparent !important;
+}
+
+.content :global(code) {
+  display: block;
+  counter-reset: line;
+}
+
+.content :global(.line)::before {
+  counter-increment: line;
+  content: counter(line);
+  display: inline-block;
+  width: 3ch;
+  margin-right: 2ch;
+  text-align: right;
+  color: theme("colors.machine.dim");
+  user-select: none;
+}

--- a/src/app/ai/post/[slug]/machine-code-block.tsx
+++ b/src/app/ai/post/[slug]/machine-code-block.tsx
@@ -1,0 +1,63 @@
+import { codeToHtml, createCssVariablesTheme } from "shiki"
+
+import styles from "./machine-code-block.module.css"
+
+// Same CSS-variables approach as the human blog's ShikiCodeBlock, with a
+// `--machine-` scope so the tokens map onto the phosphor palette (a brightness
+// ramp instead of hues) in machine-code-block.module.css.
+const theme = createCssVariablesTheme({
+  name: "machine",
+  variablePrefix: "--machine-",
+  variableDefaults: {}
+})
+
+async function highlight(code: string, language: string): Promise<string> {
+  "use cache"
+  try {
+    return await codeToHtml(code, { lang: language || "text", theme })
+  } catch {
+    return await codeToHtml(code, { lang: "text", theme })
+  }
+}
+
+export const MachineCodeBlock = async ({
+  files
+}: {
+  files: Array<{ title?: string; code?: string; language?: string }>
+}) => {
+  if (!files.length) return null
+
+  const highlighted = await Promise.all(
+    files.map(async (file) => ({
+      ...file,
+      html: await highlight(file.code ?? "", file.language ?? "")
+    }))
+  )
+
+  return (
+    <div className="flex flex-col gap-3">
+      {highlighted.map((file, i) => {
+        // The block is capped at ~40 visible lines (see the module css); flag
+        // the full length in the rule so the scroll isn't missable.
+        const lineCount = (file.code ?? "").split("\n").length
+        const label = `${file.title || "code"}${
+          file.language ? ` [${file.language}]` : ""
+        }${lineCount > 40 ? ` [${lineCount} lines]` : ""}`
+        return (
+          <figure key={i} className="flex flex-col">
+            <figcaption className="text-machine-dim">
+              {`── ${label} `.padEnd(40, "─")}
+            </figcaption>
+            <div
+              className={styles.content}
+              dangerouslySetInnerHTML={{ __html: file.html }}
+            />
+            <span aria-hidden="true" className="text-machine-dim">
+              {"─".repeat(40)}
+            </span>
+          </figure>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/app/ai/post/[slug]/machine-portable-text.tsx
+++ b/src/app/ai/post/[slug]/machine-portable-text.tsx
@@ -83,9 +83,10 @@ export const MachinePortableText = ({
 }) => {
   if (!blocks?.length) return null
 
-  // Group consecutive list items of the same kind into a single list.
+  // Group consecutive list items (any kind or level — nesting can mix them)
+  // into a single run; List rebuilds the level tree from it.
   const groups: Array<
-    | { kind: "list"; listItem: "bullet" | "number"; items: TextBlock[] }
+    | { kind: "list"; items: TextBlock[] }
     | { kind: "single"; block: PortableTextBlock }
   > = []
   for (const block of blocks) {
@@ -93,14 +94,10 @@ export const MachinePortableText = ({
       block._type === "block" ? (block as unknown as TextBlock).listItem : null
     const prev = groups[groups.length - 1]
     if (listItem) {
-      if (prev?.kind === "list" && prev.listItem === listItem) {
+      if (prev?.kind === "list") {
         prev.items.push(block as unknown as TextBlock)
       } else {
-        groups.push({
-          kind: "list",
-          listItem,
-          items: [block as unknown as TextBlock]
-        })
+        groups.push({ kind: "list", items: [block as unknown as TextBlock] })
       }
     } else {
       groups.push({ kind: "single", block })
@@ -111,7 +108,7 @@ export const MachinePortableText = ({
     <>
       {groups.map((group, i) =>
         group.kind === "list" ? (
-          <List key={i} listItem={group.listItem} items={group.items} />
+          <List key={i} items={group.items} />
         ) : (
           <Block key={i} block={group.block} />
         )
@@ -214,24 +211,76 @@ const Text = ({ block }: { block: TextBlock }) => {
   }
 }
 
-const List = ({
-  listItem,
-  items
-}: {
-  listItem: "bullet" | "number"
-  items: TextBlock[]
-}) => {
-  const Tag = listItem === "number" ? "ol" : "ul"
+interface ListNode {
+  block: TextBlock
+  children: ListNode[]
+}
+
+/**
+ * Rebuilds the nesting tree Portable Text flattens into `level`: deeper items
+ * become children of the previous shallower item, so sublists render as real
+ * nested `<ul>/<ol>` and ordered sublists restart their numbering.
+ */
+const buildListTree = (items: TextBlock[]): ListNode[] => {
+  const roots: ListNode[] = []
+  const stack: Array<{ level: number; nodes: ListNode[] }> = [
+    { level: 1, nodes: roots }
+  ]
+  for (const item of items) {
+    const level = Math.max(1, item.level ?? 1)
+    while (stack.length > 1 && level < stack[stack.length - 1].level) {
+      stack.pop()
+    }
+    const top = stack[stack.length - 1]
+    const parent = top.nodes[top.nodes.length - 1]
+    if (level > top.level && parent) {
+      stack.push({ level, nodes: parent.children })
+      parent.children.push({ block: item, children: [] })
+    } else {
+      top.nodes.push({ block: item, children: [] })
+    }
+  }
+  return roots
+}
+
+const List = ({ items }: { items: TextBlock[] }) => (
+  <ListLevel nodes={buildListTree(items)} depth={0} />
+)
+
+const ListLevel = ({ nodes, depth }: { nodes: ListNode[]; depth: number }) => {
+  // Consecutive same-kind siblings share a list; a kind switch starts a new
+  // one (so a numbered run after bullets numbers from 1).
+  const groups: Array<{ listItem: "bullet" | "number"; nodes: ListNode[] }> = []
+  for (const node of nodes) {
+    const listItem = node.block.listItem ?? "bullet"
+    const prev = groups[groups.length - 1]
+    if (prev?.listItem === listItem) {
+      prev.nodes.push(node)
+    } else {
+      groups.push({ listItem, nodes: [node] })
+    }
+  }
+
   return (
-    <Tag className="flex flex-col gap-1">
-      {items.map((item, i) => (
-        <li key={item._key ?? i} className="whitespace-pre-wrap">
-          {"  ".repeat(Math.max(0, (item.level ?? 1) - 1))}
-          {listItem === "number" ? `${i + 1}. ` : "- "}
-          <Spans block={item} />
-        </li>
-      ))}
-    </Tag>
+    <>
+      {groups.map((group, gi) => {
+        const Tag = group.listItem === "number" ? "ol" : "ul"
+        return (
+          <Tag key={gi} className="flex flex-col gap-1">
+            {group.nodes.map((node, i) => (
+              <li key={node.block._key ?? i} className="whitespace-pre-wrap">
+                {"  ".repeat(depth)}
+                {group.listItem === "number" ? `${i + 1}. ` : "- "}
+                <Spans block={node.block} />
+                {node.children.length ? (
+                  <ListLevel nodes={node.children} depth={depth + 1} />
+                ) : null}
+              </li>
+            ))}
+          </Tag>
+        )
+      })}
+    </>
   )
 }
 

--- a/src/app/ai/post/[slug]/machine-portable-text.tsx
+++ b/src/app/ai/post/[slug]/machine-portable-text.tsx
@@ -1,0 +1,335 @@
+import { Fragment } from "react"
+
+import { linkClass } from "@/app/ai/components"
+import { getImageUrl } from "@/service/sanity/helpers"
+import type {
+  PortableTextBlock,
+  SanityImage,
+  SanityMuxVideo
+} from "@/service/sanity/types"
+import { normalizeHref } from "@/utils/seo"
+
+import { MachineCodeBlock } from "./machine-code-block"
+
+interface MarkDef {
+  _key: string
+  _type: string
+  href?: string
+}
+
+interface Span {
+  _type: "span"
+  text?: string
+  marks?: string[]
+}
+
+interface TextBlock {
+  _type: "block"
+  _key?: string
+  style?: string
+  listItem?: "bullet" | "number"
+  level?: number
+  children?: Span[]
+  markDefs?: MarkDef[]
+}
+
+interface CodeBlockValue {
+  files?: Array<{ title?: string; code?: string; language?: string }>
+}
+
+interface QuoteValue {
+  quote?: PortableTextBlock[]
+  author?: string
+  role?: string
+}
+
+interface SideNoteValue {
+  content?: PortableTextBlock[]
+}
+
+interface GalleryValue {
+  images?: SanityImage[]
+  caption?: string
+}
+
+interface VideoValue {
+  videoUrl?: string
+  muxVideo?: SanityMuxVideo | null
+  caption?: string
+}
+
+// Marks that are inline decorators rather than references into `markDefs`.
+const DECORATORS = new Set([
+  "strong",
+  "em",
+  "code",
+  "underline",
+  "strike-through"
+])
+
+const quoteClass = "border-l border-machine-dim pl-4 text-machine-bright"
+
+/**
+ * Renders Sanity Portable Text as terminal-styled markup for the machine view:
+ * markdown-flavored headings, `- ` lists, bracketed placeholders for rich
+ * media (images, video, sandboxes) linking to the raw asset. Mirrors the
+ * block/mark coverage of `portable-text-to-markdown.ts` so the machine page
+ * matches the `.md` output.
+ */
+export const MachinePortableText = ({
+  blocks
+}: {
+  blocks: PortableTextBlock[] | null | undefined
+}) => {
+  if (!blocks?.length) return null
+
+  // Group consecutive list items of the same kind into a single list.
+  const groups: Array<
+    | { kind: "list"; listItem: "bullet" | "number"; items: TextBlock[] }
+    | { kind: "single"; block: PortableTextBlock }
+  > = []
+  for (const block of blocks) {
+    const listItem =
+      block._type === "block" ? (block as unknown as TextBlock).listItem : null
+    const prev = groups[groups.length - 1]
+    if (listItem) {
+      if (prev?.kind === "list" && prev.listItem === listItem) {
+        prev.items.push(block as unknown as TextBlock)
+      } else {
+        groups.push({
+          kind: "list",
+          listItem,
+          items: [block as unknown as TextBlock]
+        })
+      }
+    } else {
+      groups.push({ kind: "single", block })
+    }
+  }
+
+  return (
+    <>
+      {groups.map((group, i) =>
+        group.kind === "list" ? (
+          <List key={i} listItem={group.listItem} items={group.items} />
+        ) : (
+          <Block key={i} block={group.block} />
+        )
+      )}
+    </>
+  )
+}
+
+const Block = ({ block }: { block: PortableTextBlock }) => {
+  switch (block._type) {
+    case "block":
+      return <Text block={block as unknown as TextBlock} />
+    case "image":
+      return (
+        <ImagePlaceholder
+          image={block as unknown as SanityImage & { caption?: string }}
+        />
+      )
+    case "gridGallery":
+      return <Gallery value={block as unknown as GalleryValue} />
+    case "quoteWithAuthor":
+      return <Quote value={block as unknown as QuoteValue} />
+    case "sideNote":
+      return <SideNote value={block as unknown as SideNoteValue} />
+    case "codeBlock":
+      return <Code value={block as unknown as CodeBlockValue} />
+    case "videoEmbed":
+      return <VideoPlaceholder value={block as unknown as VideoValue} />
+    case "tweetEmbed":
+      return (
+        <TweetPlaceholder value={block as unknown as { tweetId?: string }} />
+      )
+    case "codeSandbox":
+      return (
+        <SandboxPlaceholder
+          value={block as unknown as { sandboxKey?: string }}
+        />
+      )
+    default:
+      return null
+  }
+}
+
+const Spans = ({ block }: { block: TextBlock }) => {
+  const markDefs = block.markDefs ?? []
+  return (
+    <>
+      {(block.children ?? []).map((span, i) => {
+        if (span._type !== "span") return null
+        let node: React.ReactNode = span.text ?? ""
+        const marks = span.marks ?? []
+
+        // Inline code suppresses other formatting inside it, so apply it first.
+        if (marks.includes("code")) {
+          node = <code className="text-machine-bright">`{node}`</code>
+        }
+        if (marks.includes("strong")) {
+          node = <strong className="text-machine-bright">{node}</strong>
+        }
+        if (marks.includes("em")) node = <em>{node}</em>
+
+        const linkKey = marks.find((mark) => !DECORATORS.has(mark))
+        if (linkKey) {
+          const def = markDefs.find((d) => d._key === linkKey)
+          if (def?.href) {
+            node = (
+              <a
+                href={normalizeHref(def.href)}
+                rel="noopener"
+                className={linkClass}
+              >
+                {node}
+              </a>
+            )
+          }
+        }
+
+        return <Fragment key={i}>{node}</Fragment>
+      })}
+    </>
+  )
+}
+
+const Text = ({ block }: { block: TextBlock }) => {
+  const spans = <Spans block={block} />
+
+  switch (block.style) {
+    case "h1":
+      return <h2 className="text-machine-bright"># {spans}</h2>
+    case "h2":
+      return <h2 className="text-machine-bright">## {spans}</h2>
+    case "h3":
+      return <h3 className="text-machine-bright">### {spans}</h3>
+    case "h4":
+      return <h4 className="text-machine-bright">#### {spans}</h4>
+    case "blockquote":
+      return <blockquote className={quoteClass}>{spans}</blockquote>
+    default:
+      return <p>{spans}</p>
+  }
+}
+
+const List = ({
+  listItem,
+  items
+}: {
+  listItem: "bullet" | "number"
+  items: TextBlock[]
+}) => {
+  const Tag = listItem === "number" ? "ol" : "ul"
+  return (
+    <Tag className="flex flex-col gap-1">
+      {items.map((item, i) => (
+        <li key={item._key ?? i} className="whitespace-pre-wrap">
+          {"  ".repeat(Math.max(0, (item.level ?? 1) - 1))}
+          {listItem === "number" ? `${i + 1}. ` : "- "}
+          <Spans block={item} />
+        </li>
+      ))}
+    </Tag>
+  )
+}
+
+/** `[caption]` line under media placeholders. */
+const Caption = ({ caption }: { caption?: string }) =>
+  caption ? <span className="text-machine-dim"> — {caption}</span> : null
+
+const ImagePlaceholder = ({
+  image
+}: {
+  image: SanityImage & { caption?: string }
+}) => {
+  const img = getImageUrl(image)
+  if (!img) return null
+  return (
+    <p className="text-machine-dim">
+      <a href={img.src} rel="noopener" className={linkClass}>
+        [image: {img.alt || image.caption || "untitled"}]
+      </a>
+      <Caption caption={image.caption} />
+    </p>
+  )
+}
+
+const Gallery = ({ value }: { value: GalleryValue }) => {
+  const images = (value.images ?? [])
+    .map((image) => getImageUrl(image))
+    .filter((img): img is NonNullable<typeof img> => img !== null)
+  if (!images.length) return null
+  return (
+    <p className="flex flex-col gap-1 text-machine-dim">
+      {images.map((img, i) => (
+        <a key={i} href={img.src} rel="noopener" className={linkClass}>
+          [image {i + 1}/{images.length}: {img.alt || "untitled"}]
+        </a>
+      ))}
+      <Caption caption={value.caption} />
+    </p>
+  )
+}
+
+const Quote = ({ value }: { value: QuoteValue }) => {
+  const attribution = [value.author, value.role].filter(Boolean).join(", ")
+  return (
+    <blockquote className={`flex flex-col gap-2 ${quoteClass}`}>
+      <MachinePortableText blocks={value.quote} />
+      {attribution ? <p className="text-machine-dim">— {attribution}</p> : null}
+    </blockquote>
+  )
+}
+
+const SideNote = ({ value }: { value: SideNoteValue }) => (
+  <aside className="flex flex-col gap-2 border-l border-machine-dim pl-4">
+    <p className="text-machine-dim">[note]</p>
+    <MachinePortableText blocks={value.content} />
+  </aside>
+)
+
+const Code = ({ value }: { value: CodeBlockValue }) => (
+  <MachineCodeBlock files={value.files ?? []} />
+)
+
+const VideoPlaceholder = ({ value }: { value: VideoValue }) => {
+  const playbackId = value.muxVideo?.playbackId
+  const url = playbackId
+    ? `https://stream.mux.com/${playbackId}.m3u8`
+    : value.videoUrl
+  if (!url) return null
+  return (
+    <p className="text-machine-dim">
+      <a href={url} rel="noopener" className={linkClass}>
+        [video: {value.caption || "stream"}]
+      </a>
+    </p>
+  )
+}
+
+const TweetPlaceholder = ({ value }: { value: { tweetId?: string } }) => {
+  if (!value.tweetId) return null
+  return (
+    <p className="text-machine-dim">
+      <a
+        href={`https://twitter.com/i/web/status/${value.tweetId}`}
+        rel="noopener"
+        className={linkClass}
+      >
+        [tweet: {value.tweetId}]
+      </a>
+    </p>
+  )
+}
+
+const SandboxPlaceholder = ({ value }: { value: { sandboxKey?: string } }) => {
+  if (!value.sandboxKey) return null
+  return (
+    <p className="text-machine-dim">
+      [interactive code sandbox: {value.sandboxKey} — available on the human
+      view]
+    </p>
+  )
+}

--- a/src/app/ai/post/[slug]/page.tsx
+++ b/src/app/ai/post/[slug]/page.tsx
@@ -1,0 +1,161 @@
+import type { Metadata } from "next"
+import { notFound } from "next/navigation"
+
+import {
+  fetchAllPostSlugs,
+  fetchPostBySlug,
+  fetchPostMeta,
+  fetchRelatedPosts
+} from "@/app/(site)/(plain)/(content)/post/[slug]/sanity"
+import { Field, linkClass, Section } from "@/app/ai/components"
+import { extractPlainText } from "@/lib/structured-data/extract-text"
+import { truncateDescription } from "@/utils/seo"
+
+import { MachinePortableText } from "./machine-portable-text"
+
+interface MachinePostProps {
+  params: Promise<{ slug: string }>
+}
+
+export const generateMetadata = async ({
+  params
+}: MachinePostProps): Promise<Metadata | null> => {
+  const { slug } = await params
+  const post = await fetchPostMeta(slug)
+
+  if (!post) return null
+
+  return {
+    title: { absolute: `${post.title ?? "Untitled"} | Machine view` },
+    description:
+      truncateDescription(extractPlainText(post.intro)) ||
+      `Machine-readable mirror of ${post.title ?? "a post"} from the basement.studio blog.`,
+    // The human post is the canonical document; this page is a styled mirror.
+    alternates: { canonical: `https://basement.studio/post/${slug}` }
+  }
+}
+
+async function getPostData(slug: string) {
+  "use cache"
+  const post = await fetchPostBySlug(slug)
+
+  if (!post) return null
+
+  const relatedPosts = await fetchRelatedPosts(
+    post.slug,
+    post.categories?.map((category) => category.title) ?? []
+  )
+
+  return { post, relatedPosts }
+}
+
+const MachinePostPage = async ({ params }: MachinePostProps) => {
+  const { slug } = await params
+  const data = await getPostData(slug)
+
+  if (!data) return notFound()
+
+  const { post, relatedPosts } = data
+
+  return (
+    <main className="mx-auto flex w-full max-w-2xl flex-col gap-8 px-4 pb-24 pt-12 text-f-p-mobile text-machine-base lg:text-f-p">
+      {/* Header/meta stay uppercase like the /ai index; the article body keeps
+          its authored casing for readability. */}
+      <header className="flex flex-col gap-4 uppercase">
+        <nav
+          aria-label="Machine index"
+          className="flex flex-wrap gap-x-4 gap-y-1"
+        >
+          <a href="/ai" className={linkClass}>
+            /ai
+          </a>
+          <span className="text-machine-dim">::</span>
+          <a href="/ai/blog" className={linkClass}>
+            blog
+          </a>
+          <span className="text-machine-dim">::</span>
+          <span className="text-machine-dim">post/{post.slug}</span>
+        </nav>
+        <h1 className="text-machine-bright">{post.title}</h1>
+        <dl className="flex flex-col gap-1">
+          {post.date ? (
+            <Field label="published">{post.date.split("T")[0]}</Field>
+          ) : null}
+          {post.authors?.length ? (
+            <Field label="authors">
+              {post.authors.map((author) => author.title).join(", ")}
+            </Field>
+          ) : null}
+          {post.categories?.length ? (
+            <Field label="tags">
+              {post.categories
+                .map((category) => `[${category.title}]`)
+                .join(" ")}
+            </Field>
+          ) : null}
+          <Field label="markdown">
+            <a href={`/post/${post.slug}.md`} className={linkClass}>
+              /post/{post.slug}.md
+            </a>
+          </Field>
+          <Field label="human">
+            <a href={`/post/${post.slug}`} className={linkClass}>
+              /post/{post.slug}
+            </a>
+          </Field>
+        </dl>
+      </header>
+
+      <Section title="post">
+        <article className="flex flex-col gap-4">
+          <MachinePortableText blocks={post.intro} />
+          <MachinePortableText blocks={post.content} />
+        </article>
+      </Section>
+
+      {relatedPosts.length ? (
+        <Section title="related_writing">
+          <ul className="flex flex-col gap-1 uppercase">
+            {relatedPosts.map((related) => (
+              <li key={related._id}>
+                {"- "}
+                {related.date ? (
+                  <span className="text-machine-dim">
+                    {related.date.split("T")[0]}{" "}
+                  </span>
+                ) : null}
+                <a href={`/ai/post/${related.slug}`} className={linkClass}>
+                  {related.title}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </Section>
+      ) : null}
+
+      <footer className="flex flex-col gap-1 uppercase text-machine-dim">
+        <p>
+          <a href="/ai" className={linkClass}>
+            back to machine index
+          </a>{" "}
+          ·{" "}
+          <a href="/ai/blog" className={linkClass}>
+            all writing
+          </a>{" "}
+          ·{" "}
+          <a href={`/post/${post.slug}`} className={linkClass}>
+            read as human
+          </a>
+        </p>
+        <p>/* EOF */</p>
+      </footer>
+    </main>
+  )
+}
+
+export default MachinePostPage
+
+export async function generateStaticParams() {
+  const slugs = await fetchAllPostSlugs()
+  return slugs.map((slug) => ({ slug }))
+}

--- a/src/components/layout/mode-toggle.tsx
+++ b/src/components/layout/mode-toggle.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { usePathname } from "next/navigation"
 import { useEffect, useState } from "react"
 
 import { cn } from "@/utils/cn"
@@ -11,8 +12,10 @@ const segmentClass =
 // bottom, so it doesn't sit on top of the footer.
 const BOTTOM_THRESHOLD = 120
 
-// sessionStorage key marking that the current tab entered /ai via the toggle,
-// so "Human" can history.back() to the exact page the visitor left.
+// sessionStorage key holding the machine path the current tab entered via the
+// toggle, so "Human" can history.back() to the exact page the visitor left —
+// but only while still on that entry page (navigating within the machine view
+// pushes machine pages onto the history stack, so back() would stay machine).
 // `document.referrer` alone is not enough: it goes stale across client-side
 // navigations within the human site (it keeps the original external referrer).
 const MACHINE_ENTRY_KEY = "bsmt-machine-entry"
@@ -31,6 +34,19 @@ const MACHINE_ENTRY_KEY = "bsmt-machine-entry"
  */
 export const ModeToggle = ({ mode }: { mode: "human" | "machine" }) => {
   const [atBottom, setAtBottom] = useState(false)
+  const pathname = usePathname() ?? ""
+
+  // Blog posts have a per-page machine mirror (/post/<slug> ↔ /ai/post/<slug>)
+  // and the blog index (including category views) mirrors to /ai/blog;
+  // everything else toggles against the /ai index.
+  const machineHref = pathname.startsWith("/post/")
+    ? `/ai${pathname}`
+    : pathname === "/blog" || pathname.startsWith("/blog/")
+      ? "/ai/blog"
+      : "/ai"
+  const humanHref = pathname.startsWith("/ai/")
+    ? pathname.slice("/ai".length)
+    : "/"
 
   // Machine mode matches the /ai amber-phosphor screen; human mode stays
   // grayscale over the WebGL canvas.
@@ -68,7 +84,7 @@ export const ModeToggle = ({ mode }: { mode: "human" | "machine" }) => {
 
   const rememberMachineEntry = () => {
     try {
-      sessionStorage.setItem(MACHINE_ENTRY_KEY, window.location.pathname)
+      sessionStorage.setItem(MACHINE_ENTRY_KEY, machineHref)
     } catch {
       // Storage unavailable — "Human" will fall back to the referrer check.
     }
@@ -80,7 +96,10 @@ export const ModeToggle = ({ mode }: { mode: "human" | "machine" }) => {
 
     let cameFromToggle = false
     try {
-      cameFromToggle = sessionStorage.getItem(MACHINE_ENTRY_KEY) !== null
+      // Only back() while still on the machine page the toggle entered on —
+      // after navigating within the machine view, back() would stay machine.
+      cameFromToggle =
+        sessionStorage.getItem(MACHINE_ENTRY_KEY) === window.location.pathname
       // One-shot: a later direct visit to /ai in this tab must not back() out
       // of the site.
       sessionStorage.removeItem(MACHINE_ENTRY_KEY)
@@ -91,7 +110,7 @@ export const ModeToggle = ({ mode }: { mode: "human" | "machine" }) => {
     const referrer = document.referrer
     const sameOriginReferrer =
       referrer.startsWith(window.location.origin) &&
-      new URL(referrer).pathname !== "/ai"
+      !new URL(referrer).pathname.startsWith("/ai")
 
     // A tab opened directly onto /ai (new tab via modified click, window.open)
     // can inherit the storage marker and referrer but has no session-history
@@ -106,7 +125,8 @@ export const ModeToggle = ({ mode }: { mode: "human" | "machine" }) => {
       e.preventDefault()
       window.history.back()
     }
-    // Otherwise fall through to the anchor's full navigation to "/".
+    // Otherwise fall through to the anchor's full navigation to the human
+    // counterpart of this page.
   }
 
   return (
@@ -130,7 +150,7 @@ export const ModeToggle = ({ mode }: { mode: "human" | "machine" }) => {
           </span>
         ) : (
           <a
-            href="/"
+            href={humanHref}
             onClick={handleBackToHuman}
             className={cn(segmentClass, inactiveClass)}
           >
@@ -143,7 +163,7 @@ export const ModeToggle = ({ mode }: { mode: "human" | "machine" }) => {
           </span>
         ) : (
           <a
-            href="/ai"
+            href={machineHref}
             onClick={rememberMachineEntry}
             className={cn(segmentClass, inactiveClass)}
           >


### PR DESCRIPTION
Extends the parallel.ai-style machine view (#426) to the whole blog, so the site can be browsed end-to-end as human or as machine.

## What's new

### `/ai/post/<slug>` — per-post machine view
- Rendered inside the `/ai` layout (phosphor palette, scanlines, boot shutter, pill).
- `/ai :: blog :: post/<slug>` breadcrumb, dotted key-value meta (published, authors, tags, links to the `.md` mirror and the human page), related writing, `/* EOF */` footer.
- Article body rendered by a terminal-styled Portable Text renderer mirroring the block coverage of `portable-text-to-markdown.ts`: `##`-prefixed headings, `- ` lists, bordered quotes/side-notes, and bracketed `[image] [video] [tweet]` placeholders linking to the raw assets. Header/meta stay uppercase; the article keeps its authored casing.
- Statically generated for all slugs; same `"use cache"` + Live-fetch pattern as the human post page; canonical points at `/post/<slug>` so the mirror never competes in search.

### `/ai/blog` — machine blog index
- Post count, category tags, `FEATURED` (with plain-text excerpt when the post has an intro), and an `ALL_WRITING` list of every post with dates and `[category]` tags, each linking to its machine page. Canonical `/blog`.

### Syntax-highlighted code blocks
- New `MachineCodeBlock`: server-side shiki via a `--machine-*` css-variables theme (same approach as the human blog's `ShikiCodeBlock`), cached with `"use cache"` — no client JS.
- Phosphor theme is a brightness ramp instead of hues: bright keywords/functions/constants, pale string literals, dim comments/punctuation, dim counter line numbers.
- Blocks show 40 lines (`calc(40 * 1lh + 16px)`, `em` fallback) and scroll the rest with a dim thin scrollbar; capped blocks flag their full length in the header rule, e.g. `── scene.tsx [tsx] [170 lines] ──`. CSS-only, so crawlers still get every line.

### Mode toggle
- Now pathname-aware: `/post/<slug>` ↔ `/ai/post/<slug>`, `/blog(/*)` ↔ `/ai/blog`, everything else ↔ `/ai`.
- The sessionStorage entry marker stores the machine path entered on, so **Human** only `history.back()`s (bfcache — keeps the WebGL canvas alive) while still on that entry page; after navigating within the machine view it falls through to a plain navigation to the current page's human counterpart. Referrer fallback now excludes all `/ai*` referrers.

### `/ai` index
- `LATEST_WRITING` links to the styled machine post pages (was raw `.md`) plus a `# full archive: /ai/blog` line; nav shows real hrefs with blog pointing to `/ai/blog`. Shared `Section`/`Field`/link primitives extracted to `src/app/ai/components.tsx`.

## Testing
- Smoke-tested on a dev server against the production dataset: toggle hrefs correct in both directions, unknown slugs 404, canonicals correct, and screenshot-checked posts exercising code blocks, lists, galleries, tweets, videos, and side-notes.
- Verified the 170-line code block caps at exactly 40 visible lines and scrolls internally.
- Prettier, ESLint, `tsc --noEmit`, and the Next build's TS pass are clean.
- Note: one legacy post (`basement-grotesque`) has line numbers baked into its CMS code strings, so it double-numbers — same behavior as the human view; it's a content cleanup in Sanity, not a code issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)