### PR TITLE
fix(ai): drop casing-only name variants from the /ai AKA display

### DIFF
--- a/src/app/ai/page.tsx
+++ b/src/app/ai/page.tsx
@@ -124,7 +124,14 @@ const AiPage = async () => {
       <Section title="about">
         <dl className="flex flex-col gap-1">
           <Field label="name">{COMPANY_FACTS.name}</Field>
-          <Field label="aka">{COMPANY_FACTS.alternateNames.join(", ")}</Field>
+          <Field label="aka">
+            {/* The page's CSS uppercasing collapses the "Basement Studio" /
+                "basement studio" JSON-LD variants into visible duplicates —
+                keep them out of the display (they stay in alternateName). */}
+            {COMPANY_FACTS.alternateNames
+              .filter((name) => name.toLowerCase() !== "basement studio")
+              .join(", ")}
+          </Field>
           <Field label="founded">{COMPANY_FACTS.foundingDate}</Field>
           <Field label="location">
             {COMPANY_FACTS.locationName} ({COMPANY_FACTS.addressCountry})


### PR DESCRIPTION
The machine view uppercases its copy via CSS, so the `Basement Studio` / `basement studio` entries in `COMPANY_FACTS.alternateNames` rendered as identical duplicates in the `/ai` AKA row.

- The `/ai` display now filters out the casing-only variants: `AKA ..... BASEMENT, BSMNT, BASEMENTSTUDIO`.
- `COMPANY_FACTS.alternateNames` is untouched, so the Organization JSON-LD keeps all five `alternateName` variants for answer-engine entity matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)