### PR TITLE
fix(aeo): markdown/AI-view parity with the frozen HTML site

### DIFF
--- a/src/app/(site)/(canvas)/(content)/blog/[[...slug]]/page.tsx
+++ b/src/app/(site)/(canvas)/(content)/blog/[[...slug]]/page.tsx
@@ -8,13 +8,6 @@ import { fetchCategoriesNonEmpty, fetchPostListForSchema } from "../sanity"
 
 type Params = Promise<{ slug: string[] }>
 
-const titleCase = (slug: string): string =>
-  slug
-    .split("-")
-    .filter(Boolean)
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ")
-
 export const generateMetadata = async (props: {
   params: Params
 }): Promise<Metadata> => {
@@ -33,10 +26,22 @@ export const generateMetadata = async (props: {
 
   const categories = await fetchCategoriesNonEmpty()
   const category = categories.find((c) => c.slug === categorySlug)
-  const label = category?.title ?? titleCase(categorySlug)
+
+  // Unknown category or extra segments still render (HTML is frozen) — stop
+  // them from self-canonicalizing as distinct, indexable URLs.
+  if (!category || slug.length > 1) {
+    return {
+      description:
+        "Read the basement.studio blog — articles, deep dives, and behind-the-scenes notes on design, branding, web engineering, 3D, and cool shit that performs.",
+      alternates: {
+        canonical: "https://basement.studio/blog"
+      },
+      robots: { index: false }
+    }
+  }
 
   return {
-    description: `Explore basement.studio's ${label} articles — deep dives, tutorials, and behind-the-scenes notes from our design and engineering team.`,
+    description: `Explore basement.studio's ${category.title} articles — deep dives, tutorials, and behind-the-scenes notes from our design and engineering team.`,
     alternates: {
       canonical: `https://basement.studio/blog/${categorySlug}`
     }
@@ -72,12 +77,8 @@ export default async function BlogIndexPage(props: { params: Params }) {
 export const generateStaticParams = async () => {
   const categories = await fetchCategoriesNonEmpty({ forStaticParams: true })
 
-  categories.unshift({
-    title: "Home",
-    slug: ""
-  })
-
-  return categories.map((category) => ({
-    slug: [category.slug]
-  }))
+  return [
+    { slug: [] },
+    ...categories.map((category) => ({ slug: [category.slug] }))
+  ]
 }

--- a/src/app/(site)/(canvas)/(content)/blog/sanity.ts
+++ b/src/app/(site)/(canvas)/(content)/blog/sanity.ts
@@ -117,6 +117,29 @@ export async function fetchPostCount(): Promise<number> {
   })
 }
 
+export interface PostArchiveEntry {
+  _id: string
+  title: string
+  slug: string
+  date: string | null
+  categories: Array<{ title: string }> | null
+}
+
+// Light sibling of fetchPosts() — skips intro/heroImage/heroVideo.
+export async function fetchPostsForArchive(): Promise<PostArchiveEntry[]> {
+  "use cache"
+  const query = /* groq */ `*[_type == "post"] | order(date desc)[1..-1]{
+    _id,
+    title,
+    "slug": slug.current,
+    date,
+    categories[]->{ title }
+  }`
+  return sanityFetch<PostArchiveEntry[]>({
+    query
+  })
+}
+
 const postListForSchemaQuery = /* groq */ `
   *[_type == "post" && defined(slug.current)] | order(date desc){
     title,

--- a/src/app/(site)/(canvas)/(content)/people/sanity.ts
+++ b/src/app/(site)/(canvas)/(content)/people/sanity.ts
@@ -4,7 +4,7 @@ import type { PortableTextBlock, SanityImage } from "@/service/sanity/types"
 
 // Types
 
-interface SocialNetwork {
+export interface SocialNetwork {
   platform: string
   url: string
 }
@@ -76,6 +76,23 @@ const peopleQuery = /* groq */ `
   }
 `
 
+export interface PersonMarkdownItem {
+  title: string
+  department: { title: string } | null
+  role: string | null
+  socialNetworks: SocialNetwork[]
+}
+
+// Same as peopleQuery, minus `image` — the `.md` route never renders it.
+const peopleForMarkdownQuery = /* groq */ `
+  *[_type == "person"] | order(title asc) {
+    title,
+    department->{ title },
+    role,
+    socialNetworks[]{ platform, url }
+  }
+`
+
 const valuesQuery = /* groq */ `
   *[_type == "value"] | order(_createdAt asc) {
     _key,
@@ -121,6 +138,16 @@ export async function fetchPeople(options?: {
 }): Promise<PersonItem[]> {
   const result = await sanityFetchCached<PersonItem[] | null>({
     query: peopleQuery,
+    ...(options?.published ? { perspective: "published" } : {})
+  })
+  return result ?? []
+}
+
+export async function fetchPeopleForMarkdown(options?: {
+  published?: boolean
+}): Promise<PersonMarkdownItem[]> {
+  const result = await sanityFetchCached<PersonMarkdownItem[] | null>({
+    query: peopleForMarkdownQuery,
     ...(options?.published ? { perspective: "published" } : {})
   })
   return result ?? []

--- a/src/app/(site)/(plain)/(content)/post/[slug]/sanity.ts
+++ b/src/app/(site)/(plain)/(content)/post/[slug]/sanity.ts
@@ -118,7 +118,14 @@ export async function fetchRelatedPosts(
   currentSlug: string,
   currentCategoryTitles: string[]
 ): Promise<RelatedPost[]> {
-  const query = /* groq */ `*[_type == "post"] | order(date desc){
+  if (currentCategoryTitles.length === 0) return []
+
+  // Filter + range pushed into GROQ instead of fetching all posts to keep 3.
+  const query = /* groq */ `*[
+    _type == "post" &&
+    slug.current != $slug &&
+    count(categories[@->title in $titles]) > 0
+  ] | order(date desc)[0...3]{
     _id,
     title,
     "slug": slug.current,
@@ -127,7 +134,8 @@ export async function fetchRelatedPosts(
     categories[]->{ title, "slug": slug.current }
   }`
   const posts = await sanityFetch<RelatedPost[]>({
-    query
+    query,
+    params: { slug: currentSlug, titles: currentCategoryTitles }
   })
 
   return selectRelatedPosts({

--- a/src/app/(site)/(plain)/(content)/showcase/[slug]/sanity.ts
+++ b/src/app/(site)/(plain)/(content)/showcase/[slug]/sanity.ts
@@ -90,15 +90,22 @@ const projectMetaQuery = /* groq */ `
   *[_type == "project" && slug.current == $slug][0]{ title, content }
 `
 
-const relatedProjectsQuery = /* groq */ `
+// Slugs only — icon+lqip is fetched separately for just the 2 selected.
+const relatedProjectsSlugsQuery = /* groq */ `
   *[_type == "showcasePage"][0]{
     "projects": projects[]->{
       _id,
       title,
-      "slug": slug.current,
-      icon ${imageFragment}
+      "slug": slug.current
     }
   }.projects
+`
+
+const relatedProjectsIconsQuery = /* groq */ `
+  *[_type == "project" && slug.current in $slugs]{
+    "slug": slug.current,
+    icon ${imageFragment}
+  }
 `
 
 // ---------------------------------------------------------------------------
@@ -165,13 +172,29 @@ export async function fetchProjectMeta(
 export async function fetchRelatedProjects(
   excludeSlug: string
 ): Promise<RelatedProject[]> {
-  const all = await sanityFetchCached<RelatedProject[] | null>({
-    query: relatedProjectsQuery
+  const all = await sanityFetchCached<
+    Array<{ _id: string; title: string; slug: string }> | null
+  >({
+    query: relatedProjectsSlugsQuery
   })
   if (!all) return []
 
-  return selectRelatedProjects({
-    projects: all,
+  const selected = selectRelatedProjects({
+    projects: all.map((project) => ({ ...project, icon: null })),
     excludeSlug
   })
+  if (!selected.length) return []
+
+  const icons = await sanityFetchCached<
+    Array<{ slug: string; icon: SanityImage | null }>
+  >({
+    query: relatedProjectsIconsQuery,
+    params: { slugs: selected.map((project) => project.slug) }
+  })
+  const iconBySlug = new Map(icons.map((i) => [i.slug, i.icon]))
+
+  return selected.map((project) => ({
+    ...project,
+    icon: iconBySlug.get(project.slug) ?? null
+  }))
 }

--- a/src/app/ai/blog/page.tsx
+++ b/src/app/ai/blog/page.tsx
@@ -4,7 +4,9 @@ import { toPlainText } from "next-sanity"
 import {
   fetchCategoriesNonEmpty,
   fetchFeaturedPost,
-  fetchPosts
+  fetchPostCount,
+  fetchPostsForArchive,
+  type PostArchiveEntry
 } from "@/app/(site)/(canvas)/(content)/blog/sanity"
 import { Field, linkClass, Section } from "@/app/ai/components"
 import { truncateDescription } from "@/utils/seo"
@@ -18,17 +20,27 @@ export const metadata: Metadata = {
 }
 
 const MachineBlogPage = async () => {
-  const [featuredPost, { posts, total }, categories] = await Promise.all([
+  const [featuredPost, posts, total, categories] = await Promise.all([
     fetchFeaturedPost(),
-    fetchPosts(),
+    fetchPostsForArchive(),
+    fetchPostCount(),
     fetchCategoriesNonEmpty()
   ])
 
-  // The no-category posts query intentionally skips the newest post (the blog
-  // renders it separately as featured) — merge it back in here.
-  const allPosts = [featuredPost, ...posts].filter(
-    (post): post is NonNullable<typeof post> => post !== null
-  )
+  // fetchPostsForArchive skips the newest post (rendered separately as
+  // featured) — merge it back in here.
+  const allPosts: PostArchiveEntry[] = [
+    featuredPost
+      ? {
+          _id: featuredPost._id,
+          title: featuredPost.title,
+          slug: featuredPost.slug,
+          date: featuredPost.date,
+          categories: featuredPost.categories
+        }
+      : null,
+    ...posts
+  ].filter((post): post is PostArchiveEntry => post !== null)
 
   const excerpt = featuredPost?.intro?.length
     ? truncateDescription(toPlainText(featuredPost.intro))

--- a/src/app/ai/page.tsx
+++ b/src/app/ai/page.tsx
@@ -2,13 +2,10 @@ import type { Metadata } from "next"
 import { toPlainText } from "next-sanity"
 
 import { fetchHomepage } from "@/app/(site)/(canvas)/(content)/(home)/sanity"
-import {
-  fetchFeaturedPost,
-  fetchPosts
-} from "@/app/(site)/(canvas)/(content)/blog/sanity"
 import { fetchOpenPositions } from "@/app/(site)/(canvas)/(content)/people/sanity"
 import { fetchServicesPage } from "@/app/(site)/(canvas)/(content)/services/sanity"
 import { fetchShowcaseListForMarkdown } from "@/app/(site)/(canvas)/(content)/showcase/sanity"
+import { fetchAllPostsForIndex } from "@/app/(site)/(plain)/(content)/post/[slug]/sanity"
 import { fetchCompanyInfo, fetchCurrentYear } from "@/components/layout/sanity"
 import { COMPANY_FACTS, formatFactList } from "@/lib/company-facts"
 import { fetchOrganizationData } from "@/service/sanity/organization"
@@ -62,8 +59,7 @@ const AiPage = async () => {
     servicesPage,
     positions,
     showcaseList,
-    featuredPost,
-    { posts },
+    posts,
     companyInfo,
     orgData,
     year
@@ -72,20 +68,18 @@ const AiPage = async () => {
     fetchServicesPage({ published: true }),
     fetchOpenPositions({ published: true }),
     fetchShowcaseListForMarkdown(),
-    fetchFeaturedPost(),
-    fetchPosts(),
+    fetchAllPostsForIndex(),
     fetchCompanyInfo(),
     fetchOrganizationData(),
     fetchCurrentYear()
   ])
 
-  // The no-category posts query intentionally skips the newest post (the blog
-  // renders it separately as featured) — merge it back in here.
-  const latestPosts = [featuredPost, ...posts]
-    .filter((post): post is NonNullable<typeof post> => post !== null)
-    .slice(0, 10)
+  const latestPosts = posts.slice(0, 10)
 
   const openPositions = positions.filter((p) => p.isOpen)
+
+  // HTML (ventures.tsx) only shows the first venture — match that.
+  const venture = servicesPage?.ventures?.[0] ?? null
 
   const socialLinks = [
     { label: "x-twitter", url: companyInfo.twitter },
@@ -162,7 +156,15 @@ const AiPage = async () => {
           <ul className="flex flex-col gap-3">
             {homepage.capabilities.map((cap) => (
               <li key={cap._id} className="flex flex-col gap-1">
-                <h3 className="text-machine-bright">* {cap.title}</h3>
+                <h3 className="text-machine-bright">
+                  {"* "}
+                  <a
+                    href={`/showcase?category=${encodeURIComponent(cap.title)}`}
+                    className={linkClass}
+                  >
+                    {cap.title}
+                  </a>
+                </h3>
                 {cap.description ? <p>{cap.description}</p> : null}
                 {cap.subcategories?.length ? (
                   <p className="text-machine-dim">
@@ -175,17 +177,15 @@ const AiPage = async () => {
         </Section>
       ) : null}
 
-      {servicesPage?.ventures?.length ? (
+      {venture ? (
         <Section title="ventures">
           <ul className="flex flex-col gap-3">
-            {servicesPage.ventures.map((venture) => (
-              <li key={venture._key} className="flex flex-col gap-1">
-                <h3 className="text-machine-bright">* {venture.title}</h3>
-                {plainText(venture.content) ? (
-                  <p>{plainText(venture.content)}</p>
-                ) : null}
-              </li>
-            ))}
+            <li key={venture._key} className="flex flex-col gap-1">
+              <h3 className="text-machine-bright">* {venture.title}</h3>
+              {plainText(venture.content) ? (
+                <p>{plainText(venture.content)}</p>
+              ) : null}
+            </li>
           </ul>
         </Section>
       ) : null}
@@ -261,7 +261,7 @@ const AiPage = async () => {
         <Section title="latest_writing">
           <ul className="flex flex-col gap-1">
             {latestPosts.map((post) => (
-              <li key={post._id}>
+              <li key={post.slug}>
                 {"- "}
                 {post.date ? (
                   <span className="text-machine-dim">

--- a/src/app/api/careers/[slug]/route.ts
+++ b/src/app/api/careers/[slug]/route.ts
@@ -17,7 +17,8 @@ export async function GET(
   const { slug: rawSlug } = await params
 
   // Only the `.md` form is served here; the proxy rewrites to this route.
-  if (!rawSlug.endsWith(".md")) return new NextResponse(null, { status: 404 })
+  if (!rawSlug.endsWith(".md"))
+    return new NextResponse(null, { status: 404, headers: MD_HEADERS })
   const slug = rawSlug.slice(0, -3)
 
   try {
@@ -56,7 +57,12 @@ export async function GET(
 
     const markdown = parts.filter((part) => part !== null).join("\n")
 
-    return new NextResponse(markdown, { headers: MD_HEADERS })
+    return new NextResponse(markdown, {
+      headers: {
+        ...MD_HEADERS,
+        Link: `<${SITE_URL}/careers/${slug}>; rel="canonical"`
+      }
+    })
   } catch (error) {
     console.error("Error building career position markdown:", error)
     return new NextResponse("# 500 Error\n\nFailed to build markdown.", {

--- a/src/app/api/index.md/route.ts
+++ b/src/app/api/index.md/route.ts
@@ -37,7 +37,10 @@ export async function GET() {
     const capabilities = homepage.capabilities?.length
       ? homepage.capabilities
           .map((cap) => {
-            const lines = [`### ${cap.title}`]
+            // Match HTML's title-based filter param (slug isn't used for filtering).
+            const lines = [
+              `### [${cap.title}](${SITE_URL}/showcase?category=${encodeURIComponent(cap.title)})`
+            ]
             if (cap.description) lines.push("", cap.description)
             if (cap.subcategories?.length) {
               lines.push("", ...cap.subcategories.map((s) => `- ${s.title}`))
@@ -53,6 +56,13 @@ export async function GET() {
           .join(", ")
       : null
 
+    const whatWeDoIntro =
+      portableTextToMarkdown(homepage.capabilitiesIntro, {
+        baseUrl: SITE_URL
+      }) || null
+    const hasWhatWeDo = Boolean(whatWeDoIntro || capabilities)
+    const hasBody = Boolean(featuredWork || hasWhatWeDo || clients)
+
     const parts: Array<string | null> = [
       "# basement.studio",
       "",
@@ -62,17 +72,15 @@ export async function GET() {
       portableTextToMarkdown(homepage.introSubtitle, { baseUrl: SITE_URL }) ||
         null,
       "",
-      "---",
-      "",
+      hasBody ? "---" : null,
+      hasBody ? "" : null,
       featuredWork ? "## Selected Work" : null,
       featuredWork ? "" : null,
       featuredWork,
       featuredWork ? "" : null,
-      "## What We Do",
-      "",
-      portableTextToMarkdown(homepage.capabilitiesIntro, {
-        baseUrl: SITE_URL
-      }) || null,
+      hasWhatWeDo ? "## What We Do" : null,
+      hasWhatWeDo ? "" : null,
+      whatWeDoIntro,
       capabilities ? "" : null,
       capabilities,
       capabilities ? "" : null,
@@ -100,7 +108,9 @@ export async function GET() {
 
     const markdown = parts.filter((part) => part !== null).join("\n")
 
-    return new NextResponse(markdown, { headers: MD_HEADERS })
+    return new NextResponse(markdown, {
+      headers: { ...MD_HEADERS, Link: `<${SITE_URL}>; rel="canonical"` }
+    })
   } catch (error) {
     console.error("Error building homepage markdown:", error)
     return new NextResponse("# 500 Error\n\nFailed to build markdown.", {

--- a/src/app/api/people.md/route.ts
+++ b/src/app/api/people.md/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server"
 
 import {
   fetchOpenPositions,
-  fetchPeople,
+  fetchPeopleForMarkdown,
   fetchPeoplePage
 } from "@/app/(site)/(canvas)/(content)/people/sanity"
 import { SITE_URL } from "@/lib/constants"
@@ -14,14 +14,14 @@ const MD_HEADERS = {
   "X-Content-Type-Options": "nosniff"
 } as const
 
-// Same department whitelist the HTML crew page renders (see crew.tsx)
+// Same department whitelist and order the HTML crew page renders (see crew.tsx)
 const CREW_DEPARTMENTS = ["Management", "Design", "Development"]
 
 export async function GET() {
   try {
     const [page, people, positions] = await Promise.all([
       fetchPeoplePage({ published: true }),
-      fetchPeople({ published: true }),
+      fetchPeopleForMarkdown({ published: true }),
       fetchOpenPositions({ published: true })
     ])
 
@@ -38,19 +38,34 @@ export async function GET() {
         CREW_DEPARTMENTS.includes(person.department.title)
     )
 
-    const team = crew.length
-      ? crew
-          .map((person) => {
-            const detail = [person.role, person.department?.title]
-              .filter(Boolean)
-              .join(", ")
-            return detail
-              ? `- **${person.title}** — ${detail}`
-              : `- **${person.title}**`
-          })
-          .join("\n")
-      : null
+    // Grouped under department sub-headings to mirror crew.tsx.
+    const teamSections = CREW_DEPARTMENTS.map((dept) => {
+      const deptPeople = crew.filter(
+        (person) => person.department?.title === dept
+      )
+      if (!deptPeople.length) return null
 
+      const lines = deptPeople
+        .map((person) => {
+          const socials = person.socialNetworks?.length
+            ? person.socialNetworks
+                .map((s) => ` — [${s.platform}](${s.url})`)
+                .join("")
+            : ""
+          const base = person.role
+            ? `- **${person.title}** — ${person.role}`
+            : `- **${person.title}**`
+          return `${base}${socials}`
+        })
+        .join("\n")
+
+      return [`### ${dept}`, "", lines].join("\n")
+    }).filter((section): section is string => section !== null)
+
+    const team = teamSections.length ? teamSections.join("\n\n") : null
+
+    // Closed roles are dropped — /careers/[slug].md 404s on them, so
+    // linking one would be a dead link.
     const openPositions = positions.filter((p) => p.isOpen)
     const openPositionsList = openPositions.length
       ? openPositions
@@ -60,7 +75,7 @@ export async function GET() {
             return detail ? `- ${link} — ${detail}` : `- ${link}`
           })
           .join("\n")
-      : null
+      : "none currently open"
 
     const parts: Array<string | null> = [
       `# ${page.title || "People"}`,
@@ -78,9 +93,9 @@ export async function GET() {
       portableTextToMarkdown(page.preOpenPositionsText, {
         baseUrl: SITE_URL
       }) || null,
-      openPositionsList ? "" : null,
-      openPositionsList ? "## Open Positions" : null,
-      openPositionsList ? "" : null,
+      "",
+      "## Open Positions",
+      "",
       openPositionsList,
       "",
       "---",
@@ -90,7 +105,12 @@ export async function GET() {
 
     const markdown = parts.filter((part) => part !== null).join("\n")
 
-    return new NextResponse(markdown, { headers: MD_HEADERS })
+    return new NextResponse(markdown, {
+      headers: {
+        ...MD_HEADERS,
+        Link: `<${SITE_URL}/people>; rel="canonical"`
+      }
+    })
   } catch (error) {
     console.error("Error building people markdown:", error)
     return new NextResponse("# 500 Error\n\nFailed to build markdown.", {

--- a/src/app/api/people.md/route.ts
+++ b/src/app/api/people.md/route.ts
@@ -17,6 +17,16 @@ const MD_HEADERS = {
 // Same department whitelist and order the HTML crew page renders (see crew.tsx)
 const CREW_DEPARTMENTS = ["Management", "Design", "Development"]
 
+// CMS strings land inside `[label](url)` syntax — escape the delimiters so a
+// bracketed label or a parenthesized URL can't break the link.
+const escapeLinkLabel = (text: string) => text.replace(/[\\[\]]/g, "\\$&")
+const escapeLinkUrl = (url: string) =>
+  url.replace(/\(/g, "%28").replace(/\)/g, "%29")
+
+// The CMS platform field still says "Twitter"; the site brands it 𝕏.
+const displayPlatform = (platform: string) =>
+  /twitter|^x$/i.test(platform) ? "𝕏" : platform
+
 export async function GET() {
   try {
     const [page, people, positions] = await Promise.all([
@@ -49,7 +59,10 @@ export async function GET() {
         .map((person) => {
           const socials = person.socialNetworks?.length
             ? person.socialNetworks
-                .map((s) => ` — [${s.platform}](${s.url})`)
+                .map(
+                  (s) =>
+                    ` — [${escapeLinkLabel(displayPlatform(s.platform))}](${escapeLinkUrl(s.url)})`
+                )
                 .join("")
             : ""
           const base = person.role
@@ -71,7 +84,7 @@ export async function GET() {
       ? openPositions
           .map((p) => {
             const detail = [p.type, p.location].filter(Boolean).join(", ")
-            const link = `[${p.title}](${SITE_URL}/careers/${p.slug}.md)`
+            const link = `[${escapeLinkLabel(p.title)}](${SITE_URL}/careers/${p.slug}.md)`
             return detail ? `- ${link} — ${detail}` : `- ${link}`
           })
           .join("\n")

--- a/src/app/api/post/[slug]/route.ts
+++ b/src/app/api/post/[slug]/route.ts
@@ -17,7 +17,8 @@ export async function GET(
   const { slug: rawSlug } = await params
 
   // Only the `.md` form is served here; the proxy rewrites to this route.
-  if (!rawSlug.endsWith(".md")) return new NextResponse(null, { status: 404 })
+  if (!rawSlug.endsWith(".md"))
+    return new NextResponse(null, { status: 404, headers: MD_HEADERS })
   const slug = rawSlug.slice(0, -3)
 
   try {
@@ -55,7 +56,12 @@ export async function GET(
 
     const markdown = parts.filter((part) => part !== null).join("\n")
 
-    return new NextResponse(markdown, { headers: MD_HEADERS })
+    return new NextResponse(markdown, {
+      headers: {
+        ...MD_HEADERS,
+        Link: `<${SITE_URL}/post/${slug}>; rel="canonical"`
+      }
+    })
   } catch (error) {
     console.error("Error building post markdown:", error)
     return new NextResponse("# 500 Error\n\nFailed to build markdown.", {

--- a/src/app/api/services.md/route.ts
+++ b/src/app/api/services.md/route.ts
@@ -34,18 +34,16 @@ export async function GET() {
           .join("\n\n")
       : null
 
-    const ventures = services.ventures?.length
-      ? services.ventures
-          .map((venture) =>
-            [
-              `### ${venture.title}`,
-              "",
-              portableTextToMarkdown(venture.content, { baseUrl: SITE_URL })
-            ]
-              .filter(Boolean)
-              .join("\n")
-          )
-          .join("\n\n")
+    // HTML (ventures.tsx) only shows the first venture — match that.
+    const venture = services.ventures?.[0]
+    const ventures = venture
+      ? [
+          `### ${venture.title}`,
+          "",
+          portableTextToMarkdown(venture.content, { baseUrl: SITE_URL })
+        ]
+          .filter(Boolean)
+          .join("\n")
       : null
 
     const parts: Array<string | null> = [
@@ -70,7 +68,12 @@ export async function GET() {
 
     const markdown = parts.filter((part) => part !== null).join("\n")
 
-    return new NextResponse(markdown, { headers: MD_HEADERS })
+    return new NextResponse(markdown, {
+      headers: {
+        ...MD_HEADERS,
+        Link: `<${SITE_URL}/services>; rel="canonical"`
+      }
+    })
   } catch (error) {
     console.error("Error building services markdown:", error)
     return new NextResponse("# 500 Error\n\nFailed to build markdown.", {

--- a/src/app/api/showcase.md/route.ts
+++ b/src/app/api/showcase.md/route.ts
@@ -35,7 +35,9 @@ export async function GET() {
 
     const markdown = parts.filter((part) => part !== null).join("\n")
 
-    return new NextResponse(markdown, { headers: MD_HEADERS })
+    return new NextResponse(markdown, {
+      headers: { ...MD_HEADERS, Link: `<${SITE_URL}/showcase>; rel="canonical"` }
+    })
   } catch (error) {
     console.error("Error building showcase markdown:", error)
     return new NextResponse("# 500 Error\n\nFailed to build markdown.", {

--- a/src/app/api/showcase/[slug]/route.ts
+++ b/src/app/api/showcase/[slug]/route.ts
@@ -17,7 +17,8 @@ export async function GET(
   const { slug: rawSlug } = await params
 
   // Only the `.md` form is served here; the proxy rewrites to this route.
-  if (!rawSlug.endsWith(".md")) return new NextResponse(null, { status: 404 })
+  if (!rawSlug.endsWith(".md"))
+    return new NextResponse(null, { status: 404, headers: MD_HEADERS })
   const slug = rawSlug.slice(0, -3)
 
   try {
@@ -67,7 +68,12 @@ export async function GET(
 
     const markdown = parts.filter((part) => part !== null).join("\n")
 
-    return new NextResponse(markdown, { headers: MD_HEADERS })
+    return new NextResponse(markdown, {
+      headers: {
+        ...MD_HEADERS,
+        Link: `<${SITE_URL}/showcase/${slug}>; rel="canonical"`
+      }
+    })
   } catch (error) {
     console.error("Error building project markdown:", error)
     return new NextResponse("# 500 Error\n\nFailed to build markdown.", {

--- a/src/app/sitemap.md/route.ts
+++ b/src/app/sitemap.md/route.ts
@@ -5,6 +5,12 @@ import { fetchAllPostsForIndex } from "@/app/(site)/(plain)/(content)/post/[slug
 import { fetchAllProjectsForIndex } from "@/app/(site)/(plain)/(content)/showcase/[slug]/sanity"
 import { SITE_URL } from "@/lib/constants"
 
+const MD_HEADERS = {
+  "Content-Type": "text/markdown; charset=utf-8",
+  Vary: "Accept",
+  "X-Content-Type-Options": "nosniff"
+} as const
+
 export async function GET() {
   try {
     const [posts, projects, positions] = await Promise.all([
@@ -54,17 +60,13 @@ export async function GET() {
     }
 
     return new NextResponse(parts.join("\n"), {
-      headers: {
-        "Content-Type": "text/markdown; charset=utf-8",
-        Vary: "Accept",
-        "X-Content-Type-Options": "nosniff"
-      }
+      headers: MD_HEADERS
     })
   } catch (error) {
     console.error("Error building markdown sitemap:", error)
     return new NextResponse("# 500 Error\n\nFailed to build content index.", {
       status: 500,
-      headers: { "Content-Type": "text/markdown; charset=utf-8" }
+      headers: MD_HEADERS
     })
   }
 }

--- a/src/components/brands/index.tsx
+++ b/src/components/brands/index.tsx
@@ -72,6 +72,8 @@ export const BrandsDesktop = ({ brands }: BrandsDesktopProps) => {
     ? brands.find((row) => row._id === debouncedHoveredBrandId)?._title
     : undefined
 
+  // Cap is visual only (logo grid needs full rows) — /index.md lists every
+  // client on purpose, don't "fix" that to match this number.
   const max = isLargeDesktop ? 32 : 30
   const groupSize = isLargeDesktop ? 8 : 6
   const available = Math.min(brands.length, max)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -17,6 +17,18 @@ export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
   const accept = request.headers.get("accept") ?? ""
 
+  // `skipTrailingSlashRedirect` (next.config.ts) keeps PostHog's trailing-slash
+  // requests alive, but it also suppresses Next's own 308 everywhere else —
+  // restore it here. `/ingest/*` isn't in `config.matcher`, so PostHog is unaffected.
+  if (pathname !== "/" && pathname.endsWith("/")) {
+    // Plain URL — `NextURL.clone()` re-adds the trailing slash on `.toString()`.
+    const target = new URL(
+      pathname.slice(0, -1) + request.nextUrl.search,
+      request.url
+    )
+    return NextResponse.redirect(target, 308)
+  }
+
   // Mobile visitors to /lab go to the lightweight external lab (the WebGL
   // arcade is desktop-only). Done here so the /lab page stays prerenderable.
   // Crawlers are exempt even with mobile UAs (Googlebot Smartphone, site
@@ -88,8 +100,10 @@ export const config = {
     "/",
     "/index.md",
     "/services",
+    "/services/",
     "/services.md",
     "/people",
+    "/people/",
     "/people.md",
     "/showcase.md",
     // Mobile user-agent redirect (see top of proxy()).

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -19,8 +19,12 @@ export function proxy(request: NextRequest) {
 
   // `skipTrailingSlashRedirect` (next.config.ts) keeps PostHog's trailing-slash
   // requests alive, but it also suppresses Next's own 308 everywhere else —
-  // restore it here. `/ingest/*` isn't in `config.matcher`, so PostHog is unaffected.
-  if (pathname !== "/" && pathname.endsWith("/")) {
+  // restore it here for everything except the PostHog proxy paths.
+  if (
+    pathname !== "/" &&
+    pathname.endsWith("/") &&
+    !pathname.startsWith("/ingest/")
+  ) {
     // Plain URL — `NextURL.clone()` re-adds the trailing slash on `.toString()`.
     const target = new URL(
       pathname.slice(0, -1) + request.nextUrl.search,
@@ -100,13 +104,19 @@ export const config = {
     "/",
     "/index.md",
     "/services",
-    "/services/",
     "/services.md",
     "/people",
-    "/people/",
     "/people.md",
     "/showcase.md",
     // Mobile user-agent redirect (see top of proxy()).
-    "/lab"
+    "/lab",
+    // Remaining page routes, listed only so the trailing-slash 308 above covers
+    // them. Enumerated rather than a catch-all: a catch-all would bill a
+    // middleware invocation on every /3d and /emulators asset request.
+    "/contact",
+    "/basketball",
+    "/doom",
+    "/ai/:path*",
+    "/blog/:path*"
   ]
 }

--- a/src/service/sanity/markdown-proxy.config.ts
+++ b/src/service/sanity/markdown-proxy.config.ts
@@ -27,19 +27,21 @@ export interface MarkdownRoute {
 export const markdownRoutes: MarkdownRoute[] = [
   {
     mdRegex: /^\/post\/([^/]+)\.md$/,
-    htmlRegex: /^\/post\/([^/.]+)$/,
+    // Same char class as mdRegex — dotted slugs (e.g. "next.js-thing") were
+    // silently skipped otherwise.
+    htmlRegex: /^\/post\/([^/]+)$/,
     apiPath: "/api/post/[slug].md",
     publicMdPath: "/post/[slug].md"
   },
   {
     mdRegex: /^\/showcase\/([^/]+)\.md$/,
-    htmlRegex: /^\/showcase\/([^/.]+)$/,
+    htmlRegex: /^\/showcase\/([^/]+)$/,
     apiPath: "/api/showcase/[slug].md",
     publicMdPath: "/showcase/[slug].md"
   },
   {
     mdRegex: /^\/careers\/([^/]+)\.md$/,
-    htmlRegex: /^\/careers\/([^/.]+)$/,
+    htmlRegex: /^\/careers\/([^/]+)$/,
     apiPath: "/api/careers/[slug].md",
     publicMdPath: "/careers/[slug].md"
   },


### PR DESCRIPTION
## Summary

Audit + fix of six defect classes where the `.md` and `/ai` machine-readable views had silently diverged from the human-facing HTML (same Sanity content, three separate renderers, no test suite). Per the audit's hard constraint, **no rendered HTML changed** — every fix lands on the machine side, or is a metadata-only change with zero visual impact. See commit messages for the finding-by-finding breakdown.

## Changes

- `/index.md` and `/ai`: capability names now link to `/showcase?category=`, matching the HTML grid (previously bare text)
- `/services.md` and `/ai`: show only the first venture, matching the HTML banner (was listing all 3)
- `/people.md`: appends social links and groups crew by department, matching `crew.tsx` (was a flat, link-less list)
- `/people.md`, `/ai`, `/ai/blog`: use light queries instead of the full image/hero projections they never render
- `/index.md`: gates the "What We Do" heading/divider on actual content presence
- `fetchRelatedPosts` / `fetchRelatedProjects`: push filtering into GROQ instead of fetching all posts/projects to keep 2-3 (was 28 posts × heavy projection × 2 pages × 28 slugs at build time)
- All `.md` routes: consistent headers on every response path, plus a `Link: rel="canonical"` on 200s pointing at the HTML twin (previously two indexable URLs with no relationship signal)
- `/blog/<unknown-category>` and deep segments: canonical + `robots: noindex` instead of self-referentially indexing every typo as a distinct URL (metadata-only — the rendered empty list is unchanged)
- `generateStaticParams` for the blog index: fixed an accidental `{slug: [""]}` alias of `/blog`
- `proxy.ts`: restored the trailing-slash redirect that `skipTrailingSlashRedirect` (needed for PostHog) was suppressing for every other path — `/post/<slug>/` etc. were silently missing the markdown `Link`/`Vary` headers
- `markdown-proxy.config.ts`: relaxed the HTML-slug regex to match the markdown regex's character class (a dotted slug silently skipped the `.md` alternate advertisement)

## Test Plan

- [x] `tsc --noEmit` — no new errors vs. the pre-existing baseline
- [x] Live-probed every route against a local dev server: headers, canonicals, and the fixed trailing-slash redirect (no loops; PostHog `/ingest/*` unaffected)
- [x] Diffed rendered HTML of 5 posts + 5 showcase pages before/after the related-content query changes — related sections (titles, links, icons) are byte-identical
- [ ] `pnpm lint` (couldn't run in this environment — pre-existing OOM in the eslint config, unrelated to this diff)
- [ ] Manual review in a browser