### PR TITLE
fix(ci): drop the posthog-cli sourcemap step from the Vercel build

### DIFF
--- a/vercel.sh
+++ b/vercel.sh
@@ -13,11 +13,7 @@ else
   echo "Skipping 'sanity schema deploy' — SANITY_AUTH_TOKEN is not set."
 fi
 
-if [[ $VERCEL_ENV == "production"  ]] ; then
-  pnpm run build
-  curl --proto '=https' --tlsv1.2 -LsSf https://github.com/PostHog/posthog/releases/download/posthog-cli-v0.0.4/posthog-cli-installer.sh | sh
-  /vercel/.posthog/posthog-cli --host https://us.posthog.com sourcemap inject --directory ./.next/static/chunks
-  /vercel/.posthog/posthog-cli --host https://us.posthog.com sourcemap upload --directory ./.next/static/chunks
-else
-  pnpm run build
-fi
+# Since Next 16.3, Vercel's build adapter relocates the client output into
+# .vercel/output during `next build`, so post-build steps no longer find
+# ./.next/static — sourcemap upload has to happen inside the build instead.
+pnpm run build


### PR DESCRIPTION
## Summary

Production deploys have been red since the Next.js 16.3 upgrade (#431). `next build` succeeds — the failure is the PostHog sourcemap step in `vercel.sh`:

```
Running onBuildComplete from Vercel
ERROR posthog_cli: msg="Oops! Directory './.next/static/chunks' not found or inaccessible"
Error: Command "sh vercel.sh" exited with 1
```

Comparing build logs of the last green production deploy against the failing ones:

| Deploy | Next | `.next/static/chunks` after build |
| --- | --- | --- |
| last green | 16.2.10 (Turbopack) | present — posthog-cli processed 145 chunks |
| current | 16.3.0 (Turbopack) | **gone** — `No such file or directory` |

Vercel builds Next 16 through the build-adapter API (`Applying modifyConfig from Vercel`, `Running onBuildComplete from Vercel`). As of 16.3 the adapter relocates the client output into `.vercel/output` as part of `next build`, so any shell step running *after* `pnpm run build` no longer sees `.next/static`. There's no adapter locally, which is why this only breaks on Vercel.

Sourcemap upload has to happen *inside* the build, so the post-build shell step goes away. Note it was already half-broken: even on the green build, posthog-cli logged `No sourcemap file found for file …js` on most chunks under Turbopack.

Error tracking moves to Sentry (its upload runs inside `next build`) in a follow-up PR — that one also removes PostHog entirely. Until it lands, PostHog error tracking keeps working, just with minified stack traces.

## Changes

- `vercel.sh`: remove the posthog-cli install/inject/upload block; the `$VERCEL_ENV == production` branch collapses to a single `pnpm run build`. Sanity manifest/schema steps untouched.

## Checklist

- [x] `bash -n vercel.sh` passes (no JS/TS touched, so `pnpm lint` is unaffected)
- [ ] Preview build log shows `sh vercel.sh` exiting 0 with no `posthog-cli` lines
- [x] No breaking changes