### PR TITLE
feat(analytics): track entries into machine mode

### DIFF
--- a/src/components/layout/mode-toggle.tsx
+++ b/src/components/layout/mode-toggle.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { track } from "@vercel/analytics"
 import { usePathname } from "next/navigation"
 import { useEffect, useState } from "react"
 
@@ -83,6 +84,12 @@ export const ModeToggle = ({ mode }: { mode: "human" | "machine" }) => {
   }, [fadeEnabled])
 
   const rememberMachineEntry = () => {
+    // Only fires from the human tree, where <Analytics /> is mounted — the
+    // machine view deliberately loads no analytics, so the reverse direction
+    // and machine pageviews stay invisible. The beacon uses `keepalive`, so it
+    // survives the full-document navigation this anchor triggers.
+    track("machine_mode_entered", { from: pathname || "/" })
+
     try {
       sessionStorage.setItem(MACHINE_ENTRY_KEY, machineHref)
     } catch {


### PR DESCRIPTION
## Summary

Machine mode is currently invisible to Vercel Analytics. `<Analytics />` is mounted in `src/app/(site)/layout.tsx`, and `/ai` is deliberately mounted *outside* that tree — its layout comment is explicit that the machine view "must not load the navbar, WebGL canvas, or analytics providers". So there are no `/ai` pageviews at all.

This records the one thing that *is* measurable client-side: a human clicking **Machine** from the human site, where the analytics script is already loaded. The originating path rides along as a property.

Verified the beacon survives the navigation — the toggle is a full document navigation by design, and the live `/_vercel/insights/script.js` sends events with `fetch(..., { keepalive: true })`.

## What this does not cover

- **The reverse direction.** Clicking **Human** happens on `/ai`, where `window.va` doesn't exist, so `track()` is a silent no-op there.
- **`/ai/*` pageviews and `.md` hits.** The `.md` URLs are proxy-rewritten to `/api/*.md` route handlers that return plain markdown — no HTML, no script tag, so client-side analytics can never see them.
- **Agent traffic, which is the actual audience for machine mode.** The Vercel script self-disables on `navigator.webdriver` and `Headless` user agents, and LLM crawlers don't execute JS at all.

Measuring that traffic needs server-side instrumentation (`track` from `@vercel/analytics/server`, or just Vercel Observability's per-route request counts). Worth noting the `.md` handlers are prerendered (`○ /api/index.md`, 1y), so a server-side `track()` inside them would fire once at build rather than per request — it would mean making them dynamic and giving up that caching. Left out of this PR deliberately.

## Changes

- `src/components/layout/mode-toggle.tsx`: `track("machine_mode_entered", { from: pathname })` in `rememberMachineEntry`.

## Checklist

- [x] `pnpm build` passes
- [x] Prettier + TypeScript clean on the touched file
- [ ] Event shows up in Vercel Analytics from a preview