### PR TITLE
feat: brand X (Twitter) as 𝕏 in the footer and people roster

### DIFF
--- a/src/app/(site)/(canvas)/(content)/people/crew.tsx
+++ b/src/app/(site)/(canvas)/(content)/people/crew.tsx
@@ -17,6 +17,7 @@ import { Placeholder } from "@/components/primitives/placeholder"
 import useDebounceValue from "@/hooks/use-debounce-value"
 import { useMedia } from "@/hooks/use-media"
 import { cn } from "@/utils/cn"
+import { displayPlatform, platformAriaLabel } from "@/utils/social-platform"
 
 import type { PersonDisplay } from "./sanity"
 
@@ -152,9 +153,12 @@ export const Crew = ({ data }: { data: PersonDisplay[] }) => {
                             href={socialNetwork.url}
                             target="_blank"
                             className="bg-brand-0"
+                            aria-label={platformAriaLabel(
+                              socialNetwork.platform
+                            )}
                           >
-                            <span className="actionable">
-                              {socialNetwork.platform}
+                            <span className="actionable" aria-hidden>
+                              {displayPlatform(socialNetwork.platform)}
                             </span>
                           </Link>
                           {index < person.socialNetworks.length - 1 && (

--- a/src/app/ai/components.tsx
+++ b/src/app/ai/components.tsx
@@ -19,6 +19,14 @@ export const Section = ({
   </section>
 )
 
+const FIELD_WIDTH = 15
+
+// padEnd() counts UTF-16 units, so an astral glyph (𝕏 is U+1D54F, a surrogate
+// pair) would eat two columns' worth of dots while occupying one — count code
+// points instead so the leaders stay aligned.
+const dotLeader = (label: string) =>
+  `${label} ` + ".".repeat(Math.max(0, FIELD_WIDTH - [...label].length - 1))
+
 /** `label ....... value` key-value row; mono font keeps the dots aligned. */
 export const Field = ({
   label,
@@ -29,7 +37,7 @@ export const Field = ({
 }) => (
   <div className="flex">
     <dt className="shrink-0 whitespace-pre text-machine-dim">
-      {`${label} `.padEnd(15, ".")}{" "}
+      {dotLeader(label)}{" "}
     </dt>
     {/* min-w-0 + anywhere wrapping: unbroken values (URLs) must not push the
         page wider than the viewport on small screens. */}

--- a/src/app/ai/page.tsx
+++ b/src/app/ai/page.tsx
@@ -82,7 +82,7 @@ const AiPage = async () => {
   const venture = servicesPage?.ventures?.[0] ?? null
 
   const socialLinks = [
-    { label: "x-twitter", url: companyInfo.twitter },
+    { label: "𝕏", url: companyInfo.twitter },
     { label: "instagram", url: companyInfo.instagram },
     { label: "github", url: companyInfo.github },
     { label: "linkedin", url: companyInfo.linkedIn }

--- a/src/app/api/people.md/route.ts
+++ b/src/app/api/people.md/route.ts
@@ -7,6 +7,7 @@ import {
 } from "@/app/(site)/(canvas)/(content)/people/sanity"
 import { SITE_URL } from "@/lib/constants"
 import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
+import { displayPlatform } from "@/utils/social-platform"
 
 const MD_HEADERS = {
   "Content-Type": "text/markdown; charset=utf-8",
@@ -22,10 +23,6 @@ const CREW_DEPARTMENTS = ["Management", "Design", "Development"]
 const escapeLinkLabel = (text: string) => text.replace(/[\\[\]]/g, "\\$&")
 const escapeLinkUrl = (url: string) =>
   url.replace(/\(/g, "%28").replace(/\)/g, "%29")
-
-// The CMS platform field still says "Twitter"; the site brands it 𝕏.
-const displayPlatform = (platform: string) =>
-  /twitter|^x$/i.test(platform) ? "𝕏" : platform
 
 export async function GET() {
   try {

--- a/src/components/layout/shared-sections.tsx
+++ b/src/components/layout/shared-sections.tsx
@@ -145,8 +145,16 @@ export const SocialLinks = ({ className, links }: SocialLinksProps) => (
       className
     )}
   >
-    <Link className="h-max text-brand-w1" href={links.twitter} target="_blank">
-      <span className="actionable">X (Twitter)</span>
+    <Link
+      className="h-max text-brand-w1"
+      href={links.twitter}
+      target="_blank"
+      aria-label="X (Twitter)"
+    >
+      {/* U+1D54F — screen readers skip it, hence the aria-label above. */}
+      <span className="actionable" aria-hidden>
+        𝕏
+      </span>
     </Link>
     <span aria-hidden>,</span>
     <Link

--- a/src/components/primitives/link.tsx
+++ b/src/components/primitives/link.tsx
@@ -22,6 +22,8 @@ interface LinkProps {
   onFocus?: () => void
   onBlur?: () => void
   fromMobileNav?: boolean
+  /** For links whose visible text is a glyph a screen reader can't announce. */
+  "aria-label"?: string
 }
 
 export const Link = ({

--- a/src/utils/social-platform.ts
+++ b/src/utils/social-platform.ts
@@ -1,0 +1,10 @@
+// The CMS platform field still says "Twitter"; the site brands it 𝕏.
+const X_GLYPH = "𝕏"
+
+export const displayPlatform = (platform: string) =>
+  /twitter|^x$/i.test(platform) ? X_GLYPH : platform
+
+// 𝕏 is U+1D54F, which screen readers skip — HTML callers hide the glyph and
+// expose this instead.
+export const platformAriaLabel = (platform: string) =>
+  displayPlatform(platform) === X_GLYPH ? "X (Twitter)" : platform


### PR DESCRIPTION
Swaps the `X (Twitter)` text label for the 𝕏 glyph.

### What changed

- **`components/layout/shared-sections.tsx`** — the `SocialLinks` component now renders 𝕏. This component is shared, so the change lands in the **footer**, the **navbar menu**, and the **contact page footer**.
- **`people/crew.tsx`** — the per-person social links in the roster map the CMS platform through the same helper. Instagram/GitHub/etc. pass through untouched.
- **`utils/social-platform.ts`** (new) — `displayPlatform()` maps `/twitter|^x$/i` to 𝕏; `platformAriaLabel()` returns the readable name for it.
- **`api/people.md/route.ts`** — drops its private copy of `displayPlatform` and imports the shared one. No behavior change here (the markdown/AI view already showed 𝕏); it just means the HTML roster and the markdown view can't drift apart.

### Notes

- Display-only. The CMS still stores `"Twitter"`, and `structured-data/schemas/person.ts` still emits the raw profile URL in `sameAs`, which is what schema.org wants.
- 𝕏 is U+1D54F (mathematical double-struck capital X) — screen readers skip or mangle it, so the glyph is `aria-hidden` and the link carries an `aria-label` with the readable name.
- **Worth eyeballing on preview:** most UI fonts don't ship U+1D54F, so the browser may fall back to another font and render it at a slightly different weight or size than the neighboring labels.
- The contact *screen* overlay (`contact-screen.tsx:261`) still hardcodes "X (Twitter)" — separate block, left alone. Happy to fold it in.

### Testing

None run — `node_modules` isn't installed in this workspace, so no build, typecheck, lint, or visual check. Needs a preview-deploy look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)