### PR TITLE
feat(botid): add Vercel BotID to the four public forms (observe mode)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,5 @@
 import { withSentryConfig } from "@sentry/nextjs"
+import { withBotId } from "botid/next/config"
 import type { NextConfig } from "next"
 import { sanity } from "next-sanity/live/cache-life"
 
@@ -192,7 +193,7 @@ if (process.env.VERCEL_ENV === "production" && !canPublishSentryArtifacts) {
   )
 }
 
-export default withSentryConfig(nextConfig, {
+export default withSentryConfig(withBotId(nextConfig), {
   org: "basementstudio-be",
   project: "website-2k25",
   silent: !process.env.VERCEL,

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@vercel/analytics": "^1.5.0",
     "@vercel/functions": "^2.0.0",
     "@vercel/speed-insights": "^1.2.0",
+    "botid": "^1.5.11",
     "clsx": "^2.1.1",
     "emulators": "^8.3.9",
     "isbot": "^5.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@vercel/speed-insights':
         specifier: ^1.2.0
         version: 1.2.0(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      botid:
+        specifier: ^1.5.11
+        version: 1.5.11(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -5303,6 +5306,17 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  botid@1.5.11:
+    resolution: {integrity: sha512-KOO1A3+/vFVJk5aFoG3sNwiogKFPVR+x4aw4gQ1b2e0XoE+i5xp48/EZn+WqR07jRHeDGwHWQUOtV5WVm7xiww==}
+    peerDependencies:
+      next: '*'
+      react: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      next:
+        optional: true
+      react:
+        optional: true
 
   boxen@5.1.2:
     resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
@@ -15554,6 +15568,11 @@ snapshots:
   binary-extensions@2.3.0: {}
 
   boolbase@1.0.0: {}
+
+  botid@1.5.11(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
+    optionalDependencies:
+      next: 16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
 
   boxen@5.1.2:
     dependencies:

--- a/src/actions/career-application/index.ts
+++ b/src/actions/career-application/index.ts
@@ -1,8 +1,10 @@
 "use server"
 
 import * as Sentry from "@sentry/nextjs"
+import { checkBotId } from "botid/server"
 import { headers } from "next/headers"
 
+import { reportBotDetection } from "@/lib/botid"
 import {
   buildApplicationData,
   type CareerApplication,
@@ -112,6 +114,12 @@ async function runCareerApplication(formData: CareerFormData) {
     if (isRateLimited(clientIdentifier, now)) {
       console.error("Career application rate limited:", clientIdentifier)
       return { success: false, error: GENERIC_SUBMISSION_ERROR }
+    }
+
+    const { isBot } = await checkBotId()
+
+    if (isBot) {
+      await reportBotDetection("careers")
     }
 
     const applicationData = buildApplicationData(formData)

--- a/src/actions/contact-form/index.ts
+++ b/src/actions/contact-form/index.ts
@@ -1,6 +1,9 @@
 "use server"
 
 import * as Sentry from "@sentry/nextjs"
+import { checkBotId } from "botid/server"
+
+import { reportBotDetection } from "@/lib/botid"
 
 import { generateEmailTemplate } from "./template"
 
@@ -20,7 +23,16 @@ export async function submitContactForm(formData: ContactFormData) {
 
 async function runContactForm(formData: ContactFormData) {
   try {
+    const { isBot } = await checkBotId()
+
+    if (isBot) {
+      await reportBotDetection("contact")
+    }
+
     const html = generateEmailTemplate(formData)
+
+    // Flagged, not dropped: enforcement comes later.
+    const subject = `${isBot ? "[SUSPECTED BOT] " : ""}${formData.name} - ${formData.company} | Contact Us <basement.studio>`
 
     const resendRes = await fetch("https://api.resend.com/emails", {
       method: "POST",
@@ -31,7 +43,7 @@ async function runContactForm(formData: ContactFormData) {
       body: JSON.stringify({
         from: "hello@basement.studio",
         to: ["sales@basement.studio"],
-        subject: `${formData.name} - ${formData.company} | Contact Us <basement.studio>`,
+        subject,
         html
       })
     })

--- a/src/app/(site)/actions/subscribe.ts
+++ b/src/app/(site)/actions/subscribe.ts
@@ -1,6 +1,9 @@
 "use server"
 
 import * as Sentry from "@sentry/nextjs"
+import { checkBotId } from "botid/server"
+
+import { reportBotDetection } from "@/lib/botid"
 
 // The "General" audience segment in the Resend dashboard.
 const NEWSLETTER_SEGMENT_ID = "67cdd754-44a1-492e-8ed3-47dbdac70398"
@@ -25,6 +28,12 @@ async function runSubscribe(formData: FormData): Promise<State> {
 
     if (!email) {
       throw new Error("Email is Required")
+    }
+
+    const { isBot } = await checkBotId()
+
+    if (isBot) {
+      await reportBotDetection("newsletter")
     }
 
     const resendApiKey = process.env.RESEND_API_KEY

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,6 +1,27 @@
 import * as Sentry from "@sentry/nextjs"
+import { initBotId } from "botid/client/core"
 
 import { resolveTracesSampleRate } from "@/lib/sentry-sampling"
+
+// Every `(site)` route: the contact overlay is in its layout and actions POST to the
+// invoking page. Unlisted paths fail closed; a catch-all would break /studio/* POSTs.
+initBotId({
+  protect: [
+    { path: "/", method: "POST" },
+    { path: "/blog", method: "POST" },
+    { path: "/blog/*", method: "POST" },
+    { path: "/people", method: "POST" },
+    { path: "/services", method: "POST" },
+    { path: "/showcase", method: "POST" },
+    { path: "/showcase/*", method: "POST" },
+    { path: "/post/*", method: "POST" },
+    { path: "/careers/*", method: "POST" },
+    { path: "/contact", method: "POST" },
+    { path: "/basketball", method: "POST" },
+    { path: "/doom", method: "POST" },
+    { path: "/lab", method: "POST" }
+  ]
+})
 
 const environment = process.env.NEXT_PUBLIC_VERCEL_ENV ?? "development"
 

--- a/src/lib/botid.ts
+++ b/src/lib/botid.ts
@@ -1,0 +1,20 @@
+import { track } from "@vercel/analytics/server"
+import { headers } from "next/headers"
+
+type Form = "contact" | "newsletter" | "careers"
+
+// Not Sentry: attacker-triggerable, and error events here are unsampled.
+export async function reportBotDetection(form: Form) {
+  const headerList = await headers()
+
+  // Path only — `beforeSend` doesn't scrub log arguments.
+  console.error("[BotID] bot detected", {
+    form,
+    path: headerList.get("next-url") ?? headerList.get("referer") ?? "unknown"
+  })
+
+  // Telemetry must never fail a submission.
+  await track("botid_detected", { form }, { headers: headerList }).catch(
+    () => {}
+  )
+}


### PR DESCRIPTION
## Summary

Adds [Vercel BotID](https://vercel.com/docs/botid) — an invisible CAPTCHA — to the four public forms. The contact form has no validation today and emails `sales@basement.studio` on every submit.

**Nothing is blocked here.** The actions call `checkBotId()`, report the verdict, then proceed as before. Suspected bots still reach Resend and Notion; their contact emails arrive prefixed `[SUSPECTED BOT]` so `sales@` can judge accuracy first. Enforcement is a follow-up PR, once there's data.

Observe-first because BotID **fails closed**: a route missing from the client `protect` list gets no challenge headers, so a real visitor reads as a bot — on a lead form, a silently lost lead.

## Changes

- `botid@^1.5.11`; `withSentryConfig(withBotId(nextConfig), …)`
- `initBotId()` lists all 13 `(site)` routes, not just `/contact` — the contact overlay is mounted in `(site)/layout.tsx` and a server action POSTs to whatever page invoked it
- `checkBotId()` in the three actions, after the honeypot/rate-limit so free checks short-circuit first
- `src/lib/botid.ts` reports via `console.error` + `track("botid_detected")`, not Sentry — attacker-triggerable and no `sampleRate` is set, so `captureMessage` would be unbounded under the very flood it reports on
- Deep Analysis off; no `checkLevel` set, so it stays a dashboard toggle

## Checklist

- [x] `pnpm lint` passes
- [x] Tested locally in dev mode
- [x] No breaking changes — no action returns anything different than today
