### PR TITLE
fix: settle audio load promises on network failure

### DIFF
--- a/src/hooks/use-site-audio.ts
+++ b/src/hooks/use-site-audio.ts
@@ -236,10 +236,10 @@ export const SiteAudioSFXsLoader = memo((): null => {
       const newSources = {} as Record<SiteAudioSFXKey, AudioSource>
 
       try {
-        const promises = []
+        const promises: Promise<void>[] = []
 
         promises.push(
-          Object.keys(GAME_AUDIO_SFX).map(async (key) => {
+          ...Object.keys(GAME_AUDIO_SFX).map(async (key) => {
             const audioKey = key as SiteAudioSFXKey
             const source = await player.loadAudioFromURL(
               GAME_AUDIO_SFX[audioKey as keyof typeof GAME_AUDIO_SFX],
@@ -251,7 +251,7 @@ export const SiteAudioSFXsLoader = memo((): null => {
         )
 
         promises.push(
-          ARCADE_AUDIO_SFX.BUTTONS.map(async (button, index) => {
+          ...ARCADE_AUDIO_SFX.BUTTONS.map(async (button, index) => {
             const source = await player.loadAudioFromURL(button.PRESS, true)
             source.setVolume(SFX_VOLUME)
             newSources[`ARCADE_BUTTON_${index}_PRESS`] = source
@@ -265,7 +265,7 @@ export const SiteAudioSFXsLoader = memo((): null => {
         )
 
         promises.push(
-          ARCADE_AUDIO_SFX.STICKS.map(async (stick, index) => {
+          ...ARCADE_AUDIO_SFX.STICKS.map(async (stick, index) => {
             const source = await player.loadAudioFromURL(stick.PRESS, true)
             source.setVolume(SFX_VOLUME)
             newSources[`ARCADE_STICK_${index}_PRESS`] = source
@@ -279,7 +279,7 @@ export const SiteAudioSFXsLoader = memo((): null => {
         )
 
         promises.push(
-          BLOG_AUDIO_SFX.LOCKED_DOOR.map(async (lockedDoor, index) => {
+          ...BLOG_AUDIO_SFX.LOCKED_DOOR.map(async (lockedDoor, index) => {
             const source = await player.loadAudioFromURL(lockedDoor, true)
             source.setVolume(SFX_VOLUME)
             newSources[`BLOG_LOCKED_DOOR_${index}`] = source
@@ -287,7 +287,7 @@ export const SiteAudioSFXsLoader = memo((): null => {
         )
 
         promises.push(
-          BLOG_AUDIO_SFX.DOOR.map(async (door, index) => {
+          ...BLOG_AUDIO_SFX.DOOR.map(async (door, index) => {
             const source = await player.loadAudioFromURL(door.OPEN, true)
             source.setVolume(SFX_VOLUME)
             newSources[`BLOG_DOOR_${index}_OPEN`] = source
@@ -298,7 +298,7 @@ export const SiteAudioSFXsLoader = memo((): null => {
         )
 
         promises.push(
-          BLOG_AUDIO_SFX.LAMP.map(async (lamp, index) => {
+          ...BLOG_AUDIO_SFX.LAMP.map(async (lamp, index) => {
             const source = await player.loadAudioFromURL(lamp.PULL, true)
             source.setVolume(SFX_VOLUME)
             newSources[`BLOG_LAMP_${index}_PULL`] = source
@@ -344,7 +344,16 @@ export const SiteAudioSFXsLoader = memo((): null => {
           })()
         )
 
-        await Promise.all(promises)
+        // one flaky fetch shouldn't discard every SFX that loaded
+        const results = await Promise.allSettled(promises)
+
+        const failed = results.filter((r) => r.status === "rejected")
+        if (failed.length) {
+          console.error(
+            `Failed to load ${failed.length}/${results.length} audio sources`,
+            failed.map((r) => r.reason)
+          )
+        }
 
         useSiteAudioStore.setState({
           audioSfxSources: newSources

--- a/src/lib/audio/index.ts
+++ b/src/lib/audio/index.ts
@@ -205,7 +205,14 @@ export class WebAudioPlayer {
   ): Promise<AudioSource> {
     return new Promise((resolve, reject) => {
       fetch(url)
-        .then((response) => response.arrayBuffer())
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(
+              `Failed to fetch audio (${response.status}): ${url}`
+            )
+          }
+          return response.arrayBuffer()
+        })
         .then((arrayBuffer) => {
           return this.audioContext.decodeAudioData(
             arrayBuffer,
@@ -236,6 +243,8 @@ export class WebAudioPlayer {
             }
           )
         })
+        // a network failure must reject, or awaiters hang forever
+        .catch(reject)
     })
   }
 


### PR DESCRIPTION
## Summary

Fixes [WEBSITE-2K25-3N](https://basementstudio-be.sentry.io/issues/7671201345/) — `TypeError: Load failed`, 50 occurrences on iOS Safari, reported via `onunhandledrejection`.

The error is Safari's generic fetch failure (backgrounded tab or flaky connection killing an in-flight audio request). Not actionable on its own — the defect is that it escaped as *unhandled* despite two layers that look like they handle it:

1. **`loadAudioFromURL` never rejected.** No terminal `.catch` on the `fetch` chain inside the `new Promise`, so the returned promise stayed permanently pending and the rejection went straight to the global handler.
2. **`SiteAudioSFXsLoader`'s `try/catch` was inert.** Six `promises.push()` calls pushed an *array* of promises, which `Promise.all` treats as an already-resolved value — so those promises were never awaited and their rejections bypassed the `try/catch`.

## Changes

- Add `.catch(reject)` to `loadAudioFromURL` so callers' existing `try/catch` blocks actually receive the rejection.
- Check `response.ok` — a 404/5xx previously fed an HTML error body into `decodeAudioData`.
- Spread the six array pushes (`...X.map(...)`) so they're awaited and covered by the `try/catch`.
- Type `promises` as `Promise<void>[]` — it was implicitly `any[]`, which is why TS never flagged the array-in-array.
- Use `Promise.allSettled` so one flaky file doesn't discard every SFX that loaded fine.

## Checklist

- [ ] `pnpm lint` passes
- [ ] Tested locally in dev mode
- [ ] No breaking changes (or documented in summary)

### Verification notes

- eslint and `tsc --noEmit` clean on both changed files. Repo-wide `pnpm lint` still reports 182 pre-existing errors in files untouched here, so the box is left unchecked rather than claimed.
- Not exercised in a browser — reproducing needs a throttled or aborted fetch on iOS Safari. Please confirm SFX still load in dev.
