### PR TITLE
fix(observability): report worker load failures once, with a stable title

### DIFF
--- a/src/components/contact/contact-canvas.tsx
+++ b/src/components/contact/contact-canvas.tsx
@@ -5,7 +5,7 @@ import * as Sentry from "@sentry/nextjs"
 import { useEffect, useState } from "react"
 
 import { useAssets } from "@/components/assets-provider"
-import { workerErrorFromMessage, workerEventError } from "@/lib/worker-error"
+import { workerErrorFromMessage, workerErrorReport } from "@/lib/worker-error"
 
 import { ContactScreen } from "./contact-screen"
 import { useContactStore } from "./contact-store"
@@ -149,8 +149,13 @@ export const ContactCanvas = () => {
 
     const handleError = (event: Event) => {
       console.error("[ContactCanvas] Worker error:", event)
-      Sentry.captureException(workerEventError(event, "contact"), {
-        tags: { worker: "contact" }
+      // Uncanceled, it reaches window.onerror and Sentry files a second copy.
+      event.preventDefault()
+
+      const { error, detail } = workerErrorReport(event, "contact")
+      Sentry.captureException(error, {
+        tags: { worker: "contact" },
+        ...(detail ? { extra: { detail } } : {})
       })
     }
 

--- a/src/components/loading/loading-canvas.tsx
+++ b/src/components/loading/loading-canvas.tsx
@@ -6,7 +6,7 @@ import { Vector3 } from "three"
 
 import { useAssets } from "@/components/assets-provider"
 import { useCurrentScene } from "@/hooks/use-current-scene"
-import { workerErrorFromMessage, workerEventError } from "@/lib/worker-error"
+import { workerErrorFromMessage, workerErrorReport } from "@/lib/worker-error"
 import { cn } from "@/utils/cn"
 
 import { useNavigationStore } from "../navigation-handler/navigation-store"
@@ -87,9 +87,18 @@ function LoadingCanvas({ hide }: { hide: boolean }) {
 
     const handleError = (event: Event) => {
       console.error("[LoadingCanvas] Worker error:", event)
-      Sentry.captureException(workerEventError(event, "loading"), {
-        tags: { worker: "loading" }
+      // Uncanceled, it reaches window.onerror and Sentry files a second copy.
+      event.preventDefault()
+
+      const { error, detail } = workerErrorReport(event, "loading")
+      Sentry.captureException(error, {
+        tags: { worker: "loading" },
+        ...(detail ? { extra: { detail } } : {})
       })
+
+      // `loading-transition-complete` can no longer arrive, so the black
+      // overlay would sit there until the boot timeout.
+      useAppLoadingStore.setState({ showLoadingCanvas: false })
     }
 
     worker.addEventListener("error", handleError)

--- a/src/lib/worker-error.ts
+++ b/src/lib/worker-error.ts
@@ -14,14 +14,27 @@ export function postWorkerError(error: unknown) {
   self.postMessage({ type: WORKER_ERROR, name, message, stack })
 }
 
-/** A failed script fetch fires a plain `Event` — no `error`, no `message`. */
-export function workerEventError(event: Event, name: string): Error {
-  if (event instanceof ErrorEvent) {
-    if (event.error instanceof Error) return event.error
-    if (event.message) return new Error(event.message)
+export interface WorkerErrorReport {
+  error: Error
+  detail?: string
+}
+
+/**
+ * A failed script fetch reports the chunk hash, which turns over on every
+ * deploy — keeping it out of the title keeps it in one Sentry issue.
+ */
+export function workerErrorReport(
+  event: Event,
+  name: string
+): WorkerErrorReport {
+  if (event instanceof ErrorEvent && event.error instanceof Error) {
+    return { error: event.error }
   }
 
-  return new Error(`${name} worker failed to load`)
+  return {
+    error: new Error(`${name} worker failed to load`),
+    detail: event instanceof ErrorEvent ? event.message : undefined
+  }
 }
 
 /** Rebuilds the worker's error on the main thread, keeping its stack. */


### PR DESCRIPTION
## Summary

Worker load failures reach Sentry twice, under a title that changes on every deploy.

An uncanceled `error` event on a `Worker` propagates to `window.onerror`, so each failure lands as our handled capture *and* as an unhandled `Uncaught NetworkError` — [3J](https://basementstudio-be.sentry.io/issues/WEBSITE-2K25-3J) and [3B](https://basementstudio-be.sentry.io/issues/WEBSITE-2K25-3B) are the same failure. The message embeds the chunk hash, so every deploy opens a fresh issue.

The failure itself is client-side: both chunks return 200 on the current deployment, and the affected session is a mobile user on a bad connection.

## Changes

- `worker-error.ts` — `workerEventError` → `workerErrorReport`, returning `{ error, detail }`. A real `ErrorEvent.error` passes through untouched; load failures get the stable title `"<name> worker failed to load"` with the chunk-specific message in `detail`.
- `loading-canvas.tsx` / `contact-canvas.tsx` — `event.preventDefault()` so Sentry files one handled, tagged copy; `detail` goes to `extra`.
- `loading-canvas.tsx` — clear `showLoadingCanvas` when the worker dies, instead of holding a black overlay for the full 20s boot timeout.

## Checklist

- [x] `pnpm lint` passes
- [ ] Tested locally in dev mode — reporting-path only; needs a blocked worker chunk fetch to exercise
- [x] No breaking changes

Fixes WEBSITE-2K25-3B
