### PR TITLE
fix(camera): stop infinite update loop from per-frame store writes

### DIFF
--- a/src/components/navigation-handler/navigation-store.ts
+++ b/src/components/navigation-handler/navigation-store.ts
@@ -59,8 +59,14 @@ export const useNavigationStore = create<{
     set({ disableCameraTransition: disable }),
 
   isCameraTransitioning: false,
+  // called every frame from the camera useFrame loop, so bail when unchanged —
+  // an unconditional set() notifies every subscriber and floods React with updates
   setIsCameraTransitioning: (isTransitioning) =>
-    set({ isCameraTransitioning: isTransitioning }),
+    set((state) =>
+      state.isCameraTransitioning === isTransitioning
+        ? state
+        : { isCameraTransitioning: isTransitioning }
+    ),
 
   enteredByKeyboard: false,
   setEnteredByKeyboard: (value) => set({ enteredByKeyboard: value }),

--- a/src/hooks/use-current-scene.ts
+++ b/src/hooks/use-current-scene.ts
@@ -10,7 +10,7 @@ export const useCurrentScene = () => {
   useSelectStore(
     useNavigationStore,
     (state) => state.currentScene?.name || "",
-    (state, prevState) => state !== prevState,
+    (state, prevState) => state === prevState,
     (state) => setCurrentSceneName(state)
   )
 


### PR DESCRIPTION
## Summary

Fixes Sentry [WEBSITE-2K25-3T](https://basementstudio-be.sentry.io/issues/7671467364/) — *Maximum update depth exceeded* (React error #185), 27 events in production. Two bugs compounded: `setIsCameraTransitioning` is called every frame from the camera `useFrame` loop but passed a fresh object literal to `set()`, so zustand's `Object.is` guard never tripped and every subscriber was notified on every frame; meanwhile `useCurrentScene` passed an inverted comparator to `useSelectStore`, so all 19 consumers called `setState` on every unrelated store write instead of on actual scene changes. React blew past its nested update limit.

## Changes

- `setIsCameraTransitioning` returns the existing state object when the value is unchanged, matching the `setIsNotFound` pattern in the same store
- Flip `useCurrentScene`'s comparator to `===` — `useSelectStore` fires its callback on `!comparison(...)`, so the arg is an *isEqual* predicate (as used correctly in `inspectable.tsx`)

## Checklist

- [ ] `pnpm lint` passes
- [ ] Tested locally in dev mode
- [ ] No breaking changes (or documented in summary)

> [!NOTE]
> Unverified — `node_modules` wasn't installed in this workspace, so neither lint nor the app were run. Both changes affect scene-transition behavior: `useCurrentScene` now updates on the actual scene change rather than lagging until an incidental store write, so the 3D scene transitions are worth a click-through before merging.
>
> Follow-up worth considering: `disableCameraTransition` is read via `getState()` at `camera-hooks.tsx:140` rather than subscribed, so the `useFrame` closure holds a stale `true`. That's why the loop sustains instead of firing once. Left out of this PR to keep it minimal.
