### PR TITLE
perf: fix mobile Web Vitals (CLS, INP, FID)

### DIFF
--- a/src/app/(site)/(canvas)/(content)/showcase/derive-categories.ts
+++ b/src/app/(site)/(canvas)/(content)/showcase/derive-categories.ts
@@ -1,0 +1,29 @@
+import type { ShowcaseProject } from "./sanity"
+
+export type CategoryItem = {
+  name: string
+  count: number
+}
+
+// Shared by the client list and the prerendered fallback — the two must derive
+// the same categories in the same order or hydration shifts the filters bar.
+export const deriveCategories = (
+  projects: ShowcaseProject[]
+): CategoryItem[] => {
+  const categoryMap = new Map<string, number>()
+
+  projects.forEach((project) => {
+    project?.categories?.forEach((category) => {
+      if (category?.title) {
+        categoryMap.set(
+          category.title,
+          (categoryMap.get(category.title) || 0) + 1
+        )
+      }
+    })
+  })
+
+  return Array.from(categoryMap.entries())
+    .map(([name, count]): CategoryItem => ({ name, count }))
+    .sort((a, b) => b.count - a.count)
+}

--- a/src/app/(site)/(canvas)/(content)/showcase/filters.tsx
+++ b/src/app/(site)/(canvas)/(content)/showcase/filters.tsx
@@ -3,7 +3,7 @@ import { memo, useCallback } from "react"
 
 import { cn } from "@/utils/cn"
 
-import { CategoryItem } from "./showcase-list/client"
+import type { CategoryItem } from "./derive-categories"
 
 const GridIcon = () => (
   <svg
@@ -62,6 +62,9 @@ const ViewSelector = memo(
 )
 ViewSelector.displayName = "ViewSelector"
 
+// A static copy of this markup lives in ./showcase-list/fallback.tsx (the
+// prerendered HTML under cacheComponents). If you change layout-affecting
+// classes here, mirror them there or hydration shifts the page.
 interface FiltersProps {
   categories: CategoryItem[]
   selectedCategory: string | null

--- a/src/app/(site)/(canvas)/(content)/showcase/grid.tsx
+++ b/src/app/(site)/(canvas)/(content)/showcase/grid.tsx
@@ -2,14 +2,12 @@ import { memo } from "react"
 
 import type { ImageFragment } from "@/components/primitives/image-with-video-overlay"
 import { ImageWithVideoOverlay } from "@/components/primitives/image-with-video-overlay"
-import { InfoItem } from "@/components/primitives/info-item"
 import { Link } from "@/components/primitives/link"
-import { TextList } from "@/components/primitives/text-list"
-import { useMedia } from "@/hooks/use-media"
 import { resolveVideoSource } from "@/lib/video/resolve-source"
 import type { SanityImage } from "@/service/sanity/types"
 import { cn } from "@/utils/cn"
 
+import { MobileInfo } from "./mobile-info"
 import type { ShowcaseProject } from "./sanity"
 
 /** Convert a SanityImage to the ImageFragment shape used by ImageWithVideoOverlay. */
@@ -24,37 +22,12 @@ function toImageFragment(img: SanityImage | null): ImageFragment | null {
   }
 }
 
-const MobileInfo = memo(({ project }: { project: ShowcaseProject }) => {
-  return (
-    <div className="col-span-full flex flex-col divide-y divide-brand-w1/20 lg:hidden">
-      <InfoItem label="Client" value={project.client?.title} />
-      <InfoItem
-        label="Type"
-        value={
-          <TextList
-            value={
-              project.categories?.map((cat) => (
-                <span key={cat.title}>{cat.title}</span>
-              )) || []
-            }
-            className="text-f-p-mobile lg:text-f-p"
-          />
-        }
-      />
-      <div />
-    </div>
-  )
-})
-MobileInfo.displayName = "MobileInfo"
-
 interface GridProps {
   projects: ShowcaseProject[]
   isProjectDisabled: (project: ShowcaseProject) => boolean
 }
 
 export const Grid = memo(({ projects, isProjectDisabled }: GridProps) => {
-  const isMobile = useMedia("(max-width: 1024px)")
-
   return (
     <div className="grid-layout contain-layout !gap-y-8 lg:!gap-y-3">
       {projects.map((item, index) => {
@@ -95,7 +68,7 @@ export const Grid = memo(({ projects, isProjectDisabled }: GridProps) => {
               </Link>
             </div>
 
-            {isMobile && <MobileInfo project={item} />}
+            <MobileInfo project={item} />
           </article>
         )
       })}

--- a/src/app/(site)/(canvas)/(content)/showcase/mobile-info.tsx
+++ b/src/app/(site)/(canvas)/(content)/showcase/mobile-info.tsx
@@ -1,0 +1,29 @@
+import { InfoItem } from "@/components/primitives/info-item"
+import { TextList } from "@/components/primitives/text-list"
+
+import type { ShowcaseProject } from "./sanity"
+
+// Rendered by both the interactive grid and the prerendered fallback. It must
+// be in the server HTML unconditionally (hidden on desktop via lg:hidden) —
+// inserting it after hydration grew every card ~50px and registered as CLS.
+export const MobileInfo = ({ project }: { project: ShowcaseProject }) => {
+  return (
+    <div className="col-span-full flex flex-col divide-y divide-brand-w1/20 lg:hidden">
+      <InfoItem label="Client" value={project.client?.title} />
+      <InfoItem
+        label="Type"
+        value={
+          <TextList
+            value={
+              project.categories?.map((cat) => (
+                <span key={cat.title}>{cat.title}</span>
+              )) || []
+            }
+            className="text-f-p-mobile lg:text-f-p"
+          />
+        }
+      />
+      <div />
+    </div>
+  )
+}

--- a/src/app/(site)/(canvas)/(content)/showcase/showcase-list/client.tsx
+++ b/src/app/(site)/(canvas)/(content)/showcase/showcase-list/client.tsx
@@ -3,16 +3,12 @@
 import { useSearchParams } from "next/navigation"
 import { memo, useCallback, useEffect, useMemo, useState } from "react"
 
+import { deriveCategories } from "@/app/(site)/(canvas)/(content)/showcase/derive-categories"
 import { Filters } from "@/app/(site)/(canvas)/(content)/showcase/filters"
 import { Grid } from "@/app/(site)/(canvas)/(content)/showcase/grid"
 import { List } from "@/app/(site)/(canvas)/(content)/showcase/list"
 import type { ShowcaseProject } from "@/app/(site)/(canvas)/(content)/showcase/sanity"
 import { useMedia } from "@/hooks/use-media"
-
-export type CategoryItem = {
-  name: string
-  count: number
-}
 
 const ViewModeSelector = memo(
   ({
@@ -75,29 +71,7 @@ export const ShowcaseListClient = memo<ShowcaseListClientProps>(
       [selectedCategory]
     )
 
-    const categories = useMemo(() => {
-      const categoryMap = new Map<string, number>()
-
-      projects.forEach((project) => {
-        project?.categories?.forEach((category) => {
-          if (category?.title) {
-            categoryMap.set(
-              category.title,
-              (categoryMap.get(category.title) || 0) + 1
-            )
-          }
-        })
-      })
-
-      return Array.from(categoryMap.entries())
-        .map(
-          ([name, count]): CategoryItem => ({
-            name,
-            count
-          })
-        )
-        .sort((a, b) => b.count - a.count)
-    }, [projects])
+    const categories = useMemo(() => deriveCategories(projects), [projects])
 
     const filteredProjects = useMemo(() => {
       return selectedCategory === null

--- a/src/app/(site)/(canvas)/(content)/showcase/showcase-list/fallback.tsx
+++ b/src/app/(site)/(canvas)/(content)/showcase/showcase-list/fallback.tsx
@@ -1,50 +1,115 @@
 import Image from "next/image"
 
+import { deriveCategories } from "../derive-categories"
+import { MobileInfo } from "../mobile-info"
 import type { ShowcaseProject } from "../sanity"
 
 /**
  * Server-rendered fallback for the interactive showcase list. The client list
- * bails out of prerendering (`useSearchParams`), which left the prerendered
- * /showcase HTML with zero project anchors — crawlers never saw the portfolio,
- * so most project pages had a single incoming internal link. This mirrors the
- * grid layout with plain links and covers; hydration swaps in the interactive
- * grid.
+ * bails out of prerendering (`useSearchParams`), so this is the HTML crawlers
+ * and first paint get; hydration swaps in the interactive tree. It must stay
+ * structurally identical to `ShowcaseListClient` in its default state (grid
+ * view, no category selected) — any node that only exists after hydration
+ * (the filters bar, MobileInfo) previously pushed content down and registered
+ * as CLS on mobile. Class names below are copied from ../filters.tsx and
+ * ../grid.tsx; keep them in sync.
  */
+
+/** Inert copy of ../filters.tsx in its default state (grid view active). */
+const FiltersFallback = ({ projects }: { projects: ShowcaseProject[] }) => {
+  const categories = deriveCategories(projects)
+
+  return (
+    <div className="grid-layout items-end pb-2">
+      <div className="col-span-1 hidden items-center gap-1 text-f-p text-brand-g1 lg:flex">
+        <span className="h-4 cursor-default text-brand-w1">
+          <span className="!flex items-center justify-center gap-1 underline">
+            <svg
+              fill="currentColor"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 12 12"
+              className="size-3"
+            >
+              <path d="M2 2h5v5H2zM7 7h3v3H7z" />
+            </svg>
+            <span>Grid</span>
+          </span>
+        </span>
+        <span className="text-brand-g1">,</span>
+        <span className="h-4 cursor-pointer text-brand-g1">
+          <span className="actionable actionable-no-underline !flex items-center justify-center gap-1">
+            <svg
+              fill="currentColor"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 12 12"
+              className="size-3"
+            >
+              <path d="M1 4h10v1H1zM1 7h10v1H1z" />
+            </svg>
+            <span>Rows</span>
+          </span>
+        </span>
+      </div>
+
+      <div className="col-span-3 flex flex-col gap-2 lg:col-start-7 lg:col-end-13">
+        <p className="text-f-p-mobile text-brand-g1 lg:text-f-h3">Categories</p>
+
+        <ul className="flex flex-wrap items-center gap-x-4 gap-y-1">
+          {categories.map((category) => (
+            <button
+              key={category.name}
+              className="flex w-max items-center gap-x-1.25 text-left !text-f-h2-mobile text-brand-w1 transition-colors duration-300 lg:!text-f-h2"
+            >
+              <span className="actionable">{category.name}</span>
+            </button>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
 export const ShowcaseListFallback = ({
   projects
 }: {
   projects: ShowcaseProject[]
 }) => (
-  <div className="grid-layout !gap-y-8 lg:!gap-y-3">
-    {projects.map((item) => {
-      const asset = item.cover?.asset
-      return (
-        <article
-          key={item._id}
-          className="relative col-span-full flex flex-col gap-y-2 lg:col-span-3 lg:gap-y-0"
-        >
-          <div className="relative aspect-video max-w-[100%] after:pointer-events-none after:absolute after:inset-0 after:border after:border-brand-w1/20">
-            <a
-              href={`/showcase/${item.slug}`}
-              className="block h-full w-full"
-              aria-label={`View ${item.title ?? "Untitled"}`}
-            >
-              {asset ? (
-                <Image
-                  src={asset.url}
-                  alt={item.cover?.alt ?? item.title ?? ""}
-                  width={asset.metadata.dimensions.width}
-                  height={asset.metadata.dimensions.height}
-                  placeholder={asset.metadata.lqip ? "blur" : undefined}
-                  blurDataURL={asset.metadata.lqip}
-                  sizes="(max-width: 1024px) 100vw, 25vw"
-                  className="h-full w-full object-cover"
-                />
-              ) : null}
-            </a>
-          </div>
-        </article>
-      )
-    })}
-  </div>
+  <section className="flex flex-col gap-2" id="list">
+    <FiltersFallback projects={projects} />
+
+    <div className="grid-layout !gap-y-8 lg:!gap-y-3">
+      {projects.map((item) => {
+        const asset = item.cover?.asset
+        return (
+          <article
+            key={item._id}
+            className="relative col-span-full flex flex-col gap-y-2 lg:col-span-3 lg:gap-y-0"
+          >
+            <div className="relative aspect-video max-w-[100%] after:pointer-events-none after:absolute after:inset-0 after:border after:border-brand-w1/20">
+              <a
+                href={`/showcase/${item.slug}`}
+                className="block h-full w-full"
+                aria-label={`View ${item.title ?? "Untitled"}`}
+              >
+                {asset ? (
+                  <Image
+                    src={asset.url}
+                    alt={item.cover?.alt ?? item.title ?? ""}
+                    width={asset.metadata.dimensions.width}
+                    height={asset.metadata.dimensions.height}
+                    placeholder={asset.metadata.lqip ? "blur" : undefined}
+                    blurDataURL={asset.metadata.lqip}
+                    sizes="(max-width: 1024px) 100vw, 25vw"
+                    className="h-full w-full object-cover"
+                  />
+                ) : null}
+              </a>
+            </div>
+
+            <MobileInfo project={item} />
+          </article>
+        )
+      })}
+    </div>
+  </section>
 )

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -74,9 +74,21 @@ async function DraftModeTools() {
   )
 }
 
+// Parser-blocking on purpose (a next/script beforeInteractive lands after the
+// streamed HTML starts): the (canvas) group reserves --canvas-offset of viewport,
+// so the WebGL2 decision must exist before first paint or dropping the reserve
+// registers as ~0.8 CLS on mobile. Mirrors src/lib/webgl.ts, which can't be
+// imported into an inline script.
+const canvasAvailabilityScript = `(function(){try{var gl=document.createElement("canvas").getContext("webgl2");if(!gl){document.documentElement.dataset.canvasUnavailable="true";return}var e=gl.getExtension("WEBGL_lose_context");e&&e.loseContext()}catch(_){document.documentElement.dataset.canvasUnavailable="true"}})()`
+
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{ __html: canvasAvailabilityScript }}
+        />
+      </head>
       <body
         className={cn(
           geistSans.variable,

--- a/src/components/layout/shared-sections.tsx
+++ b/src/components/layout/shared-sections.tsx
@@ -4,7 +4,6 @@ import { motion } from "motion/react"
 import { usePathname } from "next/navigation"
 
 import { Link } from "@/components/primitives/link"
-import { useDeviceDetect } from "@/hooks/use-device-detect"
 import { useHandleContactButton } from "@/hooks/use-handle-contact"
 import { cn } from "@/utils/cn"
 import { isInPath } from "@/utils/is-in-path"
@@ -32,12 +31,7 @@ export const InternalLinks = ({
   animated = false
 }: InternalLinksProps) => {
   const handleContactButton = useHandleContactButton()
-  const { isMobile } = useDeviceDetect()
   const pathname = usePathname()
-
-  const filteredLinks = links.filter(
-    (link) => !(isMobile && link.href.includes("lab"))
-  )
 
   const animateProps = animated
     ? {
@@ -55,9 +49,13 @@ export const InternalLinks = ({
         className
       )}
     >
-      {filteredLinks.map((link, idx) => (
+      {links.map((link, idx) => (
         <motion.li
           key={`${link.title}-${idx}`}
+          // Hidden with CSS rather than filtered out: useDeviceDetect resolves
+          // after hydration, and removing a full-height row then shifts the
+          // page. The proxy still redirects mobile /lab navigations.
+          className={cn(link.href.includes("lab") && "max-lg:hidden")}
           {...animateProps}
           animate={{
             ...animateProps.animate,

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -209,25 +209,41 @@ export const Map = memo(() => {
         }
       }
 
-      office.traverse((child) => traverse(child))
-      officeItems.traverse((child) => traverse(child))
-      routingElements.traverse((child) => traverse(child, { FOG: false }))
-      outdoor.traverse((child) => traverse(child, { FOG: false }))
-      outdoorCars.traverse((child) => traverse(child, { FOG: false }))
-      godrays.traverse((child) => traverse(child, { GODRAY: true }))
-
-      extractMeshes({
-        office,
-        officeItems,
-        godrays,
-        outdoorCars,
-        basketballNet,
-        inspectables
-      })
-
       alreadyTraversed.current = true
 
-      useMesh.setState({ mapMaterialsReady: true })
+      // One material swap per mesh across seven scene graphs — run per-graph
+      // with a yield in between so it lands as several short tasks instead of
+      // one uninterruptible long task right after the GLTFs decode.
+      const steps = [
+        () => office.traverse((child) => traverse(child)),
+        () => officeItems.traverse((child) => traverse(child)),
+        () =>
+          routingElements.traverse((child) => traverse(child, { FOG: false })),
+        () => outdoor.traverse((child) => traverse(child, { FOG: false })),
+        () => outdoorCars.traverse((child) => traverse(child, { FOG: false })),
+        () => godrays.traverse((child) => traverse(child, { GODRAY: true })),
+        () => {
+          extractMeshes({
+            office,
+            officeItems,
+            godrays,
+            outdoorCars,
+            basketballNet,
+            inspectables
+          })
+
+          useMesh.setState({ mapMaterialsReady: true })
+        }
+      ]
+
+      const runSteps = async () => {
+        for (const step of steps) {
+          step()
+          await new Promise((resolve) => setTimeout(resolve, 0))
+        }
+      }
+
+      runSteps()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [

--- a/src/components/navigation-handler/index.tsx
+++ b/src/components/navigation-handler/index.tsx
@@ -22,14 +22,16 @@ export const NavigationHandler = () => {
 
   const setScenes = useNavigationStore((state) => state.setScenes)
   const isNotFound = useNavigationStore((state) => state.isNotFound)
-  const {
-    isCanvasTabMode,
-    setIsCanvasTabMode,
-    currentScene,
-    setCurrentScene,
-    currentTabIndex,
-    setEnteredByKeyboard
-  } = useNavigationStore()
+  const isCanvasTabMode = useNavigationStore((state) => state.isCanvasTabMode)
+  const setIsCanvasTabMode = useNavigationStore(
+    (state) => state.setIsCanvasTabMode
+  )
+  const currentScene = useNavigationStore((state) => state.currentScene)
+  const setCurrentScene = useNavigationStore((state) => state.setCurrentScene)
+  const currentTabIndex = useNavigationStore((state) => state.currentTabIndex)
+  const setEnteredByKeyboard = useNavigationStore(
+    (state) => state.setEnteredByKeyboard
+  )
   const scenes: IScene[] = useAssets().scenes
   const { handleNavigation } = useHandleNavigation()
   const scene = useCurrentScene()

--- a/src/components/postprocessing/renderer.tsx
+++ b/src/components/postprocessing/renderer.tsx
@@ -85,7 +85,7 @@ function RendererInner({ sceneChildren }: RendererProps) {
     })
   }, [])
 
-  const { canRunMainApp } = useAppLoadingStore()
+  const canRunMainApp = useAppLoadingStore((state) => state.canRunMainApp)
 
   const mainScene = useMemo(() => new Scene(), [])
   const bloomScene = useMemo(() => new Scene(), [])
@@ -142,9 +142,12 @@ function RendererInner({ sceneChildren }: RendererProps) {
       cctvConfig.shouldBakeCCTV = false
     }
 
-    // bloom
-    gl.setRenderTarget(bloomTarget)
-    gl.render(bloomScene, bloomCameraRef.current)
+    // bloom — skipped where the post shader won't read it (uActiveBloom is 0
+    // on mobile), which drops one of the three per-frame passes
+    if (postProcessingMaterial.uniforms.uActiveBloom.value > 0) {
+      gl.setRenderTarget(bloomTarget)
+      gl.render(bloomScene, bloomCameraRef.current)
+    }
 
     // post processing
     gl.outputColorSpace = SRGBColorSpace

--- a/src/components/scene/index.tsx
+++ b/src/components/scene/index.tsx
@@ -52,12 +52,23 @@ const PhysicsWorld = dynamic(
 )
 
 export const Scene = () => {
-  const { setIsCanvasTabMode, currentScene } = useNavigationStore()
+  // Per-field selectors: destructuring the whole store re-rendered the entire
+  // <Canvas> subtree on every unrelated navigation-store write.
+  const setIsCanvasTabMode = useNavigationStore(
+    (state) => state.setIsCanvasTabMode
+  )
+  const currentScene = useNavigationStore((state) => state.currentScene)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const isBasketball = currentScene?.name === "basketball"
   const clearPlayedBalls = useMinigameStore((state) => state.clearPlayedBalls)
   const userHasLeftWindow = useRef(false)
   const [isTouchOnly, setIsTouchOnly] = useState(false)
+  // DPR is capped at 1 below the desktop breakpoint: rendering the 80svh
+  // mobile canvas at retina resolution roughly quadruples the per-frame GPU
+  // and post-processing cost on the phones already struggling with INP.
+  const [dpr, setDpr] = useState<number | [number, number]>(() =>
+    typeof window !== "undefined" && window.innerWidth < 1024 ? 1 : [1, 2]
+  )
   const scene = useCurrentScene()
 
   useTabKeyHandler()
@@ -70,6 +81,7 @@ export const Scene = () => {
       const hasFinePointer = window.matchMedia("(pointer: fine)").matches
 
       setIsTouchOnly(hasTouchScreen && hasCoarsePointer && !hasFinePointer)
+      setDpr(window.innerWidth < 1024 ? 1 : [1, 2])
     }
 
     detectTouchOnly()
@@ -140,6 +152,7 @@ export const Scene = () => {
         <Canvas
           id="canvas"
           frameloop="demand"
+          dpr={dpr}
           ref={canvasRef}
           tabIndex={0}
           onFocus={handleFocus}

--- a/src/components/shared/AnimationController.tsx
+++ b/src/components/shared/AnimationController.tsx
@@ -12,6 +12,7 @@ import {
   useState
 } from "react"
 
+import { useAppLoadingStore } from "@/components/loading/app-loading-handler"
 import { useNavigationStore } from "@/components/navigation-handler/navigation-store"
 
 // Context for sharing animation time
@@ -54,7 +55,8 @@ function AnimationControllerImpl({
   frameSkip = 0,
   pauseOnTabChange = true
 }: AnimationControllerProps) {
-  const { invalidate } = useThree()
+  const invalidate = useThree((state) => state.invalidate)
+  const gl = useThree((state) => state.gl)
 
   const [isTabVisible, setIsTabVisible] = useState(!document.hidden)
   const [isScrollPaused, setIsScrollPaused] = useState(false)
@@ -62,9 +64,14 @@ function AnimationControllerImpl({
   const disableCameraTransition = useNavigationStore(
     (state) => state.disableCameraTransition
   )
+  // Until the app is ready to reveal, every invalidate() runs ~20 frame
+  // subscribers (uTime writes over all materials, skinning, …) for frames
+  // nobody sees — the loading animation lives on the worker canvas, not here.
+  const canRunMainApp = useAppLoadingStore((state) => state.canRunMainApp)
 
   const isPaused =
     paused ||
+    !canRunMainApp ||
     (pauseOnTabChange && !isTabVisible) ||
     (isScrollPaused && !disableCameraTransition)
 
@@ -85,16 +92,18 @@ function AnimationControllerImpl({
 
   useEffect(() => {
     const handleScroll = () => {
-      const scrollPosition = window.scrollY
-      const viewportHeight = window.innerHeight
-      setIsScrollPaused(scrollPosition > viewportHeight)
+      // The canvas is 80svh on mobile (100svh on desktop), so compare against
+      // its real height — an innerHeight threshold kept rendering a fully
+      // off-screen scene for the last 20% of the first mobile viewport.
+      const canvasHeight = gl.domElement.clientHeight || window.innerHeight
+      setIsScrollPaused(window.scrollY > canvasHeight)
     }
 
     window.addEventListener("scroll", handleScroll, { passive: true })
     handleScroll()
 
     return () => window.removeEventListener("scroll", handleScroll)
-  }, [])
+  }, [gl])
 
   // Current time values exposed through context (memoized)
   const timeValues = useMemo(

--- a/src/hooks/use-ambience-playlist.ts
+++ b/src/hooks/use-ambience-playlist.ts
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react"
 import { useAudioUrls } from "@/hooks/use-audio-urls"
 import { Playlist } from "@/lib/audio"
 import { AMBIENT_VOLUME } from "@/lib/audio/constants"
+import { onIdle } from "@/utils/idle"
 
 import { BackgroundAudioType, useSiteAudioStore } from "./use-site-audio"
 
@@ -95,8 +96,10 @@ export function useAmbiencePlaylist() {
     if (!ambiencePlaylist) return
 
     if (!globalPlaylistRef.isPlaying) {
-      ambiencePlaylist.play()
       globalPlaylistRef.isPlaying = true
+      // play() fetches + decodes the first MP3; the playlist appears right
+      // after the unlocking tap, so keep that work off the interaction frame.
+      onIdle(() => ambiencePlaylist.play(), 1000)
     }
 
     if (!isBackgroundInitialized) setBackgroundInitialized(true)

--- a/src/hooks/use-canvas-availability.ts
+++ b/src/hooks/use-canvas-availability.ts
@@ -1,7 +1,6 @@
 import { useEffect } from "react"
 
 import { useAppLoadingStore } from "@/components/loading/app-loading-handler"
-import { isWebGL2Available } from "@/lib/webgl"
 
 const WEBGL_CONTEXT_FAILURE = /webgl context/i
 
@@ -9,22 +8,17 @@ const WEBGL_CONTEXT_FAILURE = /webgl context/i
 // a floating promise instead of throwing into React — the <ErrorBoundary> around
 // the canvas never sees it. Sentry WEBSITE-2K25-39.
 export const useCanvasAvailability = () => {
-  const canvasUnavailable = useAppLoadingStore(
-    (state) => state.canvasUnavailable
-  )
-
+  // The WebGL2 probe runs in an inline pre-paint script (src/app/layout.tsx) so
+  // CSS can drop the (canvas) reserve before first paint — collapsing it from a
+  // useEffect scored ~0.8 CLS on mobile. Here we only sync the store with that
+  // decision. Late failures (error boundary, rejection below) still prune the
+  // scene subtree but must never touch the dataset: shifting the page post-paint
+  // is worse than keeping an empty reserve.
   useEffect(() => {
-    if (isWebGL2Available()) return
+    if (document.documentElement.dataset.canvasUnavailable !== "true") return
 
     useAppLoadingStore.getState().reportCanvasUnavailable()
   }, [])
-
-  // Lets CSS drop the viewport of space the (canvas) group reserves.
-  useEffect(() => {
-    if (!canvasUnavailable) return
-
-    document.documentElement.dataset.canvasUnavailable = "true"
-  }, [canvasUnavailable])
 
   useEffect(() => {
     const handleRejection = (event: PromiseRejectionEvent) => {

--- a/src/hooks/use-preload-assets.ts
+++ b/src/hooks/use-preload-assets.ts
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react"
 import { preload, PreloadOptions } from "react-dom"
 
 import { AssetsResult } from "@/components/assets-provider/fetch-assets"
@@ -214,6 +215,15 @@ const preloadAllAssets = (obj: any) => {
 
 export const usePreloadAssets = (assets: AssetsResult) => {
   const offscreenCanvasReady = useAppLoadingStore((s) => s.offscreenCanvasReady)
+  const hasPreloaded = useRef(false)
 
-  if (offscreenCanvasReady) preloadAllAssets(assets)
+  // In an effect with a once-guard: calling this in the render body re-walked
+  // the whole asset manifest and re-issued every preload() each time AppHooks
+  // re-rendered (player/music/scene changes do that constantly).
+  useEffect(() => {
+    if (!offscreenCanvasReady || hasPreloaded.current) return
+
+    hasPreloaded.current = true
+    preloadAllAssets(assets)
+  }, [offscreenCanvasReady, assets])
 }

--- a/src/hooks/use-site-audio.ts
+++ b/src/hooks/use-site-audio.ts
@@ -5,6 +5,7 @@ import { useAudioUrls } from "@/hooks/use-audio-urls"
 import { AudioSource, WebAudioPlayer } from "@/lib/audio"
 import { AMBIENT_VOLUME, SFX_VOLUME } from "@/lib/audio/constants"
 import { useArcadeStore } from "@/store/arcade-store"
+import { onIdle } from "@/utils/idle"
 
 import { useCurrentScene } from "./use-current-scene"
 import { useIsOnTab } from "./use-is-on-tab"
@@ -120,9 +121,26 @@ export const useInitializeAudioContext = () => {
 
   useEffect(() => {
     const targetElement = document
+    let unlocked = false
+
     const unlock = () => {
-      if (!player) {
-        const newPlayer = new WebAudioPlayer()
+      if (player) {
+        targetElement.removeEventListener("click", unlock)
+        return
+      }
+      if (unlocked) return
+      unlocked = true
+
+      // The gesture itself only needs to create/resume the AudioContext
+      // (autoplay policy). The graph build, localStorage read and the store
+      // update (which fans out re-renders) run after the next paint so the
+      // user's first tap — the interaction INP measures — isn't billed for
+      // the audio bootstrap.
+      const audioContext = new AudioContext()
+      audioContext.resume()
+
+      setTimeout(() => {
+        const newPlayer = new WebAudioPlayer(audioContext)
         const mPref = localStorage.getItem("musicEnabled")
         const shouldEnableMusic = mPref === null ? true : mPref === "true"
 
@@ -134,9 +152,7 @@ export const useInitializeAudioContext = () => {
         }
 
         useSiteAudioStore.setState({ player: newPlayer })
-      } else {
-        targetElement.removeEventListener("click", unlock)
-      }
+      }, 0)
     }
     targetElement.addEventListener("click", unlock, { passive: true })
 
@@ -236,10 +252,10 @@ export const SiteAudioSFXsLoader = memo((): null => {
       const newSources = {} as Record<SiteAudioSFXKey, AudioSource>
 
       try {
-        const promises: Promise<void>[] = []
+        const promises: Array<() => Promise<void>> = []
 
         promises.push(
-          ...Object.keys(GAME_AUDIO_SFX).map(async (key) => {
+          ...Object.keys(GAME_AUDIO_SFX).map((key) => async () => {
             const audioKey = key as SiteAudioSFXKey
             const source = await player.loadAudioFromURL(
               GAME_AUDIO_SFX[audioKey as keyof typeof GAME_AUDIO_SFX],
@@ -251,7 +267,7 @@ export const SiteAudioSFXsLoader = memo((): null => {
         )
 
         promises.push(
-          ...ARCADE_AUDIO_SFX.BUTTONS.map(async (button, index) => {
+          ...ARCADE_AUDIO_SFX.BUTTONS.map((button, index) => async () => {
             const source = await player.loadAudioFromURL(button.PRESS, true)
             source.setVolume(SFX_VOLUME)
             newSources[`ARCADE_BUTTON_${index}_PRESS`] = source
@@ -265,7 +281,7 @@ export const SiteAudioSFXsLoader = memo((): null => {
         )
 
         promises.push(
-          ...ARCADE_AUDIO_SFX.STICKS.map(async (stick, index) => {
+          ...ARCADE_AUDIO_SFX.STICKS.map((stick, index) => async () => {
             const source = await player.loadAudioFromURL(stick.PRESS, true)
             source.setVolume(SFX_VOLUME)
             newSources[`ARCADE_STICK_${index}_PRESS`] = source
@@ -279,7 +295,7 @@ export const SiteAudioSFXsLoader = memo((): null => {
         )
 
         promises.push(
-          ...BLOG_AUDIO_SFX.LOCKED_DOOR.map(async (lockedDoor, index) => {
+          ...BLOG_AUDIO_SFX.LOCKED_DOOR.map((lockedDoor, index) => async () => {
             const source = await player.loadAudioFromURL(lockedDoor, true)
             source.setVolume(SFX_VOLUME)
             newSources[`BLOG_LOCKED_DOOR_${index}`] = source
@@ -287,7 +303,7 @@ export const SiteAudioSFXsLoader = memo((): null => {
         )
 
         promises.push(
-          ...BLOG_AUDIO_SFX.DOOR.map(async (door, index) => {
+          ...BLOG_AUDIO_SFX.DOOR.map((door, index) => async () => {
             const source = await player.loadAudioFromURL(door.OPEN, true)
             source.setVolume(SFX_VOLUME)
             newSources[`BLOG_DOOR_${index}_OPEN`] = source
@@ -298,7 +314,7 @@ export const SiteAudioSFXsLoader = memo((): null => {
         )
 
         promises.push(
-          ...BLOG_AUDIO_SFX.LAMP.map(async (lamp, index) => {
+          ...BLOG_AUDIO_SFX.LAMP.map((lamp, index) => async () => {
             const source = await player.loadAudioFromURL(lamp.PULL, true)
             source.setVolume(SFX_VOLUME)
             newSources[`BLOG_LAMP_${index}_PULL`] = source
@@ -311,41 +327,48 @@ export const SiteAudioSFXsLoader = memo((): null => {
           })
         )
 
-        promises.push(
-          (async () => {
-            const source = await player.loadAudioFromURL(
-              CONTACT_AUDIO_SFX.INTERFERENCE,
-              true
-            )
-            source.setVolume(SFX_VOLUME)
-            newSources["CONTACT_INTERFERENCE"] = source
-          })()
-        )
+        promises.push(async () => {
+          const source = await player.loadAudioFromURL(
+            CONTACT_AUDIO_SFX.INTERFERENCE,
+            true
+          )
+          source.setVolume(SFX_VOLUME)
+          newSources["CONTACT_INTERFERENCE"] = source
+        })
 
-        promises.push(
-          (async () => {
-            const source = await player.loadAudioFromURL(
-              CONTACT_AUDIO_SFX.KNOB_TURNING,
-              true
-            )
-            source.setVolume(SFX_VOLUME)
-            newSources["CONTACT_KNOB_TURNING"] = source
-          })()
-        )
+        promises.push(async () => {
+          const source = await player.loadAudioFromURL(
+            CONTACT_AUDIO_SFX.KNOB_TURNING,
+            true
+          )
+          source.setVolume(SFX_VOLUME)
+          newSources["CONTACT_KNOB_TURNING"] = source
+        })
 
-        promises.push(
-          (async () => {
-            const source = await player.loadAudioFromURL(
-              CONTACT_AUDIO_SFX.ANTENNA,
-              true
-            )
-            source.setVolume(SFX_VOLUME)
-            newSources["CONTACT_ANTENNA"] = source
-          })()
-        )
+        promises.push(async () => {
+          const source = await player.loadAudioFromURL(
+            CONTACT_AUDIO_SFX.ANTENNA,
+            true
+          )
+          source.setVolume(SFX_VOLUME)
+          newSources["CONTACT_ANTENNA"] = source
+        })
 
+        // Batched instead of one ~40-request burst: the burst competed with
+        // the GLB/KTX2 fetches on mobile connections and its decode callbacks
+        // landed as a long-task pileup right after the unlocking tap.
         // one flaky fetch shouldn't discard every SFX that loaded
-        const results = await Promise.allSettled(promises)
+        const results: PromiseSettledResult<void>[] = []
+        const BATCH_SIZE = 5
+        for (let i = 0; i < promises.length; i += BATCH_SIZE) {
+          results.push(
+            ...(await Promise.allSettled(
+              promises.slice(i, i + BATCH_SIZE).map((load) => load())
+            ))
+          )
+          // yield to the main thread between batches
+          await new Promise((resolve) => setTimeout(resolve, 0))
+        }
 
         const failed = results.filter((r) => r.status === "rejected")
         if (failed.length) {
@@ -363,7 +386,9 @@ export const SiteAudioSFXsLoader = memo((): null => {
       }
     }
 
-    loadAudioSources()
+    // The player appears right after the first tap — wait for idle so the SFX
+    // warmup never shares the frame with that interaction.
+    onIdle(loadAudioSources)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [player])
 

--- a/src/lib/audio/index.ts
+++ b/src/lib/audio/index.ts
@@ -156,8 +156,11 @@ export class WebAudioPlayer {
   public ambienceVolume: number
   private audioSources: Set<AudioSource> = new Set()
 
-  constructor() {
-    this.audioContext = new (window.AudioContext || window.AudioContext)()
+  // Accepts an existing context so the unlock gesture can create/resume the
+  // AudioContext synchronously (autoplay policy) while the graph construction
+  // here runs deferred, off the tap's INP-measured critical path.
+  constructor(audioContext?: AudioContext) {
+    this.audioContext = audioContext ?? new AudioContext()
 
     // master output
     this.masterOutput = this.audioContext.createGain()

--- a/src/lib/webgl.ts
+++ b/src/lib/webgl.ts
@@ -1,6 +1,8 @@
 // Inlined instead of three's WebGL.isWebGL2Available() to keep the Addons barrel
 // out of the bundle. The probe context is released — contexts are a limited
 // per-page resource.
+// Duplicated as an inline pre-paint script in src/app/layout.tsx (it must run
+// before first paint and can't import modules) — keep the two in sync.
 export const isWebGL2Available = () => {
   try {
     const gl = document.createElement("canvas").getContext("webgl2")

--- a/src/utils/idle.ts
+++ b/src/utils/idle.ts
@@ -1,0 +1,10 @@
+// requestIdleCallback with a deadline, falling back to a timer (Safari has no
+// requestIdleCallback). Used to push audio/asset warmup off interaction paths.
+export const onIdle = (callback: () => void, timeout = 1500) => {
+  if (typeof requestIdleCallback === "function") {
+    requestIdleCallback(() => callback(), { timeout })
+    return
+  }
+
+  setTimeout(callback, timeout)
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -161,9 +161,9 @@ export default {
         "61": "15.25rem"
       },
       fontFamily: {
-        sans: ["var(--font-geist-sans)"],
-        mono: ["var(--font-geist-mono)"],
-        flauta: ["var(--font-flauta)"]
+        sans: ["var(--font-geist-sans)", "system-ui", "sans-serif"],
+        mono: ["var(--font-geist-mono)", "ui-monospace", "monospace"],
+        flauta: ["var(--font-flauta)", "serif"]
       },
       maxWidth: {
         full: "120rem"


### PR DESCRIPTION
## Why

Vercel Speed Insights shows mobile RES **45 (Poor)** on `/`, `/people`, `/showcase`, `/blog`:

| Metric | Mobile p75 | Target |
|---|---|---|
| CLS | **0.8** | < 0.1 |
| INP | **2,024 ms** | < 200 ms |
| FID | **463 ms** | < 100 ms |

FCP / LCP / TTFB are already green.

## Root causes

- **CLS 0.8** — every `(canvas)` page reserves `80svh` via `--canvas-offset`; when WebGL2 is unavailable (in-app browsers, low-power phones) a `useEffect` collapsed it to `2.25rem` **after first paint**, shifting the entire page by ~0.8 viewports. `/showcase` additionally hydrated in a filters bar (~150–250px) and per-card `MobileInfo` rows absent from the prerendered fallback.
- **INP / FID** — the first tap created an AudioContext and unblocked ~40 fetch+decode calls (7.2 MB of SFX) — exactly the interaction INP measures. Plus: three `gl.render` passes per frame (bloom runs on mobile even though its shader read is off), retina DPR on the 80svh mobile canvas, one uninterruptible 7-graph material-swap task, `preloadAllAssets()` re-running in a render body, and whole-store zustand subscriptions re-rendering the R3F tree.

## Changes

**CLS**
- Inline pre-paint `<script>` in the root layout probes WebGL2 and sets `data-canvas-unavailable` **before first paint**; the availability hook now reads that decision instead of re-probing, and never touches the dataset post-paint (late failures prune the scene but keep the reserve, matching the existing boot-timeout UX).
- Showcase fallback is now structurally identical to the hydrated tree: shared `MobileInfo` (`lg:hidden`, always in HTML) + inert copy of the `Filters` bar driven by a shared `deriveCategories` helper.
- Footer Lab link hidden with `max-lg:hidden` instead of post-hydration JS filtering; font stacks get fallback tails.

**INP / FID**
- First-tap handler now only creates/resumes the AudioContext (autoplay policy); player graph, `localStorage`, ambience init and the store update are deferred past the next paint. SFX warmup waits for idle and loads in batches of 5 with yields; ambience playback starts on idle.
- Bloom pass skipped when `uActiveBloom` is 0 (mobile); DPR capped at 1 below 1024px.
- Frame loop paused until `canRunMainApp` and when the canvas (80svh on mobile, not `innerHeight`) is scrolled out of view.
- 7-graph material swap chunked with yields between graphs.
- `preloadAllAssets` moved to a once-guarded effect; per-field zustand selectors in `Scene`, `Renderer`, `NavigationHandler`.

## Verification

- `pnpm build` passes; all `(canvas)` routes remain fully static (`○`).
- Headless Chromium, 390×844 mobile: **CLS 0 on all four routes**, scene boots and renders, zero page errors, first tap triggers deferred audio path.
- WebGL-disabled run: flag set pre-paint, offset `2.25rem` at first paint, **CLS 0**, clean top-of-page layout (previously the 0.8 shift).
- Desktop 1440×900: scene renders, showcase filters interactive after hydration, category selection filters the grid.

## Expectations

CLS and FID should go green in field data. INP will improve substantially but may land yellow on low-end Android — the live three.js scene has irreducible main-thread cost. If p75 INP is still yellow after ~28 days, the agreed follow-up is a poster/tap-to-load-3D in the reserved slot, additive on this foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)