### PR TITLE
fix(canvas): harden Safari WebGL and video playback

### DIFF
--- a/src/components/arcade-screen/index.tsx
+++ b/src/components/arcade-screen/index.tsx
@@ -59,11 +59,14 @@ export const ArcadeScreen = () => {
   const bootTexture = useTexture(arcade.boot, (texture) => {
     texture.flipY = false
   })
-  const videoTexture = useVideoTexture(arcade.idleScreen, { loop: true })
+  // start: false — drei's own play() is uncaught. useVideoTextureResume starts it.
+  const videoTexture = useVideoTexture(arcade.idleScreen, {
+    loop: true,
+    start: false
+  })
   const screenMaterial = useMemo(() => createScreenMaterial(), [])
   const renderTarget = useMemo(() => new WebGLRenderTarget(1024, 1024), [])
 
-  // Use our custom hook to ensure video playback resumes when tab becomes visible
   useVideoTextureResume(videoTexture)
 
   useEffect(() => {

--- a/src/components/arcade-screen/render-texture.tsx
+++ b/src/components/arcade-screen/render-texture.tsx
@@ -17,6 +17,8 @@ import {
 } from "react"
 import * as THREE from "three"
 
+import { reportIfContextLost } from "@/lib/webgl-context-guard"
+
 interface R3FObject {
   __r3f: {
     parent: R3FObject | THREE.Object3D
@@ -242,6 +244,10 @@ const SceneContainer = ({
   children
 }: PropsWithChildren<SceneContainerProps>) => {
   useTextureFrame(({ state }) => {
+    // R3F invalidates on its own outside AnimationController, so the sites that
+    // actually touch the GPU still guard themselves.
+    if (reportIfContextLost(state.gl)) return
+
     state.gl.setRenderTarget(fbo)
     state.gl.render(state.scene, state.camera)
     state.gl.setRenderTarget(null)

--- a/src/components/contact/contact-canvas.tsx
+++ b/src/components/contact/contact-canvas.tsx
@@ -5,6 +5,7 @@ import * as Sentry from "@sentry/nextjs"
 import { useEffect, useState } from "react"
 
 import { useAssets } from "@/components/assets-provider"
+import { useAppLoadingStore } from "@/components/loading/app-loading-handler"
 import { workerErrorFromMessage, workerErrorReport } from "@/lib/worker-error"
 
 import { ContactScreen } from "./contact-screen"
@@ -28,6 +29,7 @@ type WorkerMessageType =
   | "scale-down-animation-complete"
   | "animation-starting"
   | "animation-complete"
+  | "screen-dimensions"
 
 export const ContactCanvas = () => {
   const { contactPhone } = useAssets()
@@ -41,6 +43,15 @@ export const ContactCanvas = () => {
     (state) => state.setClosingCompleted
   )
   const [shouldRender, setShouldRender] = useState(false)
+  const canRunMainApp = useAppLoadingStore((state) => state.canRunMainApp)
+  const loadingContextReleased = useAppLoadingStore(
+    (state) => state.loadingContextReleased
+  )
+  // Safari evicts the oldest of three live contexts — the main one. canRunMainApp
+  // alone fires ~1s before the loading canvas actually lets go. Both inputs are
+  // one-way, which is what transferControlToOffscreen needs.
+  const canMountCanvas = canRunMainApp && loadingContextReleased
+  const [sceneReady, setSceneReady] = useState(false)
 
   useEffect(() => {
     if (isContactOpen) {
@@ -91,7 +102,9 @@ export const ContactCanvas = () => {
           setAnimComplete(setClosingCompleted)
         },
         "animation-starting": () => setIsAnimating(true),
-        "animation-complete": () => setIsAnimating(false)
+        "animation-complete": () => setIsAnimating(false),
+        // Only sent once the model is in and ContactScene is listening.
+        "screen-dimensions": () => setSceneReady(true)
       }
 
       const handler = messageHandlers[type as WorkerMessageType]
@@ -167,30 +180,37 @@ export const ContactCanvas = () => {
       newWorker.removeEventListener("error", handleError)
       newWorker.terminate()
       setStoreWorker(null)
+      setSceneReady(false)
     }
   }, [contactPhone, setStoreWorker])
 
+  // @react-three/offscreen's render() replaces the worker's own onmessage, so
+  // ContactScene's listener is the only thing handling this — posting before it
+  // exists silently drops the message and strands isAnimating. Waiting on
+  // sceneReady also replays the current state once the scene comes up.
   useEffect(() => {
-    if (worker) {
-      worker.postMessage({
-        type: "update-contact-open",
-        isContactOpen: isContactOpen
-      })
-    }
-  }, [worker, isContactOpen])
+    if (!worker || !sceneReady) return
+
+    worker.postMessage({
+      type: "update-contact-open",
+      isContactOpen: isContactOpen
+    })
+  }, [worker, sceneReady, isContactOpen])
 
   if (!worker) return null
 
   return (
     <>
       <ContactScreen />
-      <OffscreenCanvas
-        worker={worker}
-        fallback={null}
-        frameloop={shouldRender || isAnimating ? "always" : "never"}
-        camera={{ position: [0, 0.2, 2], fov: 8.5 }}
-        gl={{ antialias: false }}
-      />
+      {canMountCanvas && (
+        <OffscreenCanvas
+          worker={worker}
+          fallback={null}
+          frameloop={shouldRender || isAnimating ? "always" : "never"}
+          camera={{ position: [0, 0.2, 2], fov: 8.5 }}
+          gl={{ antialias: false }}
+        />
+      )}
     </>
   )
 }

--- a/src/components/loading/app-loading-handler.tsx
+++ b/src/components/loading/app-loading-handler.tsx
@@ -24,6 +24,7 @@ interface AppLoadingState {
   canRunMainApp: boolean
   offscreenCanvasReady: boolean
   worker: Worker | null
+  loadingContextReleased: boolean
   canvasUnavailable: boolean
   canvasBootTimedOut: boolean
   setMainAppRunning: (isAppLoaded: boolean) => void
@@ -54,6 +55,11 @@ export const useAppLoadingStore = create<AppLoadingState>((set, get) => {
      * Worker canvas for loading screen
      */
     worker: null,
+    /**
+     * The loading canvas has given its WebGL context back. Safari caps how many
+     * are live at once, so the contact canvas waits on this before allocating.
+     */
+    loadingContextReleased: false,
     /**
      * Set by the error boundary, the WebGL2 probe, or a failed context creation
      */

--- a/src/components/loading/loading-canvas.tsx
+++ b/src/components/loading/loading-canvas.tsx
@@ -105,6 +105,11 @@ function LoadingCanvas({ hide }: { hide: boolean }) {
 
     return () => {
       worker.terminate()
+      // Nulled so nothing posts to a terminated worker.
+      useAppLoadingStore.setState({
+        worker: null,
+        loadingContextReleased: true
+      })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])

--- a/src/components/postprocessing/renderer.tsx
+++ b/src/components/postprocessing/renderer.tsx
@@ -19,6 +19,7 @@ import {
 import { useAppLoadingStore } from "@/components/loading/app-loading-handler"
 import { useNavigationStore } from "@/components/navigation-handler/navigation-store"
 import { useFrameCallback } from "@/hooks/use-pausable-time"
+import { reportIfContextLost } from "@/lib/webgl-context-guard"
 import { createBloomMaterial } from "@/shaders/material-bloom"
 import { createPostProcessingMaterial } from "@/shaders/material-postprocessing"
 import { doubleFbo } from "@/utils/double-fbo"
@@ -120,6 +121,10 @@ function RendererInner({ sceneChildren }: RendererProps) {
   }, [bloomTarget, bloomResolution])
 
   useFrameCallback(({ gl }) => {
+    // R3F invalidates on its own outside AnimationController, so the sites that
+    // actually touch the GPU still guard themselves.
+    if (reportIfContextLost(gl)) return
+
     if (
       !mainCamera ||
       !postProcessingCameraRef.current ||

--- a/src/components/scene/index.tsx
+++ b/src/components/scene/index.tsx
@@ -25,6 +25,7 @@ import { useMinigameStore } from "@/store/minigame-store"
 import { cn } from "@/utils/cn"
 
 import { DoomJs } from "../doom-js"
+import { WebGLContextGuard } from "./webgl-context-guard"
 
 const HoopMinigame = dynamic(
   () =>
@@ -165,6 +166,7 @@ export const Scene = () => {
           )}
         >
           <AnimationController>
+            <WebGLContextGuard />
             <UpdateCanvasCursor />
             <Renderer
               sceneChildren={

--- a/src/components/scene/webgl-context-guard.tsx
+++ b/src/components/scene/webgl-context-guard.tsx
@@ -1,0 +1,56 @@
+import { useThree } from "@react-three/fiber"
+import { useEffect } from "react"
+
+import { useAppLoadingStore } from "@/components/loading/app-loading-handler"
+import {
+  noteContextLostEvent,
+  reportIfContextLost
+} from "@/lib/webgl-context-guard"
+
+// three restores itself, so wait before tearing down: `canvasUnavailable` is
+// one-way and pushes users off /lab.
+const RESTORE_GRACE_MS = 5_000
+const POLL_MS = 1_000
+
+export const WebGLContextGuard = () => {
+  const gl = useThree((state) => state.gl)
+
+  useEffect(() => {
+    const canvas = gl.domElement
+
+    // Telemetry only, and no preventDefault() — three's listener already calls
+    // it to ask for a restore.
+    canvas.addEventListener("webglcontextlost", noteContextLostEvent)
+
+    // Polled rather than driven by the event, because WebKit can kill the
+    // context without firing it and leave a frozen canvas up forever.
+    let lostTicks = 0
+    const poll = setInterval(() => {
+      if (!reportIfContextLost(gl)) {
+        lostTicks = 0
+        return
+      }
+
+      if (++lostTicks * POLL_MS < RESTORE_GRACE_MS) return
+
+      clearInterval(poll)
+      useAppLoadingStore.getState().reportCanvasUnavailable()
+    }, POLL_MS)
+
+    if (process.env.NODE_ENV !== "production") {
+      const ext = gl.getContext().getExtension("WEBGL_lose_context")
+
+      Object.assign(window, {
+        __loseContext: () => ext?.loseContext(),
+        __restoreContext: () => ext?.restoreContext()
+      })
+    }
+
+    return () => {
+      clearInterval(poll)
+      canvas.removeEventListener("webglcontextlost", noteContextLostEvent)
+    }
+  }, [gl])
+
+  return null
+}

--- a/src/components/shared/AnimationController.tsx
+++ b/src/components/shared/AnimationController.tsx
@@ -13,6 +13,7 @@ import {
 } from "react"
 
 import { useNavigationStore } from "@/components/navigation-handler/navigation-store"
+import { reportIfContextLost } from "@/lib/webgl-context-guard"
 
 // Context for sharing animation time
 interface AnimationContext {
@@ -55,6 +56,7 @@ function AnimationControllerImpl({
   pauseOnTabChange = true
 }: AnimationControllerProps) {
   const { invalidate } = useThree()
+  const gl = useThree((state) => state.gl)
 
   const [isTabVisible, setIsTabVisible] = useState(!document.hidden)
   const [isScrollPaused, setIsScrollPaused] = useState(false)
@@ -117,6 +119,10 @@ function AnimationControllerImpl({
     (time: number, delta: number) => {
       if (isPaused) return
 
+      // The only invalidate() under frameloop="demand", so bailing here stops
+      // every frame callback at once rather than each one guarding itself.
+      if (reportIfContextLost(gl)) return
+
       // Skip frames if needed for performance
       if (frameSkip > 0) {
         frameCountRef.current = (frameCountRef.current + 1) % (frameSkip + 1)
@@ -133,7 +139,7 @@ function AnimationControllerImpl({
       // Here you could also run other global updates
       // that depend on animation time
     },
-    [isPaused, frameSkip, invalidate]
+    [isPaused, frameSkip, invalidate, gl]
   )
 
   // Use Motion's useAnimationFrame as our single RAF

--- a/src/hooks/use-video-resume.ts
+++ b/src/hooks/use-video-resume.ts
@@ -1,39 +1,66 @@
 import { useEffect, useMemo } from "react"
 import * as THREE from "three"
 
+// WebKit blocks autoplay even for muted inline video, so catching alone leaves
+// the video dead. Sentry WEBSITE-2K25-3F.
+const playWithGestureRetry = (video: HTMLVideoElement) => {
+  const controller = new AbortController()
+  const options = { capture: true, signal: controller.signal } as const
+
+  // Stays armed until play() resolves; one failed attempt must not strand it.
+  const retry = () => {
+    video.play().then(
+      () => controller.abort(),
+      () => {}
+    )
+  }
+
+  video.play().catch((err) => {
+    console.warn("Video play failed:", err)
+
+    // The rejection can land after teardown, which would arm a hidden video.
+    if (controller.signal.aborted) return
+
+    // click, not pointerdown/up: only it grants activation for every input type.
+    window.addEventListener("click", retry, options)
+    window.addEventListener("keydown", retry, options)
+  })
+
+  return () => controller.abort()
+}
+
+/** Plays now, retries on tab-return, and stops the decoder when torn down. */
+const resumeOnVisible = (video: HTMLVideoElement) => {
+  let disarm = playWithGestureRetry(video)
+
+  const handleVisibilityChange = () => {
+    if (document.visibilityState !== "visible") return
+
+    disarm()
+    disarm = playWithGestureRetry(video)
+  }
+
+  document.addEventListener("visibilitychange", handleVisibilityChange, {
+    passive: true
+  })
+
+  return () => {
+    document.removeEventListener("visibilitychange", handleVisibilityChange)
+    disarm()
+    // Nothing samples the texture once it's gone, so the element would decode
+    // for the rest of the session. Not src="" — drei caches it by URL.
+    video.pause()
+  }
+}
+
 export const useVideoResumeOnVisibilityChange = (
   videoElement: HTMLVideoElement | null
 ) => {
   useEffect(() => {
     if (!videoElement) return
 
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible" && videoElement) {
-        videoElement
-          .play()
-          .catch((err) => console.warn("Video play failed:", err))
-      }
-    }
-
-    document.addEventListener("visibilitychange", handleVisibilityChange, {
-      passive: true
-    })
-
-    return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange)
-    }
+    return resumeOnVisible(videoElement)
   }, [videoElement])
-
-  const play = () => {
-    if (videoElement) {
-      return videoElement
-        .play()
-        .catch((err) => console.warn("Video play failed:", err))
-    }
-    return Promise.reject(new Error("No video element available"))
-  }
-
-  return { play }
 }
 
 export const createVideoTextureWithResume = (url: string) => {
@@ -45,35 +72,11 @@ export const createVideoTextureWithResume = (url: string) => {
   videoElement.playsInline = true
   videoElement.crossOrigin = "anonymous"
 
-  try {
-    videoElement.play().catch((err) => console.warn("Video play failed:", err))
-  } catch (error) {
-    console.error("Error playing video:", error)
-  }
-
-  const handleVisibilityChange = () => {
-    if (document.visibilityState === "visible") {
-      try {
-        videoElement
-          .play()
-          .catch((err) => console.warn("Video play failed:", err))
-      } catch (error) {
-        console.error("Error playing video:", error)
-      }
-    }
-  }
-
-  document.addEventListener("visibilitychange", handleVisibilityChange, {
-    passive: true
-  })
-
   const texture = new THREE.VideoTexture(videoElement)
 
   texture.userData = {
     ...texture.userData,
-    cleanup: () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange)
-    },
+    cleanup: resumeOnVisible(videoElement),
     videoElement
   }
 
@@ -88,23 +91,5 @@ export const useVideoTextureResume = (
     return videoTexture.image as HTMLVideoElement
   }, [videoTexture])
 
-  useEffect(() => {
-    if (videoTexture) {
-      const originalDispose = videoTexture.dispose.bind(videoTexture)
-      videoTexture.dispose = () => {
-        if (videoElement) {
-          videoElement.pause()
-          videoElement.src = ""
-          videoElement.load()
-        }
-        originalDispose()
-      }
-
-      return () => {
-        videoTexture.dispose = originalDispose
-      }
-    }
-  }, [videoTexture, videoElement])
-
-  return useVideoResumeOnVisibilityChange(videoElement)
+  useVideoResumeOnVisibilityChange(videoElement)
 }

--- a/src/lib/webgl-context-guard.ts
+++ b/src/lib/webgl-context-guard.ts
@@ -1,0 +1,27 @@
+import * as Sentry from "@sentry/nextjs"
+import type { WebGLRenderer } from "three"
+
+let reported = false
+let sawLostEvent = false
+
+/** Whether the browser bothered to tell us, which is what we can't rely on. */
+export const noteContextLostEvent = () => {
+  sawLostEvent = true
+}
+
+// WebKit can leave the context dead without dispatching `webglcontextlost`, so
+// three's own `_isContextLost` guard never arms. Sentry WEBSITE-2K25-4B.
+// Called every frame, so the report stays one-shot.
+export const reportIfContextLost = (gl: WebGLRenderer) => {
+  if (!gl.getContext().isContextLost()) return false
+
+  if (!reported) {
+    reported = true
+    Sentry.captureMessage("WebGL context lost", {
+      level: "warning",
+      extra: { viaEvent: sawLostEvent }
+    })
+  }
+
+  return true
+}


### PR DESCRIPTION
## Summary

- Recover blocked Safari video autoplay after user interaction.
- Stop render storms from lost WebGL contexts and avoid context eviction during boot.
- Addresses Sentry issues [WEBSITE-2K25-3F](https://basementstudio-be.sentry.io/issues/7670802884/) and [WEBSITE-2K25-4B](https://basementstudio-be.sentry.io/issues/7672769103/).

## Validation

- `pnpm build`
- Targeted ESLint on changed files