### PR TITLE
feat(blog): make the Rubik's cube playable

### DIFF
--- a/src/components/inspectables/inspectable-dragger.tsx
+++ b/src/components/inspectables/inspectable-dragger.tsx
@@ -8,6 +8,7 @@ import { useMotionValue, useSpring } from "motion/react"
 import * as React from "react"
 import { type Group, MathUtils } from "three"
 
+import { useRubiksStore } from "@/components/rubiks-cube/cube-store"
 import { useCursor } from "@/hooks/use-mouse"
 import { useFrameCallback } from "@/hooks/use-pausable-time"
 
@@ -93,6 +94,9 @@ export const InspectableDragger = ({
         delta: [x, y],
         memo: [oldY, oldX] = [rotationY.get(), rotationX.get()]
       }) => {
+        // A drag that started on a Rubik's cubelet turns a layer instead of
+        // orbiting the inspectable.
+        if (useRubiksStore.getState().isCubeDragging) return [oldY, oldX]
         if (!enabled) return [y, x]
         if (cursor) setCursor(down ? "grabbing" : "grab")
 

--- a/src/components/inspectables/inspectable-viewer.tsx
+++ b/src/components/inspectables/inspectable-viewer.tsx
@@ -6,7 +6,10 @@ import { Fragment, useEffect, useState } from "react"
 import { useAssets } from "@/components/assets-provider"
 import { AssetsResult } from "@/components/assets-provider/fetch-assets"
 import { useInspectable } from "@/components/inspectables/context"
+import { RubiksTimer } from "@/components/rubiks-cube/timer"
 import { cn } from "@/utils/cn"
+
+const RUBIKS_MESH_ID = "SM_06_06"
 
 type InspectableData = AssetsResult["inspectables"][number]
 
@@ -90,6 +93,7 @@ export const InspectableViewer = () => {
           </div>
           <div className="row-span-1 flex flex-col justify-center gap-4">
             {data && <Content data={data} />}
+            {selected === RUBIKS_MESH_ID && <RubiksTimer />}
           </div>
         </div>
       </div>

--- a/src/components/inspectables/inspectable.tsx
+++ b/src/components/inspectables/inspectable.tsx
@@ -26,8 +26,12 @@ import { useSelectStore } from "@/hooks/use-select-store"
 
 import { useAssets } from "../assets-provider"
 import type { ICameraConfig } from "../navigation-handler/navigation.interface"
+import { PlayableRubiksCube } from "../rubiks-cube"
 import { useInspectable } from "./context"
 import { InspectableDragger } from "./inspectable-dragger"
+
+const RUBIKS_MESH_ID = "SM_06_06"
+const noopRaycast = () => null
 
 interface InspectableProps {
   id: string
@@ -314,9 +318,19 @@ export const Inspectable = memo(function InspectableInner({
         domElement={document.querySelector("#canvas canvas") as HTMLElement}
       >
         <primitive object={mesh} raycast={() => null} />
+        {id === RUBIKS_MESH_ID && (
+          <PlayableRubiksCube baseMesh={mesh} active={selected === id} />
+        )}
         <mesh
           position={[...offsetedBoundingBox]}
           rotation={[mesh.rotation.x, mesh.rotation.y, mesh.rotation.z]}
+          raycast={
+            // While the cube is being played, let raycasts through to the
+            // cubelets instead of this proxy hit-box.
+            id === RUBIKS_MESH_ID && selected === id
+              ? noopRaycast
+              : Mesh.prototype.raycast
+          }
         >
           <boxGeometry
             args={[size.current.x, size.current.y, size.current.z]}

--- a/src/components/rubiks-cube/cube-store.ts
+++ b/src/components/rubiks-cube/cube-store.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand"
+
+export interface RubiksStore {
+  /** A pointer drag started on a cubelet — blocks the inspectable orbit. */
+  isCubeDragging: boolean
+  /** A layer is spring-snapping to its resting angle. */
+  isTurning: boolean
+  solved: boolean
+}
+
+export const useRubiksStore = create<RubiksStore>()(() => ({
+  isCubeDragging: false,
+  isTurning: false,
+  solved: true
+}))

--- a/src/components/rubiks-cube/cube-store.ts
+++ b/src/components/rubiks-cube/cube-store.ts
@@ -8,12 +8,18 @@ export interface RubiksStore {
   /** A layer is spring-snapping to its resting angle. */
   isTurning: boolean
   solved: boolean
-  /** Wall-clock ms when the cube left the solved state; null while solved. */
+  /** Wall-clock ms of the first move of the current attempt; null when idle. */
   startedAt: number | null
   /** Duration of the last completed solve, in ms. */
   solveTime: number | null
   /** Fastest solve in this browser, in ms. */
   bestTime: number | null
+  /** User turns in the current attempt. */
+  moves: number
+  /** The scramble button was pressed; the cube component picks this up. */
+  scramblePending: boolean
+  /** A scramble sequence is animating — user input is ignored. */
+  isScrambling: boolean
 }
 
 export const useRubiksStore = create<RubiksStore>()(() => ({
@@ -22,5 +28,8 @@ export const useRubiksStore = create<RubiksStore>()(() => ({
   solved: true,
   startedAt: null,
   solveTime: null,
-  bestTime: null
+  bestTime: null,
+  moves: 0,
+  scramblePending: false,
+  isScrambling: false
 }))

--- a/src/components/rubiks-cube/cube-store.ts
+++ b/src/components/rubiks-cube/cube-store.ts
@@ -1,15 +1,26 @@
 import { create } from "zustand"
 
+export const RUBIKS_BEST_TIME_KEY = "rubiks-best-time"
+
 export interface RubiksStore {
   /** A pointer drag started on a cubelet — blocks the inspectable orbit. */
   isCubeDragging: boolean
   /** A layer is spring-snapping to its resting angle. */
   isTurning: boolean
   solved: boolean
+  /** Wall-clock ms when the cube left the solved state; null while solved. */
+  startedAt: number | null
+  /** Duration of the last completed solve, in ms. */
+  solveTime: number | null
+  /** Fastest solve in this browser, in ms. */
+  bestTime: number | null
 }
 
 export const useRubiksStore = create<RubiksStore>()(() => ({
   isCubeDragging: false,
   isTurning: false,
-  solved: true
+  solved: true,
+  startedAt: null,
+  solveTime: null,
+  bestTime: null
 }))

--- a/src/components/rubiks-cube/index.tsx
+++ b/src/components/rubiks-cube/index.tsx
@@ -1,0 +1,410 @@
+"use client"
+
+import type { ThreeEvent } from "@react-three/fiber"
+import { useThree } from "@react-three/fiber"
+import { track } from "@vercel/analytics"
+import { animate } from "motion"
+import type { AnimationPlaybackControls } from "motion/react"
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react"
+import {
+  BoxGeometry,
+  type Group,
+  type Material,
+  MathUtils,
+  Matrix4,
+  Mesh,
+  MeshBasicMaterial,
+  Quaternion,
+  Vector2,
+  Vector3
+} from "three"
+
+import { ANIMATION_CONFIG } from "@/constants/inspectables"
+import { useCursor } from "@/hooks/use-mouse"
+
+import { useRubiksStore } from "./cube-store"
+import { splitCubeGeometry } from "./split-cube-geometry"
+
+const QUARTER = Math.PI / 2
+const DRAG_THRESHOLD_PX = 8
+const PIXELS_PER_QUARTER_TURN = 200
+
+const noopRaycast = () => null
+
+const snapToAxis = (v: Vector3): Vector3 => {
+  const ax = Math.abs(v.x)
+  const ay = Math.abs(v.y)
+  const az = Math.abs(v.z)
+  if (ax >= ay && ax >= az) return new Vector3(Math.sign(v.x) || 1, 0, 0)
+  if (ay >= az) return new Vector3(0, Math.sign(v.y) || 1, 0)
+  return new Vector3(0, 0, Math.sign(v.z) || 1)
+}
+
+const componentAlong = (v: Vector3, axis: Vector3): number =>
+  v.x * Math.abs(axis.x) + v.y * Math.abs(axis.y) + v.z * Math.abs(axis.z)
+
+const quantizeMatrix = new Matrix4()
+const quantizeQuaternion = (q: Quaternion) => {
+  quantizeMatrix.makeRotationFromQuaternion(q)
+  const e = quantizeMatrix.elements
+  for (let i = 0; i < 16; i++) e[i] = Math.round(e[i])
+  q.setFromRotationMatrix(quantizeMatrix)
+}
+
+interface DragState {
+  pointerId: number
+  startX: number
+  startY: number
+  /** Principal axis of the grabbed face, in grid space */
+  normal: Vector3
+  /** Hit point in grid space */
+  hitGrid: Vector3
+  /** Resting position of the grabbed cubelet, for layer selection */
+  hitCubeletPosition: Vector3
+  /** Unit screen-pixel direction of the chosen tangent (set past threshold) */
+  screenDir: Vector2 | null
+  /** Sign relating +angle about the axis to motion along +tangent */
+  velocitySign: number
+}
+
+interface TurnState {
+  axis: Vector3
+  angle: number
+}
+
+interface PlayableRubiksCubeProps {
+  baseMesh: Mesh
+  active: boolean
+}
+
+export const PlayableRubiksCube = memo(function PlayableRubiksCubeInner({
+  baseMesh,
+  active
+}: PlayableRubiksCubeProps) {
+  const camera = useThree((state) => state.camera)
+  const size = useThree((state) => state.size)
+  const invalidate = useThree((state) => state.invalidate)
+  const setCursor = useCursor()
+
+  const [activated, setActivated] = useState(false)
+  useEffect(() => {
+    if (active) setActivated(true)
+  }, [active])
+
+  const cube = useMemo(() => {
+    if (!activated) return null
+
+    const { cubelets, cellSize, center } = splitCubeGeometry(baseMesh.geometry)
+
+    const fillerGeometry = new BoxGeometry(
+      cellSize.x * 0.95,
+      cellSize.y * 0.95,
+      cellSize.z * 0.95
+    )
+    const fillerMaterial = new MeshBasicMaterial({ color: "#0a0a0a" })
+
+    return { cubelets, cellSize, center, fillerGeometry, fillerMaterial }
+  }, [activated, baseMesh])
+
+  const gridRootRef = useRef<Group>(null)
+  const layerGroupRef = useRef<Group>(null)
+  const cubeletRefs = useRef<(Mesh | null)[]>([])
+
+  const getCubeletMeshes = () =>
+    cubeletRefs.current.filter((m): m is Mesh => m !== null)
+
+  useLayoutEffect(() => {
+    if (!cube) return
+    baseMesh.visible = false
+    return () => {
+      baseMesh.visible = true
+    }
+  }, [cube, baseMesh])
+
+  useEffect(() => {
+    if (!cube) return
+    for (const mesh of getCubeletMeshes()) {
+      mesh.raycast = active ? Mesh.prototype.raycast : noopRaycast
+    }
+  }, [cube, active])
+
+  const dragRef = useRef<DragState | null>(null)
+  const turnRef = useRef<TurnState | null>(null)
+  const animRef = useRef<AnimationPlaybackControls | null>(null)
+  const wasSolvedRef = useRef(true)
+
+  const bake = useCallback(
+    (quarterTurns: number) => {
+      const turn = turnRef.current
+      const gridRoot = gridRootRef.current
+      const layerGroup = layerGroupRef.current
+      if (!turn || !cube || !gridRoot || !layerGroup) return
+      const { cellSize, cubelets } = cube
+
+      layerGroup.quaternion.setFromAxisAngle(turn.axis, quarterTurns * QUARTER)
+      gridRoot.updateWorldMatrix(true, true)
+      for (const child of [...layerGroup.children]) {
+        gridRoot.attach(child)
+      }
+      layerGroup.quaternion.identity()
+      turnRef.current = null
+
+      const meshes = getCubeletMeshes()
+      for (const mesh of meshes) {
+        mesh.position.set(
+          Math.round(mesh.position.x / cellSize.x) * cellSize.x,
+          Math.round(mesh.position.y / cellSize.y) * cellSize.y,
+          Math.round(mesh.position.z / cellSize.z) * cellSize.z
+        )
+        quantizeQuaternion(mesh.quaternion)
+        mesh.scale.set(1, 1, 1)
+        mesh.updateMatrix()
+      }
+
+      const solved = meshes.every((mesh, index) => {
+        const cell = cubelets[index].cell
+        return (
+          Math.abs(mesh.quaternion.w) > 0.999 &&
+          Math.abs(mesh.position.x - cell[0] * cellSize.x) < 1e-3 &&
+          Math.abs(mesh.position.y - cell[1] * cellSize.y) < 1e-3 &&
+          Math.abs(mesh.position.z - cell[2] * cellSize.z) < 1e-3
+        )
+      })
+      if (solved && !wasSolvedRef.current) track("rubiks_cube_solved")
+      wasSolvedRef.current = solved
+
+      useRubiksStore.setState({ isTurning: false, solved })
+      invalidate()
+    },
+    [cube, invalidate]
+  )
+
+  const handlePointerDown = (e: ThreeEvent<PointerEvent>) => {
+    const gridRoot = gridRootRef.current
+    if (!cube || !active || !gridRoot) return
+    if (dragRef.current || turnRef.current) return
+    if (!e.face) return
+
+    e.stopPropagation()
+
+    const cubelet = e.object as Mesh
+    const normal = snapToAxis(
+      e.face.normal.clone().applyQuaternion(cubelet.quaternion)
+    )
+    const hitGrid = gridRoot.worldToLocal(e.point.clone())
+
+    const target = e.target as unknown as HTMLElement
+    if (target && "setPointerCapture" in target) {
+      target.setPointerCapture(e.pointerId)
+    }
+
+    dragRef.current = {
+      pointerId: e.pointerId,
+      startX: e.clientX,
+      startY: e.clientY,
+      normal,
+      hitGrid,
+      hitCubeletPosition: cubelet.position.clone(),
+      screenDir: null,
+      velocitySign: 1
+    }
+    useRubiksStore.setState({ isCubeDragging: true })
+    setCursor("grabbing")
+  }
+
+  const toScreen = (world: Vector3): Vector2 => {
+    const projected = world.project(camera)
+    return new Vector2(
+      (projected.x * size.width) / 2,
+      (-projected.y * size.height) / 2
+    )
+  }
+
+  const chooseTurn = (drag: DragState, dx: number, dy: number): boolean => {
+    const gridRoot = gridRootRef.current
+    const layerGroup = layerGroupRef.current
+    if (!cube || !gridRoot || !layerGroup) return false
+    const { cellSize } = cube
+
+    gridRoot.updateWorldMatrix(true, false)
+
+    const dragDir = new Vector2(dx, dy).normalize()
+    let best: {
+      tangent: Vector3
+      screenDir: Vector2
+      alignment: number
+    } | null = null
+
+    for (const candidate of [
+      new Vector3(1, 0, 0),
+      new Vector3(0, 1, 0),
+      new Vector3(0, 0, 1)
+    ]) {
+      if (Math.abs(candidate.dot(drag.normal)) > 0.5) continue
+
+      const s0 = toScreen(gridRoot.localToWorld(drag.hitGrid.clone()))
+      const s1 = toScreen(
+        gridRoot.localToWorld(
+          drag.hitGrid.clone().addScaledVector(candidate, 1)
+        )
+      )
+      const screenDir = s1.sub(s0)
+      if (screenDir.lengthSq() < 1e-6) continue
+      screenDir.normalize()
+
+      const alignment = Math.abs(dragDir.dot(screenDir))
+      if (!best || alignment > best.alignment) {
+        best = { tangent: candidate, screenDir, alignment }
+      }
+    }
+
+    if (!best) return false
+
+    const axis = new Vector3().crossVectors(drag.normal, best.tangent)
+    drag.velocitySign =
+      Math.sign(
+        new Vector3().crossVectors(axis, drag.hitGrid).dot(best.tangent)
+      ) || 1
+    drag.screenDir = best.screenDir
+
+    const cellAlong = componentAlong(cellSize, axis)
+    const layer = Math.round(
+      componentAlong(drag.hitCubeletPosition, axis) / cellAlong
+    )
+    for (const mesh of getCubeletMeshes()) {
+      if (
+        Math.round(componentAlong(mesh.position, axis) / cellAlong) === layer
+      ) {
+        layerGroup.attach(mesh)
+      }
+    }
+
+    turnRef.current = { axis, angle: 0 }
+    return true
+  }
+
+  const handlePointerMove = (e: ThreeEvent<PointerEvent>) => {
+    const drag = dragRef.current
+    const layerGroup = layerGroupRef.current
+    if (!drag || !cube || !layerGroup || e.pointerId !== drag.pointerId) return
+
+    const dx = e.clientX - drag.startX
+    const dy = e.clientY - drag.startY
+
+    if (!drag.screenDir) {
+      if (dx * dx + dy * dy < DRAG_THRESHOLD_PX * DRAG_THRESHOLD_PX) return
+      if (!chooseTurn(drag, dx, dy)) return
+    }
+
+    const turn = turnRef.current
+    if (!turn || !drag.screenDir) return
+
+    const alongScreen = dx * drag.screenDir.x + dy * drag.screenDir.y
+    turn.angle = MathUtils.clamp(
+      (drag.velocitySign * alongScreen * QUARTER) / PIXELS_PER_QUARTER_TURN,
+      -QUARTER,
+      QUARTER
+    )
+    layerGroup.quaternion.setFromAxisAngle(turn.axis, turn.angle)
+    invalidate()
+  }
+
+  const endDrag = (e: ThreeEvent<PointerEvent>) => {
+    const drag = dragRef.current
+    const layerGroup = layerGroupRef.current
+    if (!drag || e.pointerId !== drag.pointerId) return
+
+    const target = e.target as unknown as HTMLElement
+    if (target && "releasePointerCapture" in target) {
+      target.releasePointerCapture(e.pointerId)
+    }
+
+    dragRef.current = null
+    useRubiksStore.setState({ isCubeDragging: false })
+    setCursor(active ? "grab" : "default")
+
+    const turn = turnRef.current
+    if (!turn || !layerGroup) return
+
+    const snapTarget =
+      Math.abs(turn.angle) > QUARTER / 2 ? Math.sign(turn.angle) * QUARTER : 0
+    useRubiksStore.setState({ isTurning: true })
+    animRef.current = animate(turn.angle, snapTarget, {
+      ...ANIMATION_CONFIG,
+      onUpdate: (value) => {
+        turn.angle = value
+        layerGroup.quaternion.setFromAxisAngle(turn.axis, value)
+        invalidate()
+      },
+      onComplete: () => {
+        animRef.current = null
+        bake(Math.round(snapTarget / QUARTER))
+      }
+    })
+  }
+
+  // If the inspectable closes mid-turn, settle the layer instantly so the
+  // cube on the shelf is never left between two states.
+  useEffect(() => {
+    if (active || !cube) return
+
+    dragRef.current = null
+    animRef.current?.stop()
+    animRef.current = null
+
+    if (turnRef.current) {
+      bake(Math.round(turnRef.current.angle / QUARTER))
+    }
+    useRubiksStore.setState({ isCubeDragging: false, isTurning: false })
+  }, [active, cube, bake])
+
+  if (!cube) return null
+
+  return (
+    <group
+      rotation={[baseMesh.rotation.x, baseMesh.rotation.y, baseMesh.rotation.z]}
+      scale={[baseMesh.scale.x, baseMesh.scale.y, baseMesh.scale.z]}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <group
+        ref={gridRootRef}
+        position={[cube.center.x, cube.center.y, cube.center.z]}
+      >
+        <group ref={layerGroupRef} />
+        {cube.cubelets.map(({ geometry, cell }, index) => (
+          <mesh
+            key={index}
+            ref={(mesh) => {
+              cubeletRefs.current[index] = mesh
+            }}
+            geometry={geometry}
+            material={baseMesh.material as Material}
+            position={[
+              cell[0] * cube.cellSize.x,
+              cell[1] * cube.cellSize.y,
+              cell[2] * cube.cellSize.z
+            ]}
+          >
+            <mesh
+              geometry={cube.fillerGeometry}
+              material={cube.fillerMaterial}
+              raycast={noopRaycast}
+            />
+          </mesh>
+        ))}
+      </group>
+    </group>
+  )
+})

--- a/src/components/rubiks-cube/index.tsx
+++ b/src/components/rubiks-cube/index.tsx
@@ -30,7 +30,7 @@ import {
 import { ANIMATION_CONFIG } from "@/constants/inspectables"
 import { useCursor } from "@/hooks/use-mouse"
 
-import { useRubiksStore } from "./cube-store"
+import { RUBIKS_BEST_TIME_KEY, useRubiksStore } from "./cube-store"
 import { splitCubeGeometry } from "./split-cube-geometry"
 
 const QUARTER = Math.PI / 2
@@ -178,8 +178,34 @@ export const PlayableRubiksCube = memo(function PlayableRubiksCubeInner({
           Math.abs(mesh.position.z - cell[2] * cellSize.z) < 1e-3
         )
       })
-      if (solved && !wasSolvedRef.current) track("rubiks_cube_solved")
+
+      const wasSolved = wasSolvedRef.current
       wasSolvedRef.current = solved
+
+      if (wasSolved && !solved) {
+        // First turn away from solved starts the clock
+        if (useRubiksStore.getState().startedAt === null) {
+          useRubiksStore.setState({ startedAt: Date.now(), solveTime: null })
+        }
+      } else if (!wasSolved && solved) {
+        const { startedAt, bestTime } = useRubiksStore.getState()
+        if (startedAt !== null) {
+          const solveTime = Date.now() - startedAt
+          const best =
+            bestTime === null ? solveTime : Math.min(bestTime, solveTime)
+          useRubiksStore.setState({
+            startedAt: null,
+            solveTime,
+            bestTime: best
+          })
+          try {
+            localStorage.setItem(RUBIKS_BEST_TIME_KEY, String(best))
+          } catch {}
+          track("rubiks_cube_solved", {
+            seconds: Math.round(solveTime / 100) / 10
+          })
+        }
+      }
 
       useRubiksStore.setState({ isTurning: false, solved })
       invalidate()

--- a/src/components/rubiks-cube/index.tsx
+++ b/src/components/rubiks-cube/index.tsx
@@ -142,7 +142,7 @@ export const PlayableRubiksCube = memo(function PlayableRubiksCubeInner({
   const wasSolvedRef = useRef(true)
 
   const bake = useCallback(
-    (quarterTurns: number) => {
+    (quarterTurns: number, isUserMove = true) => {
       const turn = turnRef.current
       const gridRoot = gridRootRef.current
       const layerGroup = layerGroupRef.current
@@ -182,27 +182,37 @@ export const PlayableRubiksCube = memo(function PlayableRubiksCubeInner({
       const wasSolved = wasSolvedRef.current
       wasSolvedRef.current = solved
 
-      if (wasSolved && !solved) {
-        // First turn away from solved starts the clock
-        if (useRubiksStore.getState().startedAt === null) {
-          useRubiksStore.setState({ startedAt: Date.now(), solveTime: null })
-        }
-      } else if (!wasSolved && solved) {
-        const { startedAt, bestTime } = useRubiksStore.getState()
-        if (startedAt !== null) {
-          const solveTime = Date.now() - startedAt
+      if (isUserMove && quarterTurns !== 0) {
+        const state = useRubiksStore.getState()
+        if (!solved) {
+          if (state.startedAt === null) {
+            // First turn of an attempt starts the clock
+            useRubiksStore.setState({
+              startedAt: Date.now(),
+              solveTime: null,
+              moves: 1
+            })
+          } else {
+            useRubiksStore.setState({ moves: state.moves + 1 })
+          }
+        } else if (!wasSolved && state.startedAt !== null) {
+          const solveTime = Date.now() - state.startedAt
           const best =
-            bestTime === null ? solveTime : Math.min(bestTime, solveTime)
+            state.bestTime === null
+              ? solveTime
+              : Math.min(state.bestTime, solveTime)
           useRubiksStore.setState({
             startedAt: null,
             solveTime,
-            bestTime: best
+            bestTime: best,
+            moves: state.moves + 1
           })
           try {
             localStorage.setItem(RUBIKS_BEST_TIME_KEY, String(best))
           } catch {}
           track("rubiks_cube_solved", {
-            seconds: Math.round(solveTime / 100) / 10
+            seconds: Math.round(solveTime / 100) / 10,
+            moves: state.moves + 1
           })
         }
       }
@@ -217,6 +227,7 @@ export const PlayableRubiksCube = memo(function PlayableRubiksCubeInner({
     const gridRoot = gridRootRef.current
     if (!cube || !active || !gridRoot) return
     if (dragRef.current || turnRef.current) return
+    if (useRubiksStore.getState().isScrambling) return
     if (!e.face) return
 
     e.stopPropagation()
@@ -377,19 +388,113 @@ export const PlayableRubiksCube = memo(function PlayableRubiksCubeInner({
     })
   }
 
+  const scrambleCancelRef = useRef(false)
+  const scramblePending = useRubiksStore((state) => state.scramblePending)
+
+  useEffect(() => {
+    if (!scramblePending) return
+    if (!cube || !active || dragRef.current || turnRef.current) {
+      useRubiksStore.setState({ scramblePending: false })
+      return
+    }
+
+    const performTurn = (axis: Vector3, layer: number, direction: number) =>
+      new Promise<void>((resolve) => {
+        const gridRoot = gridRootRef.current
+        const layerGroup = layerGroupRef.current
+        if (!gridRoot || !layerGroup) return resolve()
+
+        const cellAlong = componentAlong(cube.cellSize, axis)
+        for (const mesh of getCubeletMeshes()) {
+          if (
+            Math.round(componentAlong(mesh.position, axis) / cellAlong) ===
+            layer
+          ) {
+            layerGroup.attach(mesh)
+          }
+        }
+        turnRef.current = { axis, angle: 0 }
+        animRef.current = animate(0, direction * QUARTER, {
+          duration: 0.14,
+          ease: "easeInOut",
+          onUpdate: (value) => {
+            if (turnRef.current) turnRef.current.angle = value
+            layerGroup.quaternion.setFromAxisAngle(axis, value)
+            invalidate()
+          },
+          onComplete: () => {
+            animRef.current = null
+            bake(direction, false)
+            resolve()
+          }
+        })
+      })
+
+    const run = async () => {
+      scrambleCancelRef.current = false
+      useRubiksStore.setState({
+        scramblePending: false,
+        isScrambling: true,
+        startedAt: null,
+        solveTime: null,
+        moves: 0
+      })
+      track("rubiks_cube_scrambled")
+
+      const axes = [
+        new Vector3(1, 0, 0),
+        new Vector3(0, 1, 0),
+        new Vector3(0, 0, 1)
+      ]
+      let prev: { axis: number; layer: number; direction: number } | null = null
+      for (let i = 0; i < 14; i++) {
+        if (scrambleCancelRef.current) break
+        let axis = 0
+        let layer = 0
+        let direction = 1
+        do {
+          axis = Math.floor(Math.random() * 3)
+          layer = Math.floor(Math.random() * 3) - 1
+          direction = Math.random() < 0.5 ? -1 : 1
+        } while (
+          // Don't immediately undo the previous turn
+          prev !== null &&
+          prev.axis === axis &&
+          prev.layer === layer &&
+          prev.direction !== direction
+        )
+        prev = { axis, layer, direction }
+        await performTurn(axes[axis], layer, direction)
+      }
+      useRubiksStore.setState({ isScrambling: false })
+    }
+
+    run()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scramblePending])
+
   // If the inspectable closes mid-turn, settle the layer instantly so the
   // cube on the shelf is never left between two states.
   useEffect(() => {
     if (active || !cube) return
 
+    scrambleCancelRef.current = true
     dragRef.current = null
     animRef.current?.stop()
     animRef.current = null
 
     if (turnRef.current) {
-      bake(Math.round(turnRef.current.angle / QUARTER))
+      bake(
+        Math.round(turnRef.current.angle / QUARTER),
+        !useRubiksStore.getState().isScrambling
+      )
     }
-    useRubiksStore.setState({ isCubeDragging: false, isTurning: false })
+    useRubiksStore.setState({
+      isCubeDragging: false,
+      isTurning: false,
+      isScrambling: false,
+      scramblePending: false
+    })
   }, [active, cube, bake])
 
   if (!cube) return null

--- a/src/components/rubiks-cube/split-cube-geometry.ts
+++ b/src/components/rubiks-cube/split-cube-geometry.ts
@@ -1,0 +1,119 @@
+import { Box3, BufferAttribute, BufferGeometry, Vector3 } from "three"
+
+export interface CubeletData {
+  geometry: BufferGeometry
+  /** Grid coordinates, -1 | 0 | 1 per axis */
+  cell: [number, number, number]
+}
+
+export interface SplitCubeResult {
+  cubelets: CubeletData[]
+  /** Size of one grid cell, in the source geometry's local units */
+  cellSize: Vector3
+  /** Center of the source bounding box, in local space */
+  center: Vector3
+}
+
+type TypedArrayConstructor = new (
+  length: number
+) => Float32Array & Record<number, number>
+
+/**
+ * Splits a merged Rubik's cube mesh into per-cubelet geometries by
+ * clustering triangles into a 3x3x3 grid of their centroids. Every
+ * attribute is copied verbatim (uv, lightmap uv, etc.), and each
+ * cubelet is recentered on its cell so the mesh can be placed at
+ * `center + cell * cellSize` and rotated about its own origin.
+ */
+export function splitCubeGeometry(source: BufferGeometry): SplitCubeResult {
+  const geometry = source.index ? source.toNonIndexed() : source
+
+  const position = geometry.getAttribute("position") as BufferAttribute
+  const box = new Box3().setFromBufferAttribute(position)
+  const center = box.getCenter(new Vector3())
+  const cellSize = box.getSize(new Vector3()).divideScalar(3)
+
+  const triangleCount = position.count / 3
+  const buckets = new Map<string, number[]>()
+
+  const centroid = new Vector3()
+  for (let t = 0; t < triangleCount; t++) {
+    centroid.set(0, 0, 0)
+    for (let v = 0; v < 3; v++) {
+      const i = t * 3 + v
+      centroid.x += position.getX(i)
+      centroid.y += position.getY(i)
+      centroid.z += position.getZ(i)
+    }
+    centroid.divideScalar(3)
+
+    const cx = cellIndex(centroid.x, box.min.x, cellSize.x)
+    const cy = cellIndex(centroid.y, box.min.y, cellSize.y)
+    const cz = cellIndex(centroid.z, box.min.z, cellSize.z)
+
+    const key = `${cx},${cy},${cz}`
+    let bucket = buckets.get(key)
+    if (!bucket) {
+      bucket = []
+      buckets.set(key, bucket)
+    }
+    bucket.push(t)
+  }
+
+  const attributeNames = Object.keys(geometry.attributes)
+
+  const cubelets: CubeletData[] = []
+  buckets.forEach((triangles, key) => {
+    const cell = key.split(",").map(Number) as [number, number, number]
+    const cellCenter = new Vector3(
+      center.x + cell[0] * cellSize.x,
+      center.y + cell[1] * cellSize.y,
+      center.z + cell[2] * cellSize.z
+    )
+
+    const cubeletGeometry = new BufferGeometry()
+
+    for (const name of attributeNames) {
+      const attribute = geometry.getAttribute(name) as BufferAttribute
+      const itemSize = attribute.itemSize
+      const ArrayCtor = attribute.array
+        .constructor as unknown as TypedArrayConstructor
+      const array = new ArrayCtor(triangles.length * 3 * itemSize)
+
+      let write = 0
+      for (const t of triangles) {
+        for (let v = 0; v < 3; v++) {
+          const read = (t * 3 + v) * itemSize
+          for (let c = 0; c < itemSize; c++) {
+            array[write++] = attribute.array[read + c]
+          }
+        }
+      }
+
+      if (name === "position") {
+        for (let i = 0; i < array.length; i += 3) {
+          array[i] -= cellCenter.x
+          array[i + 1] -= cellCenter.y
+          array[i + 2] -= cellCenter.z
+        }
+      }
+
+      cubeletGeometry.setAttribute(
+        name,
+        new BufferAttribute(array, itemSize, attribute.normalized)
+      )
+    }
+
+    cubeletGeometry.computeBoundingBox()
+    cubeletGeometry.computeBoundingSphere()
+
+    cubelets.push({ geometry: cubeletGeometry, cell })
+  })
+
+  if (geometry !== source) geometry.dispose()
+
+  return { cubelets, cellSize, center }
+}
+
+const cellIndex = (value: number, min: number, cell: number): number =>
+  Math.max(0, Math.min(2, Math.floor((value - min) / cell))) - 1

--- a/src/components/rubiks-cube/timer.tsx
+++ b/src/components/rubiks-cube/timer.tsx
@@ -28,6 +28,8 @@ export const RubiksTimer = () => {
   const startedAt = useRubiksStore((state) => state.startedAt)
   const solveTime = useRubiksStore((state) => state.solveTime)
   const bestTime = useRubiksStore((state) => state.bestTime)
+  const moves = useRubiksStore((state) => state.moves)
+  const isScrambling = useRubiksStore((state) => state.isScrambling)
   const [now, setNow] = useState(() => Date.now())
 
   useEffect(() => {
@@ -51,22 +53,37 @@ export const RubiksTimer = () => {
     return () => clearInterval(id)
   }, [startedAt])
 
-  if (startedAt === null && solveTime === null && bestTime === null) {
-    return null
-  }
+  const hasRows = startedAt !== null || solveTime !== null || bestTime !== null
 
   return (
-    <div className="flex flex-col border-t border-brand-w1/20">
-      {startedAt !== null ? (
-        <Row
-          label="Your Time"
-          value={formatTime(Math.max(0, now - startedAt))}
-        />
-      ) : solveTime !== null ? (
-        <Row label="Solved In" value={formatTime(solveTime)} />
-      ) : null}
-      {bestTime !== null && (
-        <Row label="Your Best" value={formatTime(bestTime)} />
+    <div className="flex flex-col gap-4">
+      <button
+        className="w-max text-f-p-mobile text-brand-w1 hover:underline disabled:text-brand-g1 disabled:no-underline lg:text-f-p"
+        disabled={isScrambling}
+        onClick={() => useRubiksStore.setState({ scramblePending: true })}
+      >
+        {isScrambling ? "Scrambling..." : "Scramble"}
+      </button>
+      {hasRows && (
+        <div className="flex flex-col border-t border-brand-w1/20">
+          {startedAt !== null ? (
+            <>
+              <Row
+                label="Your Time"
+                value={formatTime(Math.max(0, now - startedAt))}
+              />
+              <Row label="Moves" value={String(moves)} />
+            </>
+          ) : solveTime !== null ? (
+            <>
+              <Row label="Solved In" value={formatTime(solveTime)} />
+              <Row label="Moves" value={String(moves)} />
+            </>
+          ) : null}
+          {bestTime !== null && (
+            <Row label="Your Best" value={formatTime(bestTime)} />
+          )}
+        </div>
       )}
     </div>
   )

--- a/src/components/rubiks-cube/timer.tsx
+++ b/src/components/rubiks-cube/timer.tsx
@@ -1,0 +1,73 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+import { RUBIKS_BEST_TIME_KEY, useRubiksStore } from "./cube-store"
+
+const formatTime = (ms: number): string => {
+  const totalSeconds = ms / 1000
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds - minutes * 60
+  return minutes > 0
+    ? `${minutes}:${seconds.toFixed(1).padStart(4, "0")}`
+    : `${seconds.toFixed(1)}s`
+}
+
+const Row = ({ label, value }: { label: string; value: string }) => (
+  <div className="grid grid-cols-6 gap-2 border-b border-brand-w1/20 pb-1 pt-0.75">
+    <h3 className="col-span-2 text-f-p-mobile text-brand-g1 lg:text-f-p">
+      {label}
+    </h3>
+    <p className="col-span-4 text-f-p-mobile text-brand-w2 lg:text-f-p">
+      {value}
+    </p>
+  </div>
+)
+
+export const RubiksTimer = () => {
+  const startedAt = useRubiksStore((state) => state.startedAt)
+  const solveTime = useRubiksStore((state) => state.solveTime)
+  const bestTime = useRubiksStore((state) => state.bestTime)
+  const [now, setNow] = useState(() => Date.now())
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(RUBIKS_BEST_TIME_KEY)
+      if (stored !== null) {
+        const value = Number(stored)
+        if (Number.isFinite(value) && value > 0) {
+          useRubiksStore.setState((state) => ({
+            bestTime:
+              state.bestTime === null ? value : Math.min(state.bestTime, value)
+          }))
+        }
+      }
+    } catch {}
+  }, [])
+
+  useEffect(() => {
+    if (startedAt === null) return
+    const id = setInterval(() => setNow(Date.now()), 100)
+    return () => clearInterval(id)
+  }, [startedAt])
+
+  if (startedAt === null && solveTime === null && bestTime === null) {
+    return null
+  }
+
+  return (
+    <div className="flex flex-col border-t border-brand-w1/20">
+      {startedAt !== null ? (
+        <Row
+          label="Your Time"
+          value={formatTime(Math.max(0, now - startedAt))}
+        />
+      ) : solveTime !== null ? (
+        <Row label="Solved In" value={formatTime(solveTime)} />
+      ) : null}
+      {bestTime !== null && (
+        <Row label="Your Best" value={formatTime(bestTime)} />
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## What

The Rubik's Cube inspectable in the blog scene (`SM_06_06`) is now actually playable. Click it to inspect as before, then drag on the cube to turn the layer under the pointer — it follows the drag 1:1, springs to a full quarter turn past 45°, and snaps back on an early release. Dragging the background still orbits. Closing the inspectable leaves the cube visibly scrambled on the coffee table (state persists for the session), and solving it back fires a `rubiks_cube_solved` analytics event.

Desktop-only for now — the canvas is `pointer-events-none` on touch devices site-wide; widening that is a possible follow-up.

## How

The cube is a single merged Draco mesh in the shared office GLB, so there are no cubelet nodes to rotate and no source model in the repo. Instead:

- **`rubiks-cube/split-cube-geometry.ts`** splits the merged geometry at runtime (lazily, on first inspect) into 26 cubelet geometries by clustering triangles into the 3×3×3 grid by centroid, copying every vertex attribute so the lightmap UVs survive.
- **`rubiks-cube/index.tsx`** renders the cubelets sharing the original mesh's material instance — the `bakes.tsx` lightmap, the `inspectingFactor` zoom uniform, and the lamp's `lightLampEnabled` toggle all keep working with zero pipeline changes. Handles the gesture (face normal + screen-projected tangent → layer, axis, and direction), the spring snap (`motion` + `ANIMATION_CONFIG`), and a drift-free bake that re-parents the layer and quantizes positions/quaternions to exact grid values after every turn. Black filler cores prevent see-through gaps mid-turn. If the inspectable closes mid-turn, the layer settles instantly.
- **`rubiks-cube/cube-store.ts`** gates the orbit: `InspectableDragger` listens for drags on the canvas DOM element, so a one-line store check in its `onDrag` keeps face-turns and orbiting from fighting.
- **`inspectable.tsx`** mounts the playable cube for `SM_06_06` and lets raycasts through its invisible proxy hit-box while selected.

Note: cubelets must be declarative JSX meshes — R3F v9 drops hits on objects without an `__r3f` instance (`getRootState(hit.object)` in `handleIntersects`), so imperatively-created meshes never receive pointer events.

## Gamification

A speedcube-style timer renders as spec rows in the inspect overlay, right under the "World Record Time: 3.08s" it will never beat:

- **Scramble** button runs 14 fast random quarter turns (input ignored while animating); scramble turns count for nothing
- **Your Time** starts ticking on your first turn of an attempt — from the solved cube or after a scramble
- **Solved In** + **Moves** replace it when the cube is restored to its original state
- **Your Best** persists per browser via localStorage
- `rubiks_cube_solved` carries duration + move count; `rubiks_cube_scrambled` tracks scrambles

## Testing

Verified end-to-end with headless Chromium against `next dev` on `/blog`:

- Cube renders identically pre/post split (stickers, lightmap; no holes mid-turn)
- Turns on multiple faces/axes incl. middle layers; direction matches drag intuition
- Sub-45° release snaps back with no state change; past 45° completes and bakes
- Background drag orbits while a store flag blocks it during face-drags
- ESC close → scrambled cube visible on the shelf; reopen → state persisted
- Repeated turns stay grid-aligned (quantized bake, no drift)
- `tsc` and `eslint` clean (the two pre-existing image-module `tsc` errors on `main` are untouched)

- Timer verified in the same headless run: "Your Time" ticks after the first turn; turning the layer back shows "Solved In 5.3s" + "Your Best 5.3s"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

