### PR TITLE
perf(3d): load map models and bakes in parallel

### DIFF
--- a/src/components/map/bakes.tsx
+++ b/src/components/map/bakes.tsx
@@ -191,17 +191,7 @@ const Bakes = () => {
 
   useEffect(() => {
     markCanvasBootStage("bakes-resolved")
-    setCanRunMainApp(true)
-    const timeout = setTimeout(() => {
-      setMainAppRunning(true)
-    }, 10)
-    const timeout2 = setTimeout(() => (cctvConfig.shouldBakeCCTV = true), 10)
-
-    return () => {
-      clearTimeout(timeout)
-      clearTimeout(timeout2)
-    }
-  }, [setMainAppRunning, setCanRunMainApp])
+  }, [])
 
   const mapMaterialsReady = useMesh((state) => state.mapMaterialsReady)
 
@@ -243,6 +233,17 @@ const Bakes = () => {
       console.warn(
         `[bakes] ${skipped} mesh(es) had no global shader material; their bakes were dropped.`
       )
+    }
+
+    // Both branches gate the reveal: bakes and map models now load in parallel,
+    // so either one can be the laggard.
+    setCanRunMainApp(true)
+    const timeout = setTimeout(() => setMainAppRunning(true), 10)
+    const timeout2 = setTimeout(() => (cctvConfig.shouldBakeCCTV = true), 10)
+
+    return () => {
+      clearTimeout(timeout)
+      clearTimeout(timeout2)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mapMaterialsReady, bakes])

--- a/src/components/map/bakes.tsx
+++ b/src/components/map/bakes.tsx
@@ -235,8 +235,7 @@ const Bakes = () => {
       )
     }
 
-    // Both branches gate the reveal: bakes and map models now load in parallel,
-    // so either one can be the laggard.
+    // Not on mount: bakes can resolve before the models exist.
     setCanRunMainApp(true)
     const timeout = setTimeout(() => setMainAppRunning(true), 10)
     const timeout2 = setTimeout(() => (cctvConfig.shouldBakeCCTV = true), 10)

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -24,10 +24,10 @@ import { Weather } from "@/components/weather"
 import { useCurrentScene } from "@/hooks/use-current-scene"
 import { useMesh } from "@/hooks/use-mesh"
 import { createVideoTextureWithResume } from "@/hooks/use-video-resume"
+import { markCanvasBootStage } from "@/lib/canvas-boot"
 import { createGlobalShaderMaterial } from "@/shaders/material-global-shader"
 import { createNotFoundMaterial } from "@/shaders/material-not-found"
 
-import { BakesLoader } from "./bakes"
 import { extractMeshes } from "./extract-meshes"
 import { useFrameLoop } from "./use-frame-loop"
 import { useLoader } from "./use-loader"
@@ -227,6 +227,7 @@ export const Map = memo(() => {
 
       alreadyTraversed.current = true
 
+      markCanvasBootStage("map-ready")
       useMesh.setState({ mapMaterialsReady: true })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -300,8 +301,6 @@ export const Map = memo(() => {
           />
         )
       })}
-
-      <BakesLoader />
     </group>
   )
 })

--- a/src/components/map/use-loader.ts
+++ b/src/components/map/use-loader.ts
@@ -19,8 +19,6 @@ export const useLoader = () => {
     outdoorCars: outdoorCarsUrl
   } = useAssets()
 
-  // Single array call: one suspension for all seven, so they download in
-  // parallel. Ordered to match the destructuring below.
   const [
     office,
     officeItems,

--- a/src/components/map/use-loader.ts
+++ b/src/components/map/use-loader.ts
@@ -19,15 +19,9 @@ export const useLoader = () => {
     outdoorCars: outdoorCarsUrl
   } = useAssets()
 
-  const { scene: office } = useKTX2GLTF<GLTFResult>(officeUrl)
-  const { scene: officeItems } = useKTX2GLTF<GLTFResult>(officeItemsUrl)
-  const { scene: outdoor } = useKTX2GLTF<GLTFResult>(outdoorUrl)
-  const { scene: godrays } = useKTX2GLTF<GLTFResult>(godraysUrl)
-  const { scene: outdoorCars } = useKTX2GLTF<GLTFResult>(outdoorCarsUrl)
-  const { scene: basketballNet } = useKTX2GLTF<GLTFResult>(basketballNetUrl)
-  const { scene: routingElements } = useKTX2GLTF<GLTFResult>(routingElementsUrl)
-
-  return {
+  // Single array call: one suspension for all seven, so they download in
+  // parallel. Ordered to match the destructuring below.
+  const [
     office,
     officeItems,
     outdoor,
@@ -35,5 +29,23 @@ export const useLoader = () => {
     outdoorCars,
     basketballNet,
     routingElements
+  ] = useKTX2GLTF<GLTFResult>([
+    officeUrl,
+    officeItemsUrl,
+    outdoorUrl,
+    godraysUrl,
+    outdoorCarsUrl,
+    basketballNetUrl,
+    routingElementsUrl
+  ])
+
+  return {
+    office: office.scene,
+    officeItems: officeItems.scene,
+    outdoor: outdoor.scene,
+    godrays: godrays.scene,
+    outdoorCars: outdoorCars.scene,
+    basketballNet: basketballNet.scene,
+    routingElements: routingElements.scene
   }
 }

--- a/src/components/scene/index.tsx
+++ b/src/components/scene/index.tsx
@@ -177,9 +177,7 @@ export const Scene = () => {
                   <Suspense fallback={null}>
                     <Map />
                   </Suspense>
-                  {/* Sibling of <Map/>, not a child: nested, the bake textures
-                      only started downloading once every map model had already
-                      resolved. */}
+                  {/* Sibling, not a child: nested, bakes wait for every model. */}
                   <BakesLoader />
                   <Suspense fallback={null}>
                     <WebGlTunnelOut />

--- a/src/components/scene/index.tsx
+++ b/src/components/scene/index.tsx
@@ -177,7 +177,6 @@ export const Scene = () => {
                   <Suspense fallback={null}>
                     <Map />
                   </Suspense>
-                  {/* Sibling, not a child: nested, bakes wait for every model. */}
                   <BakesLoader />
                   <Suspense fallback={null}>
                     <WebGlTunnelOut />

--- a/src/components/scene/index.tsx
+++ b/src/components/scene/index.tsx
@@ -13,6 +13,7 @@ import { UpdateCanvasCursor } from "@/components/custom-cursor"
 import { Debug } from "@/components/debug"
 import { Inspectables } from "@/components/inspectables/inspectables"
 import { Map } from "@/components/map"
+import { BakesLoader } from "@/components/map/bakes"
 import { useNavigationStore } from "@/components/navigation-handler/navigation-store"
 import { Pets } from "@/components/pets"
 import { Renderer } from "@/components/postprocessing/renderer"
@@ -176,6 +177,10 @@ export const Scene = () => {
                   <Suspense fallback={null}>
                     <Map />
                   </Suspense>
+                  {/* Sibling of <Map/>, not a child: nested, the bake textures
+                      only started downloading once every map model had already
+                      resolved. */}
+                  <BakesLoader />
                   <Suspense fallback={null}>
                     <WebGlTunnelOut />
                   </Suspense>

--- a/src/hooks/use-ktx2-gltf.ts
+++ b/src/hooks/use-ktx2-gltf.ts
@@ -12,9 +12,7 @@ export function useKTX2GLTF<T extends GLTF>(
   draco?: string,
   useCaching?: boolean
 ): T
-// An array batches every url into one `Promise.all`, so they download
-// concurrently. Separate calls suspend one at a time: each url only starts once
-// the previous one resolved, which is a request waterfall.
+// An array is one `Promise.all`; separate calls suspend serially.
 export function useKTX2GLTF<T extends GLTF>(
   paths: string[],
   draco?: string,

--- a/src/hooks/use-ktx2-gltf.ts
+++ b/src/hooks/use-ktx2-gltf.ts
@@ -7,14 +7,27 @@ import { getKTX2Loader } from "./use-ktx2-loader"
 
 type KTX2Capable = { setKTX2Loader: (loader: KTX2Loader) => unknown }
 
-export const useKTX2GLTF = <T extends GLTF>(
+export function useKTX2GLTF<T extends GLTF>(
   path: string,
   draco?: string,
+  useCaching?: boolean
+): T
+// An array batches every url into one `Promise.all`, so they download
+// concurrently. Separate calls suspend one at a time: each url only starts once
+// the previous one resolved, which is a request waterfall.
+export function useKTX2GLTF<T extends GLTF>(
+  paths: string[],
+  draco?: string,
+  useCaching?: boolean
+): T[]
+export function useKTX2GLTF<T extends GLTF>(
+  path: string | string[],
+  draco?: string,
   useCaching = true
-): T => {
+): T | T[] {
   const { gl } = useThree()
 
   return useGLTF(path, draco, useCaching, (loader) => {
     ;(loader as unknown as KTX2Capable).setKTX2Loader(getKTX2Loader(gl))
-  }) as unknown as T
+  }) as unknown as T | T[]
 }

--- a/src/lib/canvas-boot.ts
+++ b/src/lib/canvas-boot.ts
@@ -4,8 +4,7 @@ import { DefaultLoadingManager } from "three"
 // Assumes one boot per page load, which holds because `isCanvasInPage` is
 // sticky and `canRunMainApp` only ever goes false -> true. A retry-boot feature
 // would need this module's one-shot guards (`marks`, `deadlineFired`) revisited.
-// `map-ready` and `bakes-resolved` are concurrent branches, not a sequence —
-// the reveal waits on whichever lands last.
+// map-ready and bakes-resolved are concurrent; the reveal waits for both.
 export type BootStage =
   | "worker-spawned"
   | "scene-chunk"
@@ -66,6 +65,8 @@ const visibleElapsed = () =>
     visibleAccum +
       (visibleSince === null ? 0 : performance.now() - visibleSince)
   )
+
+const toSeconds = (ms: number) => Number((ms / 1000).toFixed(2))
 
 const armDeadline = () => {
   if (deadlineFired || deadlineExpire === null) return
@@ -143,12 +144,12 @@ export const markCanvasBootStage = (stage: BootStage) => {
   if (marks[stage] !== undefined) return
   if (startedAt === 0) startCanvasBootTrace()
 
-  marks[stage] = Math.round(performance.now() - startedAt)
+  marks[stage] = toSeconds(performance.now() - startedAt)
   Sentry.addBreadcrumb({
     category: "canvas.boot",
     message: stage,
     level: "info",
-    data: { atMs: marks[stage] }
+    data: { atSec: marks[stage] }
   })
 }
 
@@ -224,7 +225,7 @@ const assetSnapshot = () => {
     )
   }
 
-  if (entries.length === 0) return { ...base, sinceLastAssetMs: undefined }
+  if (entries.length === 0) return { ...base, sinceLastAssetSec: undefined }
 
   let bytes = 0
   let cached = 0
@@ -243,28 +244,27 @@ const assetSnapshot = () => {
   // number of parallel connections.
   const windowMs = lastResponseEnd - firstStart
 
-  // Flattened to strings because Sentry's normalizeDepth (3) renders anything
-  // nested this deep as "[Object]" — contexts > canvas_boot_assets > slowest.
+  // Strings, not objects: Sentry's normalizeDepth (3) renders those "[Object]".
   const slowest = entries
     .sort((a, b) => b.duration - a.duration)
     .slice(0, 5)
     .map(
       (entry) =>
-        `${Math.round(entry.duration)}ms ${Math.round(entry.transferSize / 1024)}kb ${entry.name.slice(entry.name.indexOf(BOOT_ASSET_PATH))}`
+        `${toSeconds(entry.duration)}s ${Math.round(entry.transferSize / 1024)}kb ${entry.name.slice(entry.name.indexOf(BOOT_ASSET_PATH))}`
     )
 
   return {
     ...base,
     cached,
     totalKb: Math.round(bytes / 1024),
-    windowMs: Math.round(windowMs),
+    windowSec: toSeconds(windowMs),
     // Undefined rather than 0 on a warm cache, where transferSize is 0 for
     // every entry and the number would read as "no bandwidth".
     aggregateMbps:
       bytes > 0 && windowMs > 0
         ? Number(((bytes * 8) / (windowMs * 1000)).toFixed(2))
         : undefined,
-    sinceLastAssetMs: Math.round(performance.now() - lastResponseEnd),
+    sinceLastAssetSec: toSeconds(performance.now() - lastResponseEnd),
     slowest
   }
 }
@@ -273,7 +273,7 @@ const assetSnapshot = () => {
 const stallKind = (assets: ReturnType<typeof assetSnapshot>) => {
   if (assets.outstanding > 0) return "downloading"
   if (assets.completed === 0) return "no-assets"
-  if (assets.sinceLastAssetMs !== undefined && assets.sinceLastAssetMs > 5000) {
+  if (assets.sinceLastAssetSec !== undefined && assets.sinceLastAssetSec > 5) {
     return "post-download"
   }
   return "settling"
@@ -302,7 +302,7 @@ const commonFields = () => {
 export const captureCanvasBootTimeout = (budgetMs: number) => {
   if (startedAt === 0) return
 
-  const elapsedMs = Math.round(performance.now() - startedAt)
+  const elapsedSec = toSeconds(performance.now() - startedAt)
   const { assets, tags, contexts } = commonFields()
 
   Sentry.captureMessage("Canvas boot timed out", {
@@ -318,9 +318,9 @@ export const captureCanvasBootTimeout = (budgetMs: number) => {
       // timeout would otherwise appear to have beaten it.
       canvas_boot: {
         marks: { ...marks },
-        elapsedMs,
-        visibleMs: visibleElapsed(),
-        budgetMs
+        elapsedSec,
+        visibleSec: toSeconds(visibleElapsed()),
+        budgetSec: toSeconds(budgetMs)
       },
       ...contexts
     }
@@ -340,8 +340,8 @@ export const captureCanvasBootRecovery = () => {
     contexts: {
       canvas_boot: {
         marks: { ...marks },
-        elapsedMs: Math.round(performance.now() - startedAt),
-        visibleMs: visibleElapsed()
+        elapsedSec: toSeconds(performance.now() - startedAt),
+        visibleSec: toSeconds(visibleElapsed())
       },
       ...contexts
     }

--- a/src/lib/canvas-boot.ts
+++ b/src/lib/canvas-boot.ts
@@ -4,10 +4,13 @@ import { DefaultLoadingManager } from "three"
 // Assumes one boot per page load, which holds because `isCanvasInPage` is
 // sticky and `canRunMainApp` only ever goes false -> true. A retry-boot feature
 // would need this module's one-shot guards (`marks`, `deadlineFired`) revisited.
+// `map-ready` and `bakes-resolved` are concurrent branches, not a sequence —
+// the reveal waits on whichever lands last.
 export type BootStage =
   | "worker-spawned"
   | "scene-chunk"
   | "offscreen-ready"
+  | "map-ready"
   | "bakes-resolved"
 
 const BOOT_ASSET_PATH = "/3d/"
@@ -240,14 +243,15 @@ const assetSnapshot = () => {
   // number of parallel connections.
   const windowMs = lastResponseEnd - firstStart
 
+  // Flattened to strings because Sentry's normalizeDepth (3) renders anything
+  // nested this deep as "[Object]" — contexts > canvas_boot_assets > slowest.
   const slowest = entries
     .sort((a, b) => b.duration - a.duration)
     .slice(0, 5)
-    .map((entry) => ({
-      url: entry.name.slice(entry.name.indexOf(BOOT_ASSET_PATH)),
-      ms: Math.round(entry.duration),
-      kb: Math.round(entry.transferSize / 1024)
-    }))
+    .map(
+      (entry) =>
+        `${Math.round(entry.duration)}ms ${Math.round(entry.transferSize / 1024)}kb ${entry.name.slice(entry.name.indexOf(BOOT_ASSET_PATH))}`
+    )
 
   return {
     ...base,


### PR DESCRIPTION
## Summary

Follow-up to the [Canvas boot timed out](https://basementstudio-be.sentry.io/issues/7672503706/) diagnostics (#451). Every post-merge event showed the same shape: stalled at `offscreen-ready`, `boot.stall = downloading`, a core map GLB still outstanding. The cause was a loading waterfall, not the worker or the transcoder.

## Changes

- Batch the seven map GLBs into one `useKTX2GLTF` array call. They each had their own call, so React suspended on one url at a time and every model waited for the previous download to finish.
- Move `<BakesLoader/>` to a sibling of `<Map/>`. Nested, the bake textures could not start until every model had resolved.
- Gate the reveal on both branches instead of on bakes alone — running in parallel, bakes can now resolve first.
- Report boot timings in seconds (`*Sec`), and flatten `slowest[]` to strings: Sentry's default `normalizeDepth` of 3 was rendering those entries as `"[Object]"`.

Measured on the production build: all seven GLBs now start within 2ms of each other, and the first bake texture starts before the models instead of after them.

## Checklist

- [x] `pnpm lint` passes
- [x] Production build passes
- [x] Tested locally (scene renders with bakes applied, no console errors)
- [x] No breaking changes