### PR TITLE
fix(cache): bound the lifetime of cached Sanity misses

### DIFF
--- a/src/app/(site)/(canvas)/(content)/blog/sanity.ts
+++ b/src/app/(site)/(canvas)/(content)/blog/sanity.ts
@@ -1,3 +1,5 @@
+import { cacheLife } from "next/cache"
+
 import {
   sanityFetch,
   sanityFetchCached,
@@ -54,10 +56,12 @@ export async function fetchPosts(
       "posts": *[_type == "post" && $category in categories[]->slug.current] | order(date desc) ${postFields},
       "total": count(*[_type == "post" && $category in categories[]->slug.current])
     }`
-    return sanityFetch<{ posts: BlogPost[]; total: number }>({
+    const result = await sanityFetch<{ posts: BlogPost[]; total: number }>({
       query,
       params: { category }
     })
+    if (!result.total) cacheLife("hours")
+    return result
   }
 
   const query = /* groq */ `{

--- a/src/app/(site)/(plain)/(content)/careers/[slug]/page.tsx
+++ b/src/app/(site)/(plain)/(content)/careers/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { cacheLife } from "next/cache"
 import { notFound } from "next/navigation"
 
 import { extractPlainText } from "@/lib/structured-data/extract-text"
@@ -39,7 +40,9 @@ export const generateMetadata = async ({ params }: CareerPostProps) => {
 
 async function getPosition(slug: string) {
   "use cache"
-  return fetchCareerPosition(slug)
+  const position = await fetchCareerPosition(slug)
+  if (!position) cacheLife("hours")
+  return position
 }
 
 export default async function CareerPost({ params }: CareerPostProps) {

--- a/src/app/(site)/(plain)/(content)/careers/[slug]/sanity.ts
+++ b/src/app/(site)/(plain)/(content)/careers/[slug]/sanity.ts
@@ -96,6 +96,7 @@ export async function fetchCareerPositionMeta(
   return sanityFetchCached<{ title: string } | null>({
     query,
     params: { slug },
-    perspective: "published"
+    perspective: "published",
+    boundEmptyResult: true
   })
 }

--- a/src/app/(site)/(plain)/(content)/post/[slug]/page.tsx
+++ b/src/app/(site)/(plain)/(content)/post/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { cacheLife } from "next/cache"
 import { notFound } from "next/navigation"
 
 import { extractPlainText } from "@/lib/structured-data/extract-text"
@@ -47,7 +48,10 @@ async function getPostData(slug: string) {
   "use cache"
   const post = await fetchPostBySlug(slug)
 
-  if (!post) return null
+  if (!post) {
+    cacheLife("hours")
+    return null
+  }
 
   const relatedPosts = await fetchRelatedPosts(
     post.slug,

--- a/src/app/(site)/(plain)/(content)/post/[slug]/sanity.ts
+++ b/src/app/(site)/(plain)/(content)/post/[slug]/sanity.ts
@@ -207,6 +207,7 @@ export async function fetchPostMeta(
   } | null>({
     query,
     params: { slug },
-    perspective: "published"
+    perspective: "published",
+    boundEmptyResult: true
   })
 }

--- a/src/app/(site)/(plain)/(content)/showcase/[slug]/page.tsx
+++ b/src/app/(site)/(plain)/(content)/showcase/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { cacheLife } from "next/cache"
 import { notFound } from "next/navigation"
 
 import { extractPlainText } from "@/lib/structured-data/extract-text"
@@ -41,7 +42,9 @@ export const generateMetadata = async ({ params }: ProjectPostProps) => {
 
 async function getProject(slug: string) {
   "use cache"
-  return fetchProjectBySlug(slug)
+  const project = await fetchProjectBySlug(slug)
+  if (!project) cacheLife("hours")
+  return project
 }
 
 export default async function ProjectPost({ params }: ProjectPostProps) {

--- a/src/app/(site)/(plain)/(content)/showcase/[slug]/sanity.ts
+++ b/src/app/(site)/(plain)/(content)/showcase/[slug]/sanity.ts
@@ -165,7 +165,8 @@ export async function fetchProjectMeta(
   } | null>({
     query: projectMetaQuery,
     params: { slug },
-    perspective: "published"
+    perspective: "published",
+    boundEmptyResult: true
   })
 }
 

--- a/src/app/ai/post/[slug]/page.tsx
+++ b/src/app/ai/post/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import { cacheLife } from "next/cache"
 import { notFound } from "next/navigation"
 
 import {
@@ -40,7 +41,10 @@ async function getPostData(slug: string) {
   "use cache"
   const post = await fetchPostBySlug(slug)
 
-  if (!post) return null
+  if (!post) {
+    cacheLife("hours")
+    return null
+  }
 
   const relatedPosts = await fetchRelatedPosts(
     post.slug,

--- a/src/components/layout/sanity.ts
+++ b/src/components/layout/sanity.ts
@@ -1,3 +1,5 @@
+import { cacheLife } from "next/cache"
+
 import { sanityFetch, sanityFetchCached } from "@/service/sanity"
 import type { PortableTextBlock } from "@/service/sanity/types"
 
@@ -11,6 +13,7 @@ export interface CompanyInfo {
 
 export async function fetchCurrentYear(): Promise<number> {
   "use cache"
+  cacheLife("days")
   return new Date().getFullYear()
 }
 

--- a/src/service/sanity/index.ts
+++ b/src/service/sanity/index.ts
@@ -1,3 +1,4 @@
+import { cacheLife } from "next/cache"
 import { draftMode } from "next/headers"
 import type { QueryParams } from "next-sanity"
 
@@ -49,9 +50,12 @@ export async function sanityFetchCached<T>(opts: {
   query: string
   params?: QueryParams
   perspective?: Perspective
+  boundEmptyResult?: boolean
 }): Promise<T> {
   "use cache"
-  return sanityFetch<T>(opts)
+  const data = await sanityFetch<T>(opts)
+  if (opts.boundEmptyResult && data == null) cacheLife("hours")
+  return data
 }
 
 /**


### PR DESCRIPTION
## Summary

Cached Sanity reads keyed on a URL segment remembered a **miss** for a year. They set no `cacheLife`, so they inherit the `default` profile — which `next.config.ts` overrides with next-sanity's `sanity` profile (`revalidate: 31536000`). A year is right for a document that exists, since publishes arrive by webhook; it's wrong for a `null`, which has no document to publish and therefore no event that ever clears it. `/showcase/<anything>` minted year-lived entries.

Fix: `cacheLife("hours")` on the negative branch only. Hits are untouched.

Second commit, same cause — `fetchCurrentYear` is an *untagged* scope, so no publish could clear it and the footer year stayed frozen until the next deploy. `cacheLife("days")` fixes that and, because it reaches the root layout, prices every site route at 1d/1w. Deliberate.

Same config as basementstudio/greylock#159.

## Changes

- `cacheLife("hours")` on the miss path of `getProject`, `getPosition` and both `getPostData` scopes.
- `fetchPosts(category)` guards on `!result.total` — an unknown category returns an empty result, not `null`.
- `sanityFetchCached` gained `boundEmptyResult` for the three `*Meta` fetchers, whose cache boundary is the shared helper rather than the fetcher.
- `cacheLife("days")` on `fetchCurrentYear`.

## Verification

`next start`, pristine baseline vs this branch:

| | before | after |
|---|---|---|
| site pages | `s-maxage=31536000` | `s-maxage=86400, swr=518400` |
| `/{showcase,post,careers}/<junk>`, `/blog/<junk>` | `s-maxage=31536000` | `s-maxage=3600, swr=82800` |

`hours` stays tighter than the `days` floor, so the guards still bite. With the footer commit reverted the route table is byte-identical to baseline. No regression test — the repo has no test runner.

## Checklist

- [x] `pnpm lint` passes — exit 0; only prettier nits in generated files.
- [ ] Tested locally in dev mode — used a production build with `next start`, which is what cache behaviour requires.
- [x] No breaking changes (or documented in summary)
