### PR TITLE
perf(inp): cut tap-time re-renders, pause hidden canvas, push routes immediately

### DIFF
--- a/src/app/(site)/(canvas)/(content)/people/crew.tsx
+++ b/src/app/(site)/(canvas)/(content)/people/crew.tsx
@@ -282,9 +282,6 @@ export const Face = ({
   setHoveredPerson,
   hoveredPerson
 }: FaceProps) => (
-  // A CSS opacity transition instead of motion.div: ~40 of these mount inside
-  // the tap-driven route commit, and each motion instance constructs
-  // MotionValues + an animation even when the container is display:none.
   <div
     key={person.title}
     className="with-dots group relative aspect-[83/96] bg-brand-k text-brand-w1/20 transition-opacity duration-200 ease-in-out lg:aspect-[136/156]"

--- a/src/app/(site)/(canvas)/(content)/people/crew.tsx
+++ b/src/app/(site)/(canvas)/(content)/people/crew.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { motion } from "motion/react"
 import Image from "next/image"
 import {
   Fragment,
@@ -283,15 +282,17 @@ export const Face = ({
   setHoveredPerson,
   hoveredPerson
 }: FaceProps) => (
-  <motion.div
+  // A CSS opacity transition instead of motion.div: ~40 of these mount inside
+  // the tap-driven route commit, and each motion instance constructs
+  // MotionValues + an animation even when the container is display:none.
+  <div
     key={person.title}
-    className="with-dots group relative aspect-[83/96] bg-brand-k text-brand-w1/20 lg:aspect-[136/156]"
-    onMouseEnter={() => setHoveredPerson(person.title)}
-    onMouseLeave={() => setHoveredPerson(null)}
-    animate={{
+    className="with-dots group relative aspect-[83/96] bg-brand-k text-brand-w1/20 transition-opacity duration-200 ease-in-out lg:aspect-[136/156]"
+    style={{
       opacity: hoveredPerson ? (hoveredPerson === person.title ? 1 : 0.5) : 1
     }}
-    transition={{ duration: 0.2, ease: "easeInOut" }}
+    onMouseEnter={() => setHoveredPerson(person.title)}
+    onMouseLeave={() => setHoveredPerson(null)}
   >
     <div className="after:pointer-events-none after:absolute after:inset-0 after:border after:border-brand-w1/20">
       {person.image ? (
@@ -312,7 +313,7 @@ export const Face = ({
         { "opacity-100": hoveredPerson === person.title }
       )}
     />
-  </motion.div>
+  </div>
 )
 
 interface CrewFooterProps {

--- a/src/app/(site)/(canvas)/(content)/showcase/grid.tsx
+++ b/src/app/(site)/(canvas)/(content)/showcase/grid.tsx
@@ -47,58 +47,76 @@ const MobileInfo = memo(({ project }: { project: ShowcaseProject }) => {
 })
 MobileInfo.displayName = "MobileInfo"
 
+const GridCard = memo(
+  ({
+    project,
+    disabled,
+    isMobile
+  }: {
+    project: ShowcaseProject
+    disabled: boolean
+    isMobile: boolean | undefined
+  }) => {
+    const image = toImageFragment(project.cover)
+    return (
+      <article
+        className={cn(
+          "contain-paint relative col-span-full flex flex-col gap-y-2 lg:col-span-3 lg:gap-y-0"
+        )}
+      >
+        <div
+          className={cn(
+            "group relative aspect-video max-w-[100%] will-change-[opacity,transform] after:pointer-events-none after:absolute after:inset-0 after:border after:border-brand-w1/20 after:transition-colors after:duration-300 hover:will-change-auto lg:h-full",
+            disabled && "after:border-brand-g1/20"
+          )}
+        >
+          <Link
+            disabled={disabled}
+            href={`/showcase/${project.slug}`}
+            className={cn(
+              "with-dots block h-full w-full cursor-pointer opacity-100 transition-opacity duration-300 focus-visible:!ring-offset-0",
+              disabled && "pointer-events-none cursor-default opacity-10"
+            )}
+            aria-label={`View ${project.title ?? "Untitled"}`}
+          >
+            {image ? (
+              <ImageWithVideoOverlay
+                image={image}
+                video={resolveVideoSource({
+                  mux: project.muxCoverVideo,
+                  legacy: project.coverVideo
+                })}
+                variant="showcase"
+              />
+            ) : null}
+          </Link>
+        </div>
+
+        {isMobile && <MobileInfo project={project} />}
+      </article>
+    )
+  }
+)
+GridCard.displayName = "GridCard"
+
 interface GridProps {
   projects: ShowcaseProject[]
-  isProjectDisabled: (project: ShowcaseProject) => boolean
+  disabledSlugs: Set<string> | null
 }
 
-export const Grid = memo(({ projects, isProjectDisabled }: GridProps) => {
+export const Grid = memo(({ projects, disabledSlugs }: GridProps) => {
   const isMobile = useMedia("(max-width: 1024px)")
 
   return (
     <div className="grid-layout contain-layout !gap-y-8 lg:!gap-y-3">
-      {projects.map((item, index) => {
-        const image = toImageFragment(item.cover)
-        return (
-          <article
-            key={item.title + index}
-            className={cn(
-              "contain-paint relative col-span-full flex flex-col gap-y-2 lg:col-span-3 lg:gap-y-0"
-            )}
-          >
-            <div
-              className={cn(
-                "group relative aspect-video max-w-[100%] will-change-[opacity,transform] after:pointer-events-none after:absolute after:inset-0 after:border after:border-brand-w1/20 after:transition-colors after:duration-300 hover:will-change-auto lg:h-full",
-                isProjectDisabled(item) && "after:border-brand-g1/20"
-              )}
-            >
-              <Link
-                disabled={isProjectDisabled(item)}
-                href={`/showcase/${item.slug}`}
-                className={cn(
-                  "with-dots block h-full w-full cursor-pointer opacity-100 transition-opacity duration-300 focus-visible:!ring-offset-0",
-                  isProjectDisabled(item) &&
-                    "pointer-events-none cursor-default opacity-10"
-                )}
-                aria-label={`View ${item.title ?? "Untitled"}`}
-              >
-                {image ? (
-                  <ImageWithVideoOverlay
-                    image={image}
-                    video={resolveVideoSource({
-                      mux: item.muxCoverVideo,
-                      legacy: item.coverVideo
-                    })}
-                    variant="showcase"
-                  />
-                ) : null}
-              </Link>
-            </div>
-
-            {isMobile && <MobileInfo project={item} />}
-          </article>
-        )
-      })}
+      {projects.map((item, index) => (
+        <GridCard
+          key={item.title + index}
+          project={item}
+          disabled={disabledSlugs?.has(item.slug) ?? false}
+          isMobile={isMobile}
+        />
+      ))}
     </div>
   )
 })

--- a/src/app/(site)/(canvas)/(content)/showcase/list.tsx
+++ b/src/app/(site)/(canvas)/(content)/showcase/list.tsx
@@ -189,10 +189,10 @@ AccordionListItem.displayName = "AccordionListItem"
 export const List = memo(
   ({
     projects,
-    isProjectDisabled
+    disabledSlugs
   }: {
     projects: ShowcaseProject[]
-    isProjectDisabled: (project: ShowcaseProject) => boolean
+    disabledSlugs: Set<string> | null
   }) => {
     const [itemOpen, setItemOpen] = useState<string>()
 
@@ -214,7 +214,7 @@ export const List = memo(
             key={item.title + index}
             project={item}
             index={index}
-            disabled={isProjectDisabled(item)}
+            disabled={disabledSlugs?.has(item.slug) ?? false}
           />
         ))}
       </AccordionPrimitive.Root>

--- a/src/app/(site)/(canvas)/(content)/showcase/showcase-list/client.tsx
+++ b/src/app/(site)/(canvas)/(content)/showcase/showcase-list/client.tsx
@@ -65,9 +65,6 @@ export const ShowcaseListClient = memo<ShowcaseListClientProps>(
       searchParams.get("category") || null
     )
 
-    // A slug set instead of a predicate + cloned project list: stable project
-    // identities let the memoized cards skip re-rendering on filter taps
-    // unless their own disabled state flips.
     const disabledSlugs = useMemo(() => {
       if (selectedCategory === null) return null
       return new Set(

--- a/src/app/(site)/(canvas)/(content)/showcase/showcase-list/client.tsx
+++ b/src/app/(site)/(canvas)/(content)/showcase/showcase-list/client.tsx
@@ -18,16 +18,16 @@ const ViewModeSelector = memo(
   ({
     viewMode,
     projects,
-    isProjectDisabled
+    disabledSlugs
   }: {
     viewMode: "grid" | "rows"
     projects: ShowcaseProject[]
-    isProjectDisabled: (project: ShowcaseProject) => boolean
+    disabledSlugs: Set<string> | null
   }) => {
     return viewMode === "grid" ? (
-      <Grid projects={projects} isProjectDisabled={isProjectDisabled} />
+      <Grid projects={projects} disabledSlugs={disabledSlugs} />
     ) : (
-      <List projects={projects} isProjectDisabled={isProjectDisabled} />
+      <List projects={projects} disabledSlugs={disabledSlugs} />
     )
   }
 )
@@ -65,15 +65,22 @@ export const ShowcaseListClient = memo<ShowcaseListClientProps>(
       searchParams.get("category") || null
     )
 
-    const isProjectDisabled = useCallback(
-      (project: ShowcaseProject) => {
-        if (selectedCategory === null) return false
-        return !project?.categories?.some(
-          (category) => selectedCategory === category.title
-        )
-      },
-      [selectedCategory]
-    )
+    // A slug set instead of a predicate + cloned project list: stable project
+    // identities let the memoized cards skip re-rendering on filter taps
+    // unless their own disabled state flips.
+    const disabledSlugs = useMemo(() => {
+      if (selectedCategory === null) return null
+      return new Set(
+        projects
+          .filter(
+            (project) =>
+              !project?.categories?.some(
+                (category) => selectedCategory === category.title
+              )
+          )
+          .map((project) => project.slug)
+      )
+    }, [projects, selectedCategory])
 
     const categories = useMemo(() => {
       const categoryMap = new Map<string, number>()
@@ -98,17 +105,6 @@ export const ShowcaseListClient = memo<ShowcaseListClientProps>(
         )
         .sort((a, b) => b.count - a.count)
     }, [projects])
-
-    const filteredProjects = useMemo(() => {
-      return selectedCategory === null
-        ? projects
-        : projects.map((project) => ({
-            ...project,
-            disabled: !project?.categories?.some(
-              (category) => selectedCategory === category.title
-            )
-          }))
-    }, [projects, selectedCategory])
 
     const handleSetSelectedCategory = useCallback((category: string | null) => {
       setSelectedCategory(category)
@@ -136,8 +132,8 @@ export const ShowcaseListClient = memo<ShowcaseListClientProps>(
 
         <ViewModeSelector
           viewMode={viewMode}
-          projects={filteredProjects}
-          isProjectDisabled={isProjectDisabled}
+          projects={projects}
+          disabledSlugs={disabledSlugs}
         />
       </section>
     )

--- a/src/components/camera/camera-hooks.tsx
+++ b/src/components/camera/camera-hooks.tsx
@@ -179,6 +179,9 @@ export const useCameraMovement = (
 
   const newDelta = useMemo(() => new THREE.Vector3(), [])
   const newLookAtDelta = useMemo(() => new THREE.Vector3(), [])
+  const finalPos = useMemo(() => new THREE.Vector3(), [])
+  const finalLookAt = useMemo(() => new THREE.Vector3(), [])
+  const lastAppliedFov = useRef<number | null>(null)
 
   const progress = useRef(1)
   const isTransitioning = useRef(false)
@@ -303,13 +306,19 @@ export const useCameraMovement = (
     }
 
     if (cameraRef.current) {
-      const finalPos = currentPos.clone().add(panTargetDelta)
-      const finalLookAt = currentTarget.clone().add(panLookAtDelta)
+      finalPos.copy(currentPos).add(panTargetDelta)
+      finalLookAt.copy(currentTarget).add(panLookAtDelta)
 
       cameraRef.current.position.copy(finalPos)
       cameraRef.current.lookAt(finalLookAt)
       cameraRef.current.fov = currentFov.current
-      cameraRef.current.updateProjectionMatrix()
+      // lookAt only writes the world matrix; the projection matrix depends on
+      // fov alone here (R3F handles aspect on resize), so skip the rebuild
+      // unless fov moved.
+      if (lastAppliedFov.current !== currentFov.current) {
+        cameraRef.current.updateProjectionMatrix()
+        lastAppliedFov.current = currentFov.current
+      }
 
       if (loadingCanvasWorker) {
         loadingCanvasWorker.postMessage({

--- a/src/components/loading/loading-canvas.tsx
+++ b/src/components/loading/loading-canvas.tsx
@@ -108,6 +108,9 @@ function LoadingCanvas({ hide }: { hide: boolean }) {
 
     return () => {
       worker.terminate()
+      // Drop the handle so per-frame senders (useCameraMovement) stop
+      // structured-cloning camera updates to a dead worker.
+      useAppLoadingStore.setState({ worker: null })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])

--- a/src/components/loading/loading-canvas.tsx
+++ b/src/components/loading/loading-canvas.tsx
@@ -108,8 +108,6 @@ function LoadingCanvas({ hide }: { hide: boolean }) {
 
     return () => {
       worker.terminate()
-      // Drop the handle so per-frame senders (useCameraMovement) stop
-      // structured-cloning camera updates to a dead worker.
       useAppLoadingStore.setState({ worker: null })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -72,9 +72,6 @@ export const Map = memo(() => {
   useFrameLoop()
 
   const scene = useCurrentScene()
-  // Tabs identity is stable per scene object, so Map re-renders only when the
-  // scene actually changes — the previous effect re-traversed the whole
-  // routing graph and double-committed (setState) on every navigation.
   const tabs = useNavigationStore((state) => state.currentScene?.tabs)
 
   const routingMeshes = useMemo(() => {

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import dynamic from "next/dynamic"
-import { memo, Suspense, useEffect, useRef, useState } from "react"
+import { memo, Suspense, useEffect, useMemo, useRef } from "react"
 import { Mesh, MeshStandardMaterial, Object3D } from "three"
 import * as THREE from "three"
 
@@ -72,26 +72,20 @@ export const Map = memo(() => {
   useFrameLoop()
 
   const scene = useCurrentScene()
-  const currentScene = useNavigationStore((state) => state.currentScene)
+  // Tabs identity is stable per scene object, so Map re-renders only when the
+  // scene actually changes — the previous effect re-traversed the whole
+  // routing graph and double-committed (setState) on every navigation.
+  const tabs = useNavigationStore((state) => state.currentScene?.tabs)
 
-  const [routingNodes, setRoutingNodes] = useState<Record<string, Mesh>>({})
-
-  useEffect(() => {
-    const routingNodes: Record<string, Mesh> = {}
+  const routingMeshes = useMemo(() => {
+    const meshes: Record<string, Mesh> = {}
     routingElements?.traverse((child) => {
       if (child instanceof Mesh) {
-        const matchingTab = currentScene?.tabs?.find(
-          (tab) => child.name === tab.tabClickableName
-        )
-
-        if (matchingTab) {
-          routingNodes[matchingTab.tabClickableName] = child
-        }
+        meshes[child.name] = child
       }
     })
-
-    setRoutingNodes(routingNodes)
-  }, [currentScene, routingElements])
+    return meshes
+  }, [routingElements])
 
   const alreadyTraversed = useRef(false)
 
@@ -297,10 +291,9 @@ export const Map = memo(() => {
       <Net />
 
       {/* Routing */}
-      {Object.values(routingNodes).map((node) => {
-        const matchingTab = currentScene?.tabs?.find(
-          (tab) => tab.tabClickableName === node.name
-        )
+      {tabs?.map((tab) => {
+        const node = routingMeshes[tab.tabClickableName]
+        if (!node) return null
 
         const isLabGroup =
           node.name === "LaboratoryHome_HoverA" ||
@@ -311,8 +304,8 @@ export const Map = memo(() => {
           <RoutingElement
             key={node.name}
             node={node}
-            route={matchingTab?.tabRoute ?? ""}
-            hoverName={matchingTab?.tabHoverName ?? node.name}
+            route={tab.tabRoute ?? ""}
+            hoverName={tab.tabHoverName ?? node.name}
             groupName={groupName}
           />
         )

--- a/src/components/primitives/image-with-video-overlay.tsx
+++ b/src/components/primitives/image-with-video-overlay.tsx
@@ -46,9 +46,6 @@ export const ImageWithVideoOverlay = ({
   }, [])
 
   const handleMouseEnter = () => {
-    // Touch devices get the synthetic mouseenter on tap; checked here instead
-    // of useDeviceDetect in the render path, whose post-hydration state flip
-    // re-rendered every card on the page.
     if (window.matchMedia("(hover: none)").matches) return
 
     setShouldLoadVideo(true)

--- a/src/components/primitives/image-with-video-overlay.tsx
+++ b/src/components/primitives/image-with-video-overlay.tsx
@@ -4,7 +4,6 @@ import dynamic from "next/dynamic"
 import Image from "next/image"
 import { useEffect, useRef, useState } from "react"
 
-import { useDeviceDetect } from "@/hooks/use-device-detect"
 import type { ResolvedVideoSource } from "@/lib/video/resolve-source"
 import { cn } from "@/utils/cn"
 
@@ -39,7 +38,6 @@ export const ImageWithVideoOverlay = ({
   const [shouldLoadVideo, setShouldLoadVideo] = useState(false)
   const videoRef = useRef<HTMLVideoElement>(null)
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
-  const { isMobile } = useDeviceDetect()
 
   useEffect(() => {
     return () => {
@@ -48,6 +46,11 @@ export const ImageWithVideoOverlay = ({
   }, [])
 
   const handleMouseEnter = () => {
+    // Touch devices get the synthetic mouseenter on tap; checked here instead
+    // of useDeviceDetect in the render path, whose post-hydration state flip
+    // re-rendered every card on the page.
+    if (window.matchMedia("(hover: none)").matches) return
+
     setShouldLoadVideo(true)
     timeoutRef.current = setTimeout(() => {
       videoRef.current?.play().catch(() => {})
@@ -85,7 +88,7 @@ export const ImageWithVideoOverlay = ({
         className="h-full w-full object-cover group-hover:animate-subtle-pulse"
         priority={false}
       />
-      {video && shouldLoadVideo && !isMobile ? (
+      {video && shouldLoadVideo ? (
         <div className="pointer-events-none absolute inset-0 h-full w-full opacity-0 transition-opacity duration-200 group-hover:opacity-100">
           {video.type === "mux" ? (
             <Video

--- a/src/components/primitives/link.tsx
+++ b/src/components/primitives/link.tsx
@@ -79,7 +79,11 @@ export const Link = ({
         }
         onClick?.()
       }}
-      onMouseEnter={handleMouseEnter}
+      onPointerEnter={(e) => {
+        // Mobile taps fire a synthetic mouseenter inside the measured
+        // interaction, so hover prefetch is limited to actual mice.
+        if (e.pointerType === "mouse") handleMouseEnter()
+      }}
       className={className}
       {...rest}
     >

--- a/src/components/primitives/link.tsx
+++ b/src/components/primitives/link.tsx
@@ -80,8 +80,6 @@ export const Link = ({
         onClick?.()
       }}
       onPointerEnter={(e) => {
-        // Mobile taps fire a synthetic mouseenter inside the measured
-        // interaction, so hover prefetch is limited to actual mice.
         if (e.pointerType === "mouse") handleMouseEnter()
       }}
       className={className}

--- a/src/components/routing-element/routing-element.tsx
+++ b/src/components/routing-element/routing-element.tsx
@@ -61,14 +61,22 @@ const RoutingElementComponent = ({
   const pathname = usePathname()
   const setCursor = useCursor("default")
 
-  const {
-    currentTabIndex,
-    isCanvasTabMode,
-    currentScene,
-    scenes,
-    setCurrentTabIndex,
-    setEnteredByKeyboard
-  } = useNavigationStore()
+  // One derived boolean per hotspot: subscribing to the raw fields (or the
+  // whole store) re-rendered every hotspot on each navigation-store write,
+  // including the setCurrentScene that runs inside a tap. `scenes` is only
+  // read at keydown time, via getState().
+  const isFocusedTab = useNavigationStore(
+    (state) =>
+      state.isCanvasTabMode &&
+      state.currentScene?.tabs?.[state.currentTabIndex]?.tabClickableName ===
+        node.name
+  )
+  const setCurrentTabIndex = useNavigationStore(
+    (state) => state.setCurrentTabIndex
+  )
+  const setEnteredByKeyboard = useNavigationStore(
+    (state) => state.setEnteredByKeyboard
+  )
   const { handleNavigation } = useHandleNavigation()
   const { selected } = useInspectable()
 
@@ -115,6 +123,8 @@ const RoutingElementComponent = ({
 
   const handleKeyPress = useCallback(
     (event: KeyboardEvent) => {
+      const { scenes } = useNavigationStore.getState()
+
       if (event.key === "Enter" && scenes) {
         const trimmedPathname = pathname.replace("/", "")
         const tabIndex = scenes[0].tabs.findIndex(
@@ -128,14 +138,7 @@ const RoutingElementComponent = ({
         }
       }
     },
-    [
-      navigate,
-      pathname,
-      route,
-      scenes,
-      setCurrentTabIndex,
-      setEnteredByKeyboard
-    ]
+    [navigate, pathname, route, setCurrentTabIndex, setEnteredByKeyboard]
   )
 
   const handlePointerEnter = useCallback(
@@ -184,40 +187,24 @@ const RoutingElementComponent = ({
 
   useEffect(() => {
     if (activeRoute) setHover(false)
-    if (!isCanvasTabMode || !currentScene?.tabs) {
+    if (!isFocusedTab) {
       setHover(false)
       setCursor("default", null)
       return
     }
 
-    const currentTab = currentScene.tabs[currentTabIndex]
-    if (currentTab && currentTab.tabClickableName === node.name) {
-      setHover(true)
-      router.prefetch(route)
-      setCursor("pointer", hoverName)
+    setHover(true)
+    router.prefetch(route)
+    setCursor("pointer", hoverName)
 
-      window.addEventListener("keydown", handleKeyPress, { passive: true })
+    window.addEventListener("keydown", handleKeyPress, { passive: true })
 
-      return () => {
-        window.removeEventListener("keydown", handleKeyPress)
-        setCursor("default", null)
-      }
-    } else {
-      setHover(false)
+    return () => {
+      window.removeEventListener("keydown", handleKeyPress)
       setCursor("default", null)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    activeRoute,
-    isCanvasTabMode,
-    currentScene?.tabs,
-    currentTabIndex,
-    node.name,
-    hoverName,
-    route,
-    router,
-    handleKeyPress
-  ])
+  }, [activeRoute, isFocusedTab, hoverName, route, router, handleKeyPress])
 
   useEffect(() => {
     if (!groupName || !groupHoverHandlers) return

--- a/src/components/scene/index.tsx
+++ b/src/components/scene/index.tsx
@@ -57,9 +57,6 @@ export const Scene = () => {
   const setIsCanvasTabMode = useNavigationStore(
     (state) => state.setIsCanvasTabMode
   )
-  // Derived booleans instead of the currentScene object: setCurrentScene runs
-  // synchronously inside the navigation tap, and an object-identity
-  // subscription here reconciled the whole Canvas subtree in that interaction.
   const isBasketball = useNavigationStore(
     (state) => state.currentScene?.name === "basketball"
   )

--- a/src/components/scene/index.tsx
+++ b/src/components/scene/index.tsx
@@ -20,7 +20,6 @@ import { Renderer } from "@/components/postprocessing/renderer"
 import { AnimationController } from "@/components/shared/AnimationController"
 import { Sparkles } from "@/components/sparkles"
 import { WebGlTunnelOut } from "@/components/tunnel"
-import { useCurrentScene } from "@/hooks/use-current-scene"
 import { useTabKeyHandler } from "@/hooks/use-key-press"
 import { useMinigameStore } from "@/store/minigame-store"
 import { cn } from "@/utils/cn"
@@ -58,9 +57,17 @@ export const Scene = () => {
   const setIsCanvasTabMode = useNavigationStore(
     (state) => state.setIsCanvasTabMode
   )
-  const currentScene = useNavigationStore((state) => state.currentScene)
+  // Derived booleans instead of the currentScene object: setCurrentScene runs
+  // synchronously inside the navigation tap, and an object-identity
+  // subscription here reconciled the whole Canvas subtree in that interaction.
+  const isBasketball = useNavigationStore(
+    (state) => state.currentScene?.name === "basketball"
+  )
+  const isFullHeightScene = useNavigationStore((state) => {
+    const name = state.currentScene?.name
+    return name === "basketball" || name === "lab" || name === "404"
+  })
   const canvasRef = useRef<HTMLCanvasElement>(null)
-  const isBasketball = currentScene?.name === "basketball"
   const clearPlayedBalls = useMinigameStore((state) => state.clearPlayedBalls)
   const userHasLeftWindow = useRef(false)
   const [isTouchOnly, setIsTouchOnly] = useState(false)
@@ -70,8 +77,6 @@ export const Scene = () => {
   const [dpr, setDpr] = useState<number | [number, number]>(() =>
     typeof window !== "undefined" && window.innerWidth < 1024 ? 1 : [1, 2]
   )
-  const scene = useCurrentScene()
-
   useTabKeyHandler()
 
   useEffect(() => {
@@ -145,8 +150,7 @@ export const Scene = () => {
       <div
         className={cn(
           "absolute inset-0",
-          (scene === "basketball" || scene === "lab" || scene === "404") &&
-            "inset-x-0 top-0 h-[100svh]"
+          isFullHeightScene && "inset-x-0 top-0 h-[100svh]"
         )}
       >
         <Debug />

--- a/src/components/shared/AnimationController.tsx
+++ b/src/components/shared/AnimationController.tsx
@@ -68,14 +68,8 @@ function AnimationControllerImpl({
   // subscribers (uTime writes over all materials, skinning, …) for frames
   // nobody sees — the loading animation lives on the worker canvas, not here.
   const canRunMainApp = useAppLoadingStore((state) => state.canRunMainApp)
-  // Plain-group routes (/post/*, /careers/*, /showcase/*) hide the canvas
-  // container with CSS but keep the Scene mounted for the WebGL context —
-  // without this term the full office kept rendering at 60fps under the page.
   const canvasVisible = useAppLoadingStore((state) => state.canvasVisible)
 
-  // Both hidden-canvas and scrolled-away pauses share the transition carve-out:
-  // during a navigation the camera must snap to the new scene while still
-  // hidden, or the reveal shows one stale frame of the previous scene.
   const isPaused =
     paused ||
     !canRunMainApp ||

--- a/src/components/shared/AnimationController.tsx
+++ b/src/components/shared/AnimationController.tsx
@@ -68,12 +68,19 @@ function AnimationControllerImpl({
   // subscribers (uTime writes over all materials, skinning, …) for frames
   // nobody sees — the loading animation lives on the worker canvas, not here.
   const canRunMainApp = useAppLoadingStore((state) => state.canRunMainApp)
+  // Plain-group routes (/post/*, /careers/*, /showcase/*) hide the canvas
+  // container with CSS but keep the Scene mounted for the WebGL context —
+  // without this term the full office kept rendering at 60fps under the page.
+  const canvasVisible = useAppLoadingStore((state) => state.canvasVisible)
 
+  // Both hidden-canvas and scrolled-away pauses share the transition carve-out:
+  // during a navigation the camera must snap to the new scene while still
+  // hidden, or the reveal shows one stale frame of the previous scene.
   const isPaused =
     paused ||
     !canRunMainApp ||
     (pauseOnTabChange && !isTabVisible) ||
-    (isScrollPaused && !disableCameraTransition)
+    ((isScrollPaused || !canvasVisible) && !disableCameraTransition)
 
   // Use refs for internal values that don't need to trigger re-renders
   const timeValuesRef = useRef({ time: 0, delta: 0 })
@@ -91,18 +98,30 @@ function AnimationControllerImpl({
   }, [pauseOnTabChange])
 
   useEffect(() => {
+    // The canvas is 80svh on mobile (100svh on desktop), so compare against
+    // its real height — an innerHeight threshold kept rendering a fully
+    // off-screen scene for the last 20% of the first mobile viewport. The
+    // height is cached via ResizeObserver: reading clientHeight inside the
+    // scroll handler forced a layout per scroll tick.
+    let canvasHeight = gl.domElement.clientHeight || window.innerHeight
+
+    const observer = new ResizeObserver(() => {
+      canvasHeight = gl.domElement.clientHeight || window.innerHeight
+      handleScroll()
+    })
+    observer.observe(gl.domElement)
+
     const handleScroll = () => {
-      // The canvas is 80svh on mobile (100svh on desktop), so compare against
-      // its real height — an innerHeight threshold kept rendering a fully
-      // off-screen scene for the last 20% of the first mobile viewport.
-      const canvasHeight = gl.domElement.clientHeight || window.innerHeight
       setIsScrollPaused(window.scrollY > canvasHeight)
     }
 
     window.addEventListener("scroll", handleScroll, { passive: true })
     handleScroll()
 
-    return () => window.removeEventListener("scroll", handleScroll)
+    return () => {
+      observer.disconnect()
+      window.removeEventListener("scroll", handleScroll)
+    }
   }, [gl])
 
   // Current time values exposed through context (memoized)

--- a/src/hooks/use-handle-navigation.ts
+++ b/src/hooks/use-handle-navigation.ts
@@ -26,9 +26,6 @@ const handleTransitionEffectOff = (fromMobileNav?: boolean) => {
   }
 }
 
-// Store values are read via getState() at call time instead of subscriptions:
-// this hook is instantiated by every <Link> (~80 on /people), so each
-// subscription here multiplies across the whole page.
 export const useHandleNavigation = () => {
   const { disableScroll, enableScroll } = useScrollControl()
   const router = useRouter()
@@ -74,9 +71,6 @@ export const useHandleNavigation = () => {
         if (route !== "/lab") {
           useArcadeStore.getState().setIsInLabTab(false)
         }
-        // Push before the cosmetic scroll: the route render is a React
-        // transition, and serializing it behind the smooth-scroll animation
-        // delayed the new page by the whole scroll duration.
         router.push(route, { scroll: false })
 
         scrollToRef.current({

--- a/src/hooks/use-handle-navigation.ts
+++ b/src/hooks/use-handle-navigation.ts
@@ -26,41 +26,91 @@ const handleTransitionEffectOff = (fromMobileNav?: boolean) => {
   }
 }
 
+// Store values are read via getState() at call time instead of subscriptions:
+// this hook is instantiated by every <Link> (~80 on /people), so each
+// subscription here multiplies across the whole page.
 export const useHandleNavigation = () => {
   const { disableScroll, enableScroll } = useScrollControl()
   const router = useRouter()
   const pathname = usePathname()
   const scrollToFn = useScrollTo()
   const scrollToRef = useRef(scrollToFn)
-  const setCurrentScene = useNavigationStore((state) => state.setCurrentScene)
-  const setDisableCameraTransition = useNavigationStore(
-    (state) => state.setDisableCameraTransition
-  )
-  const canvasUnavailable = useAppLoadingStore(
-    (state) => state.canvasUnavailable
-  )
-  const scenes = useNavigationStore((state) => state.scenes)
 
   useEffect(() => {
     scrollToRef.current = scrollToFn
   }, [scrollToFn])
 
-  const getScene = useCallback(
-    (route: string) => {
-      if (route === "/") {
-        return scenes?.find((scene) => scene.name.toLowerCase() === "home")
+  const getScene = useCallback((route: string) => {
+    const { scenes } = useNavigationStore.getState()
+
+    if (route === "/") {
+      return scenes?.find((scene) => scene.name.toLowerCase() === "home")
+    }
+
+    const routeWithoutParams = route.split("?")[0].split("#")[0]
+    const finalRoute = routeWithoutParams.split("/").filter(Boolean)[0]
+
+    if (finalRoute === "careers") {
+      return scenes?.find((scene) => scene.name === "people")
+    }
+
+    return scenes?.find((scene) => scene.name === finalRoute)
+  }, [])
+
+  const continueNavigation = useCallback(
+    (route: string, fromMobileNav?: boolean) => {
+      const selectedScene = getScene(route)
+
+      if (!selectedScene) return
+
+      const { setCurrentScene, setDisableCameraTransition } =
+        useNavigationStore.getState()
+      const canvasUnavailable = useAppLoadingStore.getState().canvasUnavailable
+
+      if (window.scrollY < window.innerHeight && !fromMobileNav) {
+        setCurrentScene(selectedScene)
+        disableScroll()
+
+        if (route !== "/lab") {
+          useArcadeStore.getState().setIsInLabTab(false)
+        }
+        // Push before the cosmetic scroll: the route render is a React
+        // transition, and serializing it behind the smooth-scroll animation
+        // delayed the new page by the whole scroll duration.
+        router.push(route, { scroll: false })
+
+        scrollToRef.current({
+          offset: 0,
+          behavior: "smooth",
+          callback: () => enableScroll()
+        })
+      } else {
+        handleTransitionEffectOn(fromMobileNav || canvasUnavailable)
+        disableScroll()
+        setDisableCameraTransition(true)
+        setCurrentScene(selectedScene)
+
+        setTimeout(
+          () => {
+            if (route !== "/lab") {
+              useArcadeStore.getState().setIsInLabTab(false)
+            }
+            router.push(route, { scroll: false })
+
+            scrollToRef.current({
+              offset: 0,
+              behavior: "instant",
+              callback: () => {
+                handleTransitionEffectOff(fromMobileNav || canvasUnavailable)
+                enableScroll()
+              }
+            })
+          },
+          window.innerWidth >= 1024 && !fromMobileNav ? TRANSITION_DURATION : 0
+        )
       }
-
-      const routeWithoutParams = route.split("?")[0].split("#")[0]
-      const finalRoute = routeWithoutParams.split("/").filter(Boolean)[0]
-
-      if (finalRoute === "careers") {
-        return scenes?.find((scene) => scene.name === "people")
-      }
-
-      return scenes?.find((scene) => scene.name === finalRoute)
     },
-    [scenes]
+    [router, disableScroll, enableScroll, getScene]
   )
 
   const handleNavigation = useCallback(
@@ -91,71 +141,7 @@ export const useHandleNavigation = () => {
 
       continueNavigation(route, fromMobileNav)
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      pathname,
-      setCurrentScene,
-      scenes,
-      setDisableCameraTransition,
-      canvasUnavailable
-    ]
-  )
-
-  const continueNavigation = useCallback(
-    (route: string, fromMobileNav?: boolean) => {
-      const selectedScene = getScene(route)
-
-      if (!selectedScene) return
-
-      if (window.scrollY < window.innerHeight && !fromMobileNav) {
-        setCurrentScene(selectedScene)
-        disableScroll()
-
-        scrollToRef.current({
-          offset: 0,
-          behavior: "smooth",
-          callback: () => {
-            if (route !== "/lab") {
-              useArcadeStore.getState().setIsInLabTab(false)
-            }
-            router.push(route, { scroll: false })
-            enableScroll()
-          }
-        })
-      } else {
-        handleTransitionEffectOn(fromMobileNav || canvasUnavailable)
-        disableScroll()
-        setDisableCameraTransition(true)
-        setCurrentScene(selectedScene)
-
-        setTimeout(
-          () => {
-            scrollToRef.current({
-              offset: 0,
-              behavior: "instant",
-              callback: () => {
-                handleTransitionEffectOff(fromMobileNav || canvasUnavailable)
-                enableScroll()
-              }
-            })
-            if (route !== "/lab") {
-              useArcadeStore.getState().setIsInLabTab(false)
-            }
-            router.push(route, { scroll: false })
-          },
-          window.innerWidth >= 1024 && !fromMobileNav ? TRANSITION_DURATION : 0
-        )
-      }
-    },
-    [
-      router,
-      setCurrentScene,
-      setDisableCameraTransition,
-      disableScroll,
-      enableScroll,
-      getScene,
-      canvasUnavailable
-    ]
+    [pathname, continueNavigation]
   )
 
   return { handleNavigation }

--- a/src/hooks/use-key-press.ts
+++ b/src/hooks/use-key-press.ts
@@ -7,8 +7,6 @@ export const useKeyPress = (
   callback: (event: KeyboardEvent) => void,
   event: "keydown" | "keyup" = "keydown"
 ) => {
-  // Per-field selector: destructuring the whole store re-rendered every
-  // consumer on every navigation-store write.
   const isCanvasTabMode = useNavigationStore((state) => state.isCanvasTabMode)
 
   useEffect(() => {
@@ -30,10 +28,6 @@ export const useKeyPress = (
 }
 
 export const useTabKeyHandler = () => {
-  // Subscription-free: this hook sits at the top of <Scene>, so a store
-  // subscription here reconciles the whole Canvas subtree on every
-  // navigation-store write (including setCurrentScene inside a tap). The
-  // values are only needed at keydown time, so read them off the store then.
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
       if (event.key !== "Tab") return

--- a/src/hooks/use-key-press.ts
+++ b/src/hooks/use-key-press.ts
@@ -7,7 +7,9 @@ export const useKeyPress = (
   callback: (event: KeyboardEvent) => void,
   event: "keydown" | "keyup" = "keydown"
 ) => {
-  const { isCanvasTabMode } = useNavigationStore()
+  // Per-field selector: destructuring the whole store re-rendered every
+  // consumer on every navigation-store write.
+  const isCanvasTabMode = useNavigationStore((state) => state.isCanvasTabMode)
 
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
@@ -28,12 +30,18 @@ export const useKeyPress = (
 }
 
 export const useTabKeyHandler = () => {
-  const { setCurrentTabIndex, isCanvasTabMode, currentScene } =
-    useNavigationStore()
-
+  // Subscription-free: this hook sits at the top of <Scene>, so a store
+  // subscription here reconciles the whole Canvas subtree on every
+  // navigation-store write (including setCurrentScene inside a tap). The
+  // values are only needed at keydown time, so read them off the store then.
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
-      if (event.key === "Tab" && !isCanvasTabMode) {
+      if (event.key !== "Tab") return
+
+      const { isCanvasTabMode, currentScene, setCurrentTabIndex } =
+        useNavigationStore.getState()
+
+      if (!isCanvasTabMode) {
         if (event.shiftKey && currentScene?.tabs?.length) {
           setCurrentTabIndex(currentScene.tabs.length - 1)
         } else {
@@ -44,5 +52,5 @@ export const useTabKeyHandler = () => {
 
     window.addEventListener("keydown", handler)
     return () => window.removeEventListener("keydown", handler)
-  }, [currentScene, isCanvasTabMode, setCurrentTabIndex])
+  }, [])
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -122,17 +122,12 @@
 
   .with-diagonal-lines {
     @apply relative overflow-hidden;
-    /* Overscan must be >= one 64px tile (px, not rem — the translate loop and
-       SVG tile are px-fixed) so the transform loop below wraps seamlessly
-       under the overflow clip. */
     @apply after:pointer-events-none after:absolute after:-inset-[64px];
   }
 
   .with-diagonal-lines:after {
     background-image: url("data:image/svg+xml,%3Csvg width='64' height='64' viewBox='0 0 64 64' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cg clip-path='url(%23clip0_5291_41301)' stroke='%23fff' stroke-opacity='.10'%3E%3Cpath d='M-27 27 91-91M-27 35 91-83M-27 43 91-75M-27 51 91-67M-27 59 91-59M-27 67 91-51M-27 75 91-43M-27 83 91-35M-27 91 91-27M-27 99 91-19M-27 107 91-11M-27 115 91-3M-27 123 91 5M-27 131 91 13M-27 139 91 21M-27 147 91 29M-27 155 91 37'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='clip0_5291_41301'%3E%3Cpath fill='%23fff' d='M0 0h64v64H0z'/%3E%3C/clipPath%3E%3C/defs%3E%3C/svg%3E");
     background-repeat: repeat;
-    /* Animate transform, not background-position: the latter repaints on the
-       main thread every frame, even while the element sits at opacity 0. */
     animation: diagonalPatternAnimation 6s linear infinite;
   }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -122,12 +122,17 @@
 
   .with-diagonal-lines {
     @apply relative overflow-hidden;
-    @apply after:pointer-events-none after:absolute after:-inset-12;
+    /* Overscan must be >= one 64px tile (px, not rem — the translate loop and
+       SVG tile are px-fixed) so the transform loop below wraps seamlessly
+       under the overflow clip. */
+    @apply after:pointer-events-none after:absolute after:-inset-[64px];
   }
 
   .with-diagonal-lines:after {
     background-image: url("data:image/svg+xml,%3Csvg width='64' height='64' viewBox='0 0 64 64' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cg clip-path='url(%23clip0_5291_41301)' stroke='%23fff' stroke-opacity='.10'%3E%3Cpath d='M-27 27 91-91M-27 35 91-83M-27 43 91-75M-27 51 91-67M-27 59 91-59M-27 67 91-51M-27 75 91-43M-27 83 91-35M-27 91 91-27M-27 99 91-19M-27 107 91-11M-27 115 91-3M-27 123 91 5M-27 131 91 13M-27 139 91 21M-27 147 91 29M-27 155 91 37'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='clip0_5291_41301'%3E%3Cpath fill='%23fff' d='M0 0h64v64H0z'/%3E%3C/clipPath%3E%3C/defs%3E%3C/svg%3E");
     background-repeat: repeat;
+    /* Animate transform, not background-position: the latter repaints on the
+       main thread every frame, even while the element sits at opacity 0. */
     animation: diagonalPatternAnimation 6s linear infinite;
   }
 }
@@ -164,10 +169,10 @@ img {
 
 @keyframes diagonalPatternAnimation {
   from {
-    background-position: 0 0;
+    transform: translate3d(-64px, 0, 0);
   }
   to {
-    background-position: 64px 0px;
+    transform: translate3d(0, 0, 0);
   }
 }
 


### PR DESCRIPTION
## Context

Speed Insights still shows mobile INP p75 at **2,376ms (Poor)** after #455/#456 — worst routes `/people` (3352ms), `/` (2856ms), `/showcase` (2344ms), `/post/[slug]` (1888ms), while `/contact` (96ms, never mounts the Scene on cold load) shows what the page costs without the leaks below. This PR removes the remaining interaction-time cost chains; the 3D scene stays on mobile.

## What was wrong

1. **Every tap re-rendered the whole R3F tree synchronously.** `useKeyPress`/`useTabKeyHandler` subscribed to the entire navigation store (defeating the selector work in #456 — `useTabKeyHandler` sits at the top of `Scene`), `Scene` subscribed to `currentScene` object identity, and every `RoutingElement` destructured the whole store. Since `setCurrentScene` runs inside the click handler, all of it reconciled inside the measured interaction.
2. **The hidden canvas kept rendering at 60fps.** Plain-group routes reached in-app only hide the canvas with CSS (`invisible opacity-0`); `AnimationController` never checked `canvasVisible`, so the full office rendered behind `/post/*`, `/careers/*`, `/showcase/*` until scrolled past 80svh.
3. **`router.push` waited for a smooth-scroll animation to finish**, and `Link` fired `router.prefetch` inside mobile taps via the synthetic `mouseenter`.
4. **Per-frame `postMessage` to a dead worker, forever.** `LoadingCanvas` terminated the loading worker but never nulled the store handle, so the camera hook structured-cloned two `Vector3`s to it every frame; plus two `clone()` allocations and an unconditional `updateProjectionMatrix()` per frame.
5. **Route weight:** `/people` mounted ~40 `motion.div` faces (MotionValues constructed even in `display:none` desktop trees) inside the nav commit; showcase cards double-rendered post-hydration via `useDeviceDetect` and fully re-rendered on filter taps; `.with-diagonal-lines` animated `background-position` — a non-compositable, always-running main-thread repaint; `Map` re-traversed the routing graph and double-committed on every navigation.

## Changes

- Per-field/derived zustand selectors on the tap path: `Scene` uses two booleans, hotspots one `isFocusedTab` boolean, `useTabKeyHandler` is subscription-free (`getState()` at keydown), `useHandleNavigation` reads stores in callbacks (removes 4 subscriptions × ~80 Links on `/people`).
- `AnimationController` pauses on `!canvasVisible` (with the same `disableCameraTransition` carve-out as the scroll pause so the camera still snaps while hidden during navigations) and caches canvas height via `ResizeObserver` instead of a forced layout per scroll tick.
- `continueNavigation` pushes the route immediately; the scroll-to-top stays cosmetic. `Link` prefetch is gated on `pointerType === "mouse"` (desktop hover unchanged).
- Worker handle nulled after terminate; scratch vectors hoisted; `updateProjectionMatrix()` only on fov change (drei handles aspect on resize).
- `/people` faces use CSS opacity transitions; showcase drops `useDeviceDetect` from the render path (`hover: none` checked in the event handler) and moves to a memoized `GridCard` + `disabledSlugs` set with stable project identities; `Map` builds its mesh lookup once and derives hotspots from `currentScene.tabs`; `.with-diagonal-lines` animates `transform` (px-based overscan so the 64px loop stays seamless at any root font size).

## Verification

- `pnpm build` (Turbopack) passes with full static prerender; ESLint and `tsc` clean on all touched files.
- Two adversarial review passes over the diff (3D/nav behavior parity + route/CSS): both findings they surfaced are fixed in this PR (the `canvasVisible` transition carve-out and the rem/px overscan mismatch); keyboard Tab-navigation, the loading-worker reveal handshake, camera transitions, and the contact-overlay pending-navigation path were verified branch-by-branch for parity.
- Worth a manual pass: desktop Tab into canvas (focus outline, Enter navigates), hard-reload loading reveal, showcase hover video, diagonal-lines tiling.
- Field: expect Speed Insights per-route p75 to move within days; CrUX is a 28-day window. If p75 stays >~700ms after this bakes, the agreed next lever is the poster/tap-to-load in the 80svh slot.