### PR TITLE
refactor(physics): share one rapier world between blog (lamp) and basketball

### DIFF
--- a/src/components/lamp/index.tsx
+++ b/src/components/lamp/index.tsx
@@ -19,9 +19,7 @@ import { createGlobalShaderMaterial } from "@/shaders/material-global-shader"
 
 extend({ MeshLineGeometry, MeshLineMaterial })
 
-// The rope was tuned in a dedicated world at gravity -24. It now shares the
-// scene's world, which runs at rapier's default -9.81, so scale gravity back up
-// for these bodies alone rather than retuning the rope.
+// The rope was tuned at gravity -24; the shared world runs at rapier's default.
 const LAMP_GRAVITY_SCALE = 24 / 9.81
 
 const colorWhenOn = new THREE.Color("#f2f2f2")

--- a/src/components/lamp/index.tsx
+++ b/src/components/lamp/index.tsx
@@ -19,6 +19,11 @@ import { createGlobalShaderMaterial } from "@/shaders/material-global-shader"
 
 extend({ MeshLineGeometry, MeshLineMaterial })
 
+// The rope was tuned in a dedicated world at gravity -24. It now shares the
+// scene's world, which runs at rapier's default -9.81, so scale gravity back up
+// for these bodies alone rather than retuning the rope.
+const LAMP_GRAVITY_SCALE = 24 / 9.81
+
 const colorWhenOn = new THREE.Color("#f2f2f2")
 const colorWhenOff = new THREE.Color("#595959")
 const colorWhenInspecting = new THREE.Color("#000000")
@@ -253,6 +258,7 @@ export const Lamp = memo(function LampInner() {
           position={[0, -0.02, 0]}
           angularDamping={100}
           linearDamping={2}
+          gravityScale={LAMP_GRAVITY_SCALE}
         >
           <BallCollider args={[0.01]} />
         </RigidBody>
@@ -262,6 +268,7 @@ export const Lamp = memo(function LampInner() {
           position={[0, -0.04, 0]}
           angularDamping={100}
           linearDamping={2}
+          gravityScale={LAMP_GRAVITY_SCALE}
         >
           <BallCollider args={[0.01]} />
         </RigidBody>
@@ -271,6 +278,7 @@ export const Lamp = memo(function LampInner() {
           position={[0, -0.06, 0]}
           angularDamping={100}
           linearDamping={2}
+          gravityScale={LAMP_GRAVITY_SCALE}
           type={dragged ? "kinematicPosition" : "dynamic"}
         >
           <BallCollider args={[0.01]} />

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -240,7 +240,6 @@ export const Map = memo(() => {
       {/*Blog */}
       <BlogDoor />
       <LockedDoor />
-      {/* <Lamp /> lives in the shared physics world in <Scene /> */}
 
       {/*Services */}
       <Weather />

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -1,7 +1,6 @@
 "use client"
 
-import dynamic from "next/dynamic"
-import { memo, Suspense, useEffect, useMemo, useRef } from "react"
+import { memo, useEffect, useMemo, useRef } from "react"
 import { Mesh, MeshStandardMaterial, Object3D } from "three"
 import * as THREE from "three"
 
@@ -13,7 +12,6 @@ import { BlogDoor } from "@/components/blog-door"
 import { ChristmasTree } from "@/components/christmas-tree"
 import { Clock } from "@/components/clock"
 import { Godrays } from "@/components/godrays"
-import { Lamp } from "@/components/lamp"
 import { LockedDoor } from "@/components/locked-door"
 import { useNavigationStore } from "@/components/navigation-handler/navigation-store"
 import { OutdoorCars } from "@/components/outdoor-cars"
@@ -21,7 +19,6 @@ import { cctvConfig } from "@/components/postprocessing/renderer"
 import { RoutingElement } from "@/components/routing-element/routing-element"
 import { SpeakerHover } from "@/components/speaker-hover"
 import { Weather } from "@/components/weather"
-import { useCurrentScene } from "@/hooks/use-current-scene"
 import { useMesh } from "@/hooks/use-mesh"
 import { createVideoTextureWithResume } from "@/hooks/use-video-resume"
 import { markCanvasBootStage } from "@/lib/canvas-boot"
@@ -31,29 +28,6 @@ import { createNotFoundMaterial } from "@/shaders/material-not-found"
 import { extractMeshes } from "./extract-meshes"
 import { useFrameLoop } from "./use-frame-loop"
 import { useLoader } from "./use-loader"
-
-const PhysicsWorld = dynamic(
-  () =>
-    import("@react-three/rapier").then((mod) => {
-      const { Physics } = mod
-      return function PhysicsWrapper({
-        children,
-        paused,
-        gravity
-      }: {
-        children: React.ReactNode
-        paused: boolean
-        gravity: [number, number, number]
-      }) {
-        return (
-          <Physics paused={paused} gravity={gravity}>
-            {children}
-          </Physics>
-        )
-      }
-    }),
-  { ssr: false }
-)
 
 export const Map = memo(() => {
   const { inspectables, videos, matcaps, glassMaterials, doubleSideElements } =
@@ -71,7 +45,6 @@ export const Map = memo(() => {
 
   useFrameLoop()
 
-  const scene = useCurrentScene()
   const tabs = useNavigationStore((state) => state.currentScene?.tabs)
 
   const routingMeshes = useMemo(() => {
@@ -267,13 +240,7 @@ export const Map = memo(() => {
       {/*Blog */}
       <BlogDoor />
       <LockedDoor />
-      <Suspense fallback={null}>
-        <PhysicsWorld gravity={[0, -24, 0]} paused={scene !== "blog"}>
-          {/* TODO: shut down physics after x seconds of not being in blog scene */}
-          {/* TODO: basketball should use the same physics world */}
-          <Lamp />
-        </PhysicsWorld>
-      </Suspense>
+      {/* <Lamp /> lives in the shared physics world in <Scene /> */}
 
       {/*Services */}
       <Weather />

--- a/src/components/scene/index.tsx
+++ b/src/components/scene/index.tsx
@@ -210,9 +210,11 @@ export const Scene = () => {
                   <Suspense fallback={null}>
                     <PhysicsWorld paused={!isBasketball && !isBlog}>
                       <Lamp />
-                      <ErrorBoundary>
-                        <HoopMinigame />
-                      </ErrorBoundary>
+                      {isBasketball && (
+                        <ErrorBoundary>
+                          <HoopMinigame />
+                        </ErrorBoundary>
+                      )}
                     </PhysicsWorld>
                   </Suspense>
                   <Suspense fallback={null}>

--- a/src/components/scene/index.tsx
+++ b/src/components/scene/index.tsx
@@ -205,11 +205,8 @@ export const Scene = () => {
                   <Suspense fallback={null}>
                     <Sparkles />
                   </Suspense>
-                  {/* One world for the whole scene. It is never unmounted:
-                      tearing a world down in the same commit that removes its
-                      bodies throws "recursive use of an object detected" out of
-                      rapier's wasm, and two worlds sharing one wasm module made
-                      that reachable on every blog/basketball transition. */}
+                  {/* Never unmount: tearing a world down while its bodies are
+                      being removed throws out of rapier's wasm. */}
                   <Suspense fallback={null}>
                     <PhysicsWorld paused={!isBasketball && !isBlog}>
                       <Lamp />

--- a/src/components/scene/index.tsx
+++ b/src/components/scene/index.tsx
@@ -12,6 +12,7 @@ import { CharactersSpawn } from "@/components/characters/characters-spawn"
 import { UpdateCanvasCursor } from "@/components/custom-cursor"
 import { Debug } from "@/components/debug"
 import { Inspectables } from "@/components/inspectables/inspectables"
+import { Lamp } from "@/components/lamp"
 import { Map } from "@/components/map"
 import { BakesLoader } from "@/components/map/bakes"
 import { useNavigationStore } from "@/components/navigation-handler/navigation-store"
@@ -59,6 +60,9 @@ export const Scene = () => {
   )
   const isBasketball = useNavigationStore(
     (state) => state.currentScene?.name === "basketball"
+  )
+  const isBlog = useNavigationStore(
+    (state) => state.currentScene?.name === "blog"
   )
   const isFullHeightScene = useNavigationStore((state) => {
     const name = state.currentScene?.name
@@ -201,13 +205,19 @@ export const Scene = () => {
                   <Suspense fallback={null}>
                     <Sparkles />
                   </Suspense>
-                  {isBasketball && (
-                    <PhysicsWorld paused={!isBasketball}>
+                  {/* One world for the whole scene. It is never unmounted:
+                      tearing a world down in the same commit that removes its
+                      bodies throws "recursive use of an object detected" out of
+                      rapier's wasm, and two worlds sharing one wasm module made
+                      that reachable on every blog/basketball transition. */}
+                  <Suspense fallback={null}>
+                    <PhysicsWorld paused={!isBasketball && !isBlog}>
+                      <Lamp />
                       <ErrorBoundary>
                         <HoopMinigame />
                       </ErrorBoundary>
                     </PhysicsWorld>
-                  )}
+                  </Suspense>
                   <Suspense fallback={null}>
                     <CharacterInstanceConfig />
                     <CharactersSpawn />


### PR DESCRIPTION
## Summary

Fixes the cause of Sentry `WEBSITE-2K25-4S` — *"recursive use of an object detected which would lead to unsafe aliasing in rust"*.

The scene ran **two** `<Physics>` worlds over one rapier wasm module: the lamp's (always mounted, only paused) and basketball's (conditionally **unmounted**). Unmounting a world in the same commit that removes its bodies throws out of the wasm glue, and every rapier call after that throws too. Only reachable once the second world started stepping — i.e. blog/basketball transitions.

Does what the two `TODO`s at the old call site already asked for: one shared world.

## Changes

- `scene/index.tsx` — one `<Physics>` wrapping `<Lamp />` and `<HoopMinigame />`; never unmounted, `paused={!isBasketball && !isBlog}`.
- `map/index.tsx` — its world removed, plus the now-unused `dynamic`, `Suspense` and `useCurrentScene`. Both TODOs gone.
- `lamp/index.tsx` — rope bodies get `gravityScale={24 / 9.81}`, so the rope keeps its `-24` tuning and basketball keeps rapier's default. Switching world gravity per scene would leave the inactive one mistuned. No retuning of the Sanity `physicsParams`.

Notes for review:

- `Physics` suspends on the wasm load, so the world can't wrap `<Map />` without gating the whole 3D scene on rapier. `Lamp` is hoisted out instead; `Map` is an untransformed `<group>`, so nothing moves.
- Rapier already loaded on every route, so a permanently-live world is not a new bundle cost.
- The lamp now simulates during `/basketball` instead of being frozen. Offscreen, and rapier auto-sleeps settled bodies — but it is a real change.

## Verification

**Not verified by reproduction.** The crash reproduced once against prod (real Safari 26.5.2, stack matching the issue frame for frame) and never again — ~70 further attempts across prod, a local production build and dev, all clean, including a fix-removed control run. At that hit rate a passing run proves nothing either way.

Judge it on `WEBSITE-2K25-4S` after deploy: it was escalating, so a drop to zero over a few days is the signal. Repro harness is in `.context/safari-repro/`.

## Checklist

- [x] `pnpm lint` passes
- [x] `tsc --noEmit` clean on touched files
- [x] Tested locally in dev mode and a local production build
- [x] No breaking changes (lamp-during-basketball noted above)
