### PR TITLE
fix(canvas): skip frame work while the WebGL context is lost

### DIFF
--- a/src/hooks/use-pausable-time.ts
+++ b/src/hooks/use-pausable-time.ts
@@ -24,6 +24,8 @@ export const useFrameCallback = (
   const lastTime = useRef(0)
 
   useFrame((state, rawDelta) => {
+    if (state.gl.getContext().isContextLost()) return
+
     const elapsed = state.clock.getElapsedTime()
     const { isContactOpen } = useContactStore.getState()
 


### PR DESCRIPTION
## Summary

Fixes `WEBSITE-2K25-5M` — `TypeError: WeakMap keys must be objects` on iOS Safari, 52 events in ~1s from a single session.

When iOS drops the WebGL context under memory pressure, `_gl.createFramebuffer()` returns `null`, so three stores `__webglFramebuffer = null` and `WebGLState.drawBuffers` calls `currentDrawbuffers.set(null, [])` on a WeakMap — which throws. `WebGLRenderer.render()` early-returns on a lost context but `setRenderTarget()` does not, so the frame loop has to bail out itself.

It surfaced at `renderer.tsx:139` (the CCTV bake) rather than the `mainTarget` line above it because already-uploaded targets keep stale-but-non-null framebuffers and pass — the CCTV FBO is just the first target three sets up *after* the loss. The throw also skips `shouldBakeCCTV = false`, so it retried and rethrew every frame.

## Changes

- `useFrameCallback` returns early when `gl.getContext().isContextLost()`, covering every frame callback that goes through it (including the post-processing renderer).

## Notes

- Raw `useFrame` loops that also call `setRenderTarget` remain exposed: `loading-scene/index.tsx:349`, `arcade-screen/render-texture.tsx:222`.
- Nothing handles `webglcontextrestored`, so a lost context still leaves a black canvas. This stops the error storm; it does not recover the scene.

## Checklist

- [ ] `pnpm lint` passes
- [ ] Tested locally in dev mode
- [x] No breaking changes