### PR TITLE
feat(agents): 404 recovery body, OpenAPI spec, and live MCP server

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@codesandbox/sandpack-react": "^2.19.11",
     "@hookform/resolvers": "^4.1.3",
     "@million/lint": "^1.0.14",
+    "@modelcontextprotocol/server": "^2.0.0",
     "@mux/mux-video-react": "^0.24.3",
     "@notionhq/client": "^5.13.0",
     "@phosphor-icons/react": "^2.1.10",
@@ -57,6 +58,7 @@
     "leva": "^0.9.35",
     "lodash.throttle": "^4.1.1",
     "maath": "^0.10.8",
+    "mcp-handler": "^2.1.1",
     "meshline": "^3.3.1",
     "motion": "^12.42.0",
     "nanoid": "^5.1.2",
@@ -83,6 +85,7 @@
     "tunnel-rat": "^0.1.2",
     "typescript-eslint": "^8.27.0",
     "xss": "^1.0.15",
+    "zod": "^4.4.3",
     "zustand": "^5.0.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@million/lint':
         specifier: ^1.0.14
         version: 1.0.14(rollup@4.62.4)
+      '@modelcontextprotocol/server':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@mux/mux-video-react':
         specifier: ^0.24.3
         version: 0.24.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -122,6 +125,9 @@ importers:
       maath:
         specifier: ^0.10.8
         version: 0.10.8(@types/three@0.170.0)(three@0.180.0)
+      mcp-handler:
+        specifier: ^2.1.1
+        version: 2.1.1(@modelcontextprotocol/server@2.0.0)(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       meshline:
         specifier: ^3.3.1
         version: 3.3.1(three@0.180.0)
@@ -200,6 +206,9 @@ importers:
       xss:
         specifier: ^1.0.15
         version: 1.0.15
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
       zustand:
         specifier: ^5.0.1
         version: 5.0.1(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
@@ -2360,6 +2369,14 @@ packages:
     resolution: {integrity: sha512-u6/kglVwZRu5+GMmtkNlGLqJVkgTl0TtM+hLa9rBg7pldx+5NG5bk45NvL37uZmAr2Xfa1C6qHb7GrFwfP372g==}
     deprecated: This package is no longer maintained
     hasBin: true
+
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/server@2.0.0':
+    resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
+    engines: {node: '>=20'}
 
   '@monogrid/gainmap-js@3.1.0':
     resolution: {integrity: sha512-Obb0/gEd/HReTlg8ttaYk+0m62gQJmCblMOjHSMHRrBP2zdfKMHLCRbh/6ex9fSUJMKdjjIEiohwkbGD3wj2Nw==}
@@ -5555,6 +5572,10 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -7372,6 +7393,17 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mcp-handler@2.1.1:
+    resolution: {integrity: sha512-D/PAwxF9TexmixJY+FZMgYq9SSbGm3vtcUjwUHZ8tYYuOtGT3/KgAKBjO3UJZoXgW8nHDtv8ySOICMEZPD0b/Q==}
+    engines: {node: '>=20'}
+    hasBin: true
+    peerDependencies:
+      '@modelcontextprotocol/server': ^2.0.0
+      next: '>=13.0.0'
+    peerDependenciesMeta:
+      next:
+        optional: true
 
   md5-o-matic@0.1.1:
     resolution: {integrity: sha512-QBJSFpsedXUl/Lgs4ySdB2XCzUEcJ3ujpbagdZCkRaYIaC0kFnID8jhc84KEiVv6dNFtIrmW7bqow0lDxgJi6A==}
@@ -9932,8 +9964,8 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zustand@3.7.2:
     resolution: {integrity: sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==}
@@ -12229,6 +12261,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.4.3
+
+  '@modelcontextprotocol/server@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      zod: 4.4.3
+
   '@monogrid/gainmap-js@3.1.0(three@0.180.0)':
     dependencies:
       promise-worker-transferable: 1.0.4
@@ -13698,8 +13739,8 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       read-package-up: 12.0.0
       semver: 7.8.5
-      vite: 7.3.6(@types/node@24.13.2)(jiti@2.7.0)(terser@5.37.0)(tsx@4.22.4)(yaml@2.9.0)
-      zod: 4.3.6
+      vite: 7.3.6(@types/node@24.13.2)(jiti@2.7.0)(terser@5.37.0)(tsx@4.21.0)(yaml@2.9.0)
+      zod: 4.4.3
     optionalDependencies:
       babel-plugin-react-compiler: 1.0.0
     transitivePeerDependencies:
@@ -13739,7 +13780,7 @@ snapshots:
       tsx: 4.22.4
       vite: 7.3.6(@types/node@24.13.2)(jiti@2.7.0)(terser@5.37.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-node: 5.3.0(@types/node@24.13.2)(jiti@2.7.0)(terser@5.37.0)(tsx@4.22.4)(yaml@2.9.0)
-      zod: 4.3.6
+      zod: 4.4.3
     optionalDependencies:
       babel-plugin-react-compiler: 1.0.0
     transitivePeerDependencies:
@@ -13822,7 +13863,7 @@ snapshots:
       vite: 7.3.6(@types/node@24.13.2)(jiti@2.7.0)(terser@5.37.0)(tsx@4.22.4)(yaml@2.9.0)
       which: 6.0.1
       yaml: 2.9.0
-      zod: 4.3.6
+      zod: 4.4.3
     optionalDependencies:
       babel-plugin-react-compiler: 1.0.0
     transitivePeerDependencies:
@@ -13879,7 +13920,7 @@ snapshots:
       prettier: 3.8.1
       reselect: 5.1.1
       tsconfig-paths: 4.2.0
-      zod: 4.3.6
+      zod: 4.4.3
     transitivePeerDependencies:
       - react
       - supports-color
@@ -14114,7 +14155,7 @@ snapshots:
       mime-types: 3.0.2
       ora: 9.4.1
       tar-stream: 3.2.0
-      vite: 7.3.6(@types/node@24.13.2)(jiti@2.7.0)(terser@5.37.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@24.13.2)(jiti@2.7.0)(terser@5.37.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-tsconfig-paths: 6.1.1(typescript@5.8.2)(vite@7.3.6(@types/node@24.13.2)(jiti@2.7.0)(terser@5.37.0)(tsx@4.22.4)(yaml@2.9.0))
       ws: 8.20.0
       xdg-basedir: 5.1.0
@@ -15816,6 +15857,8 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@11.1.0: {}
+
   commander@2.20.3: {}
 
   commander@4.1.1: {}
@@ -16538,8 +16581,8 @@ snapshots:
       '@babel/parser': 7.29.2
       eslint: 9.23.0(jiti@2.7.0)
       hermes-parser: 0.25.1
-      zod: 4.3.6
-      zod-validation-error: 4.0.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -17866,6 +17909,14 @@ snapshots:
       uc.micro: 2.1.0
 
   math-intrinsics@1.1.0: {}
+
+  mcp-handler@2.1.1(@modelcontextprotocol/server@2.0.0)(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)):
+    dependencies:
+      '@modelcontextprotocol/server': 2.0.0
+      chalk: 5.6.2
+      commander: 11.1.0
+    optionalDependencies:
+      next: 16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   md5-o-matic@0.1.1: {}
 
@@ -20719,13 +20770,13 @@ snapshots:
 
   yoga-layout@3.2.1: {}
 
-  zod-validation-error@4.0.2(zod@4.3.6):
+  zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   zod@3.25.76: {}
 
-  zod@4.3.6: {}
+  zod@4.4.3: {}
 
   zustand@3.7.2(react@19.2.7):
     optionalDependencies:

--- a/public/agents.md
+++ b/public/agents.md
@@ -37,3 +37,9 @@ The studio works with both startups and established companies, worldwide.
   posts, showcase projects, and open positions) or request it with
   `Accept: text/markdown`. Content index: https://basement.studio/sitemap.md
 - Sitemap: https://basement.studio/sitemap.xml
+- OpenAPI spec: https://basement.studio/openapi.json — machine-readable
+  description of the public API (content mirrors + scores API).
+- MCP server: https://basement.studio/.well-known/mcp — live Model Context
+  Protocol server (Streamable HTTP, no auth) with tools to list, search, and
+  read site content. Discovery card: https://basement.studio/.well-known/mcp.json.
+  Alias: https://basement.studio/mcp.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -33,6 +33,11 @@ via `Accept: text/markdown`). Full index: https://basement.studio/sitemap.md
 - https://basement.studio/faq.md
 - https://basement.studio/contact.md
 
+## Developer & agent resources
+
+- [OpenAPI description](https://basement.studio/openapi.json): Machine-readable spec of the public API (content mirrors + scores API).
+- [MCP server](https://basement.studio/.well-known/mcp): Live Model Context Protocol server (Streamable HTTP, no auth) exposing site content as tools; discovery card at https://basement.studio/.well-known/mcp.json, alias at https://basement.studio/mcp.
+
 ## Contact
 
 - General & project inquiries: hello@basement.studio

--- a/src/app/(site)/[...notFound]/page.tsx
+++ b/src/app/(site)/[...notFound]/page.tsx
@@ -1,5 +1,9 @@
 import { notFound } from "next/navigation"
 
+// Prerendered notFound() keeps the real 404 status (a streamed/request-time
+// notFound() would lock the status at 200 — see loading.md "Status Codes").
+// The served artifact is an empty client shell, so agent-readable 404 bodies
+// are handled in src/proxy.ts instead.
 export default function NotFoundCatchAll() {
   notFound()
 }

--- a/src/app/(site)/[...notFound]/page.tsx
+++ b/src/app/(site)/[...notFound]/page.tsx
@@ -1,9 +1,5 @@
 import { notFound } from "next/navigation"
 
-// Prerendered notFound() keeps the real 404 status (a streamed/request-time
-// notFound() would lock the status at 200 — see loading.md "Status Codes").
-// The served artifact is an empty client shell, so agent-readable 404 bodies
-// are handled in src/proxy.ts instead.
 export default function NotFoundCatchAll() {
   notFound()
 }

--- a/src/app/(site)/not-found.client.tsx
+++ b/src/app/(site)/not-found.client.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+import { useEffect, useLayoutEffect, useState } from "react"
+
+import { SetCanvasMode } from "@/components/layout/set-canvas-mode"
+import { useNavigationStore } from "@/components/navigation-handler/navigation-store"
+import { useHandleNavigation } from "@/hooks/use-handle-navigation"
+import { cn } from "@/utils/cn"
+
+// Flag must land before NavigationHandler's useEffect runs.
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect
+
+export default function NotFoundClient() {
+  const { handleNavigation } = useHandleNavigation()
+  const currentScene = useNavigationStore((state) => state.currentScene)
+  const setIsNotFound = useNavigationStore((state) => state.setIsNotFound)
+  const [formattedTime, setFormattedTime] = useState("00:00:00:00")
+  const [fadeOutHtml, setFadeOutHtml] = useState(false)
+
+  useIsomorphicLayoutEffect(() => {
+    setIsNotFound(true)
+    return () => setIsNotFound(false)
+  }, [setIsNotFound])
+
+  useEffect(() => {
+    const updateTime = () => {
+      const time = new Date()
+        .toLocaleTimeString("es-AR", {
+          hour: "2-digit",
+          minute: "2-digit",
+          second: "2-digit",
+          hour12: false,
+          timeZone: "America/Argentina/Buenos_Aires"
+        })
+        .replace(/:/g, ":")
+      setFormattedTime(`00:${time}`)
+    }
+
+    updateTime()
+    const interval = setInterval(updateTime, 1000)
+
+    return () => clearInterval(interval)
+  }, [])
+
+  const goBack = () => {
+    setFadeOutHtml(true)
+
+    setTimeout(() => {
+      handleNavigation("/")
+    }, 500)
+  }
+
+  if (currentScene?.name !== "404") return null
+
+  return (
+    <>
+      <SetCanvasMode enabled />
+      <div
+        className={cn(
+          "fixed inset-0 z-30 mx-auto grid h-full w-full max-w-full place-items-center p-6 lg:p-18",
+          fadeOutHtml
+            ? "opacity-0 transition-opacity duration-500"
+            : "[animation:fade-in_1500ms_ease-in-out_1_normal_none_running]"
+        )}
+      >
+        <div className="relative mx-auto grid h-full w-full place-items-center p-4 lg:p-12">
+          <div className="absolute left-0 top-0">
+            <div className="h-7 w-0.5 bg-brand-w1 shadow-[0_0_10px_#fff,0_0_20px_#fff] lg:h-14" />
+            <div className="absolute top-0 h-0.5 w-7 bg-brand-w1 shadow-[0_0_10px_#fff,0_0_20px_#fff] lg:w-14" />
+          </div>
+
+          <div className="absolute right-0 top-0">
+            <div className="h-7 w-0.5 bg-brand-w1 shadow-[0_0_10px_#fff,0_0_20px_#fff] lg:h-14" />
+            <div className="absolute right-0 top-0 h-0.5 w-7 bg-brand-w1 shadow-[0_0_10px_#fff,0_0_20px_#fff] lg:w-14" />
+          </div>
+
+          <div className="absolute bottom-0 left-0">
+            <div className="h-7 w-0.5 bg-brand-w1 shadow-[0_0_10px_#fff,0_0_20px_#fff] lg:h-14" />
+            <div className="absolute bottom-0 h-0.5 w-7 bg-brand-w1 shadow-[0_0_10px_#fff,0_0_20px_#fff] lg:w-14" />
+          </div>
+
+          <div className="absolute bottom-0 right-0">
+            <div className="h-7 w-0.5 bg-brand-w1 shadow-[0_0_10px_#fff,0_0_20px_#fff] lg:h-14" />
+            <div className="absolute bottom-0 right-0 h-0.5 w-7 bg-brand-w1 shadow-[0_0_10px_#fff,0_0_20px_#fff] lg:w-14" />
+          </div>
+
+          <div className="relative grid h-full w-full place-items-center font-mono text-f-h4-mobile uppercase text-brand-w1 lg:text-f-h4">
+            <span className="absolute left-0 top-0 tracking-wider [text-shadow:0_0_10px_#fff]">
+              ERROR - 404
+            </span>
+
+            <div className="absolute bottom-0 left-0 flex items-center gap-2">
+              <div className="size-2 animate-pulse rounded-full bg-brand-r shadow-[0_0_10px_#ff0000]" />
+              <span className="font-bold tracking-widest text-brand-w1 [text-shadow:0_0_10px_#fff]">
+                REC
+              </span>
+            </div>
+
+            <span className="absolute right-0 top-0 tracking-wider [text-shadow:0_0_10px_#fff]">
+              SECURITY CAM 4870
+            </span>
+            <span className="absolute bottom-0 right-0 font-bold tracking-[0.2em] text-brand-w1 [text-shadow:0_0_10px_#fff]">
+              {formattedTime}
+            </span>
+
+            <button
+              onClick={() => goBack()}
+              className="actionable actionable-no-underline text-f-h3-mobile uppercase tracking-widest text-brand-w1 lg:text-f-h3"
+            >
+              Go Back Home
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/app/(site)/not-found.tsx
+++ b/src/app/(site)/not-found.tsx
@@ -1,118 +1,14 @@
-"use client"
+import { AgentRecoveryLinks } from "@/components/agent-recovery-links"
 
-import { useEffect, useLayoutEffect, useState } from "react"
+import NotFoundClient from "./not-found.client"
 
-import { SetCanvasMode } from "@/components/layout/set-canvas-mode"
-import { useNavigationStore } from "@/components/navigation-handler/navigation-store"
-import { useHandleNavigation } from "@/hooks/use-handle-navigation"
-import { cn } from "@/utils/cn"
-
-// Flag must land before NavigationHandler's useEffect runs.
-const useIsomorphicLayoutEffect =
-  typeof window !== "undefined" ? useLayoutEffect : useEffect
-
+// Server boundary: the visual 404 only exists after hydration flips the WebGL
+// scene, so the sr-only block is the entire body a non-JS agent receives.
 export default function NotFound() {
-  const { handleNavigation } = useHandleNavigation()
-  const currentScene = useNavigationStore((state) => state.currentScene)
-  const setIsNotFound = useNavigationStore((state) => state.setIsNotFound)
-  const [formattedTime, setFormattedTime] = useState("00:00:00:00")
-  const [fadeOutHtml, setFadeOutHtml] = useState(false)
-
-  useIsomorphicLayoutEffect(() => {
-    setIsNotFound(true)
-    return () => setIsNotFound(false)
-  }, [setIsNotFound])
-
-  useEffect(() => {
-    const updateTime = () => {
-      const time = new Date()
-        .toLocaleTimeString("es-AR", {
-          hour: "2-digit",
-          minute: "2-digit",
-          second: "2-digit",
-          hour12: false,
-          timeZone: "America/Argentina/Buenos_Aires"
-        })
-        .replace(/:/g, ":")
-      setFormattedTime(`00:${time}`)
-    }
-
-    updateTime()
-    const interval = setInterval(updateTime, 1000)
-
-    return () => clearInterval(interval)
-  }, [])
-
-  const goBack = () => {
-    setFadeOutHtml(true)
-
-    setTimeout(() => {
-      handleNavigation("/")
-    }, 500)
-  }
-
-  if (currentScene?.name !== "404") return null
-
   return (
     <>
-      <SetCanvasMode enabled />
-      <div
-        className={cn(
-          "fixed inset-0 z-30 mx-auto grid h-full w-full max-w-full place-items-center p-6 lg:p-18",
-          fadeOutHtml
-            ? "opacity-0 transition-opacity duration-500"
-            : "[animation:fade-in_1500ms_ease-in-out_1_normal_none_running]"
-        )}
-      >
-        <div className="relative mx-auto grid h-full w-full place-items-center p-4 lg:p-12">
-          <div className="absolute left-0 top-0">
-            <div className="h-7 w-0.5 bg-brand-w1 shadow-[0_0_10px_#fff,0_0_20px_#fff] lg:h-14" />
-            <div className="absolute top-0 h-0.5 w-7 bg-brand-w1 shadow-[0_0_10px_#fff,0_0_20px_#fff] lg:w-14" />
-          </div>
-
-          <div className="absolute right-0 top-0">
-            <div className="h-7 w-0.5 bg-brand-w1 shadow-[0_0_10px_#fff,0_0_20px_#fff] lg:h-14" />
-            <div className="absolute right-0 top-0 h-0.5 w-7 bg-brand-w1 shadow-[0_0_10px_#fff,0_0_20px_#fff] lg:w-14" />
-          </div>
-
-          <div className="absolute bottom-0 left-0">
-            <div className="h-7 w-0.5 bg-brand-w1 shadow-[0_0_10px_#fff,0_0_20px_#fff] lg:h-14" />
-            <div className="absolute bottom-0 h-0.5 w-7 bg-brand-w1 shadow-[0_0_10px_#fff,0_0_20px_#fff] lg:w-14" />
-          </div>
-
-          <div className="absolute bottom-0 right-0">
-            <div className="h-7 w-0.5 bg-brand-w1 shadow-[0_0_10px_#fff,0_0_20px_#fff] lg:h-14" />
-            <div className="absolute bottom-0 right-0 h-0.5 w-7 bg-brand-w1 shadow-[0_0_10px_#fff,0_0_20px_#fff] lg:w-14" />
-          </div>
-
-          <div className="relative grid h-full w-full place-items-center font-mono text-f-h4-mobile uppercase text-brand-w1 lg:text-f-h4">
-            <span className="absolute left-0 top-0 tracking-wider [text-shadow:0_0_10px_#fff]">
-              ERROR - 404
-            </span>
-
-            <div className="absolute bottom-0 left-0 flex items-center gap-2">
-              <div className="size-2 animate-pulse rounded-full bg-brand-r shadow-[0_0_10px_#ff0000]" />
-              <span className="font-bold tracking-widest text-brand-w1 [text-shadow:0_0_10px_#fff]">
-                REC
-              </span>
-            </div>
-
-            <span className="absolute right-0 top-0 tracking-wider [text-shadow:0_0_10px_#fff]">
-              SECURITY CAM 4870
-            </span>
-            <span className="absolute bottom-0 right-0 font-bold tracking-[0.2em] text-brand-w1 [text-shadow:0_0_10px_#fff]">
-              {formattedTime}
-            </span>
-
-            <button
-              onClick={() => goBack()}
-              className="actionable actionable-no-underline text-f-h3-mobile uppercase tracking-widest text-brand-w1 lg:text-f-h3"
-            >
-              Go Back Home
-            </button>
-          </div>
-        </div>
-      </div>
+      <AgentRecoveryLinks className="sr-only" />
+      <NotFoundClient />
     </>
   )
 }

--- a/src/app/(site)/not-found.tsx
+++ b/src/app/(site)/not-found.tsx
@@ -2,8 +2,6 @@ import { AgentRecoveryLinks } from "@/components/agent-recovery-links"
 
 import NotFoundClient from "./not-found.client"
 
-// Server boundary: the visual 404 only exists after hydration flips the WebGL
-// scene, so the sr-only block is the entire body a non-JS agent receives.
 export default function NotFound() {
   return (
     <>

--- a/src/app/.well-known/mcp.json/route.ts
+++ b/src/app/.well-known/mcp.json/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server"
+
+import { serveMcpCard } from "@/lib/mcp/handlers"
+
+export function GET() {
+  return serveMcpCard()
+}
+
+export function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type"
+    }
+  })
+}

--- a/src/app/.well-known/mcp/route.ts
+++ b/src/app/.well-known/mcp/route.ts
@@ -1,0 +1,7 @@
+import { mcpRequestHandler, serveMcpCardOr405 } from "@/lib/mcp/handlers"
+
+export const maxDuration = 30
+
+export const GET = serveMcpCardOr405
+export const POST = mcpRequestHandler
+export const DELETE = mcpRequestHandler

--- a/src/app/api/[[...rest]]/route.ts
+++ b/src/app/api/[[...rest]]/route.ts
@@ -2,12 +2,6 @@ import { NextResponse } from "next/server"
 
 import { SITE_URL } from "@/lib/constants"
 
-/**
- * Structured JSON 404 for unmatched /api/* paths — agents get parseable
- * structure instead of the HTML app shell. Literal and dynamic routes (the
- * .md mirrors, /api/scores, /api/draft-mode/*) always win over this optional
- * catch-all, including ones added later.
- */
 const notFound = () =>
   NextResponse.json(
     {

--- a/src/app/api/[[...rest]]/route.ts
+++ b/src/app/api/[[...rest]]/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server"
+
+import { SITE_URL } from "@/lib/constants"
+
+/**
+ * Structured JSON 404 for unmatched /api/* paths — agents get parseable
+ * structure instead of the HTML app shell. Literal and dynamic routes (the
+ * .md mirrors, /api/scores, /api/draft-mode/*) always win over this optional
+ * catch-all, including ones added later.
+ */
+const notFound = () =>
+  NextResponse.json(
+    {
+      error: {
+        code: "not_found",
+        message: "No such API endpoint.",
+        hint: `See ${SITE_URL}/openapi.json for the API surface and ${SITE_URL}/llms.txt for content entry points.`
+      }
+    },
+    { status: 404, headers: { "Cache-Control": "no-store" } }
+  )
+
+export {
+  notFound as DELETE,
+  notFound as GET,
+  notFound as HEAD,
+  notFound as PATCH,
+  notFound as POST,
+  notFound as PUT
+}
+
+export function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: { Allow: "GET, POST, OPTIONS" }
+  })
+}

--- a/src/app/mcp/route.ts
+++ b/src/app/mcp/route.ts
@@ -1,0 +1,9 @@
+// Alias: /.well-known/mcp is the audited/advertised path, but /mcp is the
+// de-facto default MCP clients try first.
+import { mcpRequestHandler, serveMcpCardOr405 } from "@/lib/mcp/handlers"
+
+export const maxDuration = 30
+
+export const GET = serveMcpCardOr405
+export const POST = mcpRequestHandler
+export const DELETE = mcpRequestHandler

--- a/src/app/mcp/route.ts
+++ b/src/app/mcp/route.ts
@@ -1,5 +1,3 @@
-// Alias: /.well-known/mcp is the audited/advertised path, but /mcp is the
-// de-facto default MCP clients try first.
 import { mcpRequestHandler, serveMcpCardOr405 } from "@/lib/mcp/handlers"
 
 export const maxDuration = 30

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,8 +1,24 @@
+import { SITE_URL } from "@/lib/constants"
+
 export default function NotFound() {
   return (
     <div style={{ padding: "2rem", textAlign: "center" }}>
       <h1>404</h1>
       <p>Not Found</p>
+      <ul style={{ listStyle: "none", padding: 0 }}>
+        <li>
+          <a href={SITE_URL}>Home</a>
+        </li>
+        <li>
+          <a href={`${SITE_URL}/sitemap.md`}>Content index (markdown)</a>
+        </li>
+        <li>
+          <a href={`${SITE_URL}/llms.txt`}>llms.txt</a>
+        </li>
+        <li>
+          <a href={`${SITE_URL}/ai`}>Machine view</a>
+        </li>
+      </ul>
     </div>
   )
 }

--- a/src/app/openapi.json/route.ts
+++ b/src/app/openapi.json/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server"
+
+import { openApiDocument } from "@/lib/openapi"
+
+// CORS is open on purpose: function-calling clients fetch specs cross-origin.
+const HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Cache-Control": "public, max-age=3600"
+} as const
+
+export function GET() {
+  return NextResponse.json(openApiDocument, { headers: HEADERS })
+}
+
+export function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type"
+    }
+  })
+}

--- a/src/app/sitemap.md/route.ts
+++ b/src/app/sitemap.md/route.ts
@@ -71,6 +71,8 @@ export async function GET() {
       `- [llms.txt](${SITE_URL}/llms.txt) — curated link map for LLMs`,
       `- [agents.md](${SITE_URL}/agents.md) — notes for AI agents and crawlers`,
       `- [XML sitemap](${SITE_URL}/sitemap.xml)`,
+      `- [OpenAPI spec](${SITE_URL}/openapi.json) — machine-readable description of the public API`,
+      `- [MCP server](${SITE_URL}/.well-known/mcp) — live MCP server (Streamable HTTP) exposing site content as tools`,
       `- [Basketball](${SITE_URL}/basketball) — interactive experience, HTML only`,
       `- [Doom](${SITE_URL}/doom) — interactive experience, HTML only`,
       ""

--- a/src/components/agent-recovery-links.tsx
+++ b/src/components/agent-recovery-links.tsx
@@ -1,10 +1,5 @@
 import { SITE_URL } from "@/lib/constants"
 
-/**
- * Recovery links for the 404 responses. Rendered server-side so agents and
- * crawlers (which never hydrate the WebGL 404 scene) get a usable body with
- * pointers to the machine-readable surfaces instead of an empty shell.
- */
 export function AgentRecoveryLinks({ className }: { className?: string }) {
   return (
     <section className={className}>

--- a/src/components/agent-recovery-links.tsx
+++ b/src/components/agent-recovery-links.tsx
@@ -1,0 +1,39 @@
+import { SITE_URL } from "@/lib/constants"
+
+/**
+ * Recovery links for the 404 responses. Rendered server-side so agents and
+ * crawlers (which never hydrate the WebGL 404 scene) get a usable body with
+ * pointers to the machine-readable surfaces instead of an empty shell.
+ */
+export function AgentRecoveryLinks({ className }: { className?: string }) {
+  return (
+    <section className={className}>
+      <h1>404 — Page not found</h1>
+      <p>
+        This page does not exist on basement.studio. Useful entry points to find
+        what you were looking for:
+      </p>
+      <ul>
+        <li>
+          <a href={`${SITE_URL}/sitemap.md`}>
+            Content index of every page, post, and project (markdown)
+          </a>
+        </li>
+        <li>
+          <a href={`${SITE_URL}/llms.txt`}>llms.txt — curated link map</a>
+        </li>
+        <li>
+          <a href={`${SITE_URL}/index.md`}>Homepage (markdown)</a>
+        </li>
+        <li>
+          <a href={`${SITE_URL}/ai`}>Machine view — plain-HTML site index</a>
+        </li>
+        <li>
+          <a href={`${SITE_URL}/openapi.json`}>
+            OpenAPI description of the public API
+          </a>
+        </li>
+      </ul>
+    </section>
+  )
+}

--- a/src/lib/mcp/content.ts
+++ b/src/lib/mcp/content.ts
@@ -1,0 +1,55 @@
+import { fetchAllOpenPositionsForIndex } from "@/app/(site)/(plain)/(content)/careers/[slug]/sanity"
+import { fetchAllPostsForIndex } from "@/app/(site)/(plain)/(content)/post/[slug]/sanity"
+import { fetchAllProjectsForIndex } from "@/app/(site)/(plain)/(content)/showcase/[slug]/sanity"
+import { SITE_URL } from "@/lib/constants"
+
+export interface ContentIndexEntry {
+  title: string
+  type: "page" | "post" | "project" | "position"
+  /** Markdown mirror path, e.g. `/post/<slug>.md` — valid input for `get_page`. */
+  mdPath: string
+  url: string
+}
+
+// Keep in sync with the singleton entries in markdown-proxy.config.ts.
+const STATIC_PAGES: Array<{ title: string; mdPath: string }> = [
+  { title: "Home", mdPath: "/index.md" },
+  { title: "Services", mdPath: "/services.md" },
+  { title: "People", mdPath: "/people.md" },
+  { title: "Showcase", mdPath: "/showcase.md" },
+  { title: "Blog", mdPath: "/blog.md" },
+  { title: "Lab", mdPath: "/lab.md" },
+  { title: "FAQ", mdPath: "/faq.md" },
+  { title: "Contact", mdPath: "/contact.md" }
+]
+
+/** Same data the /sitemap.md route serves, as structured entries. */
+export async function fetchContentIndex(): Promise<ContentIndexEntry[]> {
+  const [posts, projects, positions] = await Promise.all([
+    fetchAllPostsForIndex(),
+    fetchAllProjectsForIndex(),
+    fetchAllOpenPositionsForIndex()
+  ])
+
+  const entry = (
+    title: string,
+    type: ContentIndexEntry["type"],
+    mdPath: string
+  ): ContentIndexEntry => ({
+    title,
+    type,
+    mdPath,
+    url: `${SITE_URL}${mdPath}`
+  })
+
+  return [
+    ...STATIC_PAGES.map((page) => entry(page.title, "page", page.mdPath)),
+    ...posts.map((post) => entry(post.title, "post", `/post/${post.slug}.md`)),
+    ...projects.map((project) =>
+      entry(project.title, "project", `/showcase/${project.slug}.md`)
+    ),
+    ...positions.map((position) =>
+      entry(position.title, "position", `/careers/${position.slug}.md`)
+    )
+  ]
+}

--- a/src/lib/mcp/content.ts
+++ b/src/lib/mcp/content.ts
@@ -6,7 +6,6 @@ import { SITE_URL } from "@/lib/constants"
 export interface ContentIndexEntry {
   title: string
   type: "page" | "post" | "project" | "position"
-  /** Markdown mirror path, e.g. `/post/<slug>.md` — valid input for `get_page`. */
   mdPath: string
   url: string
 }
@@ -23,7 +22,6 @@ const STATIC_PAGES: Array<{ title: string; mdPath: string }> = [
   { title: "Contact", mdPath: "/contact.md" }
 ]
 
-/** Same data the /sitemap.md route serves, as structured entries. */
 export async function fetchContentIndex(): Promise<ContentIndexEntry[]> {
   const [posts, projects, positions] = await Promise.all([
     fetchAllPostsForIndex(),

--- a/src/lib/mcp/get-page.ts
+++ b/src/lib/mcp/get-page.ts
@@ -1,0 +1,28 @@
+import { SITE_URL } from "@/lib/constants"
+import { markdownRoutes } from "@/service/sanity/markdown-proxy.config"
+
+// Non-content markdown surfaces that aren't in the proxy registry.
+const EXTRA_ALLOWED = new Set(["/sitemap.md", "/llms.txt", "/agents.md"])
+
+/**
+ * Allowlist check for `get_page` input. Reusing the proxy registry's anchored
+ * regexes doubles as the SSRF guard: only registered `.md` mirrors (whose slug
+ * class rejects slashes) can be fetched.
+ */
+export function isKnownMarkdownPath(path: string): boolean {
+  return (
+    EXTRA_ALLOWED.has(path) ||
+    markdownRoutes.some((route) => route.mdRegex.test(path))
+  )
+}
+
+export async function fetchMarkdownPage(
+  path: string
+): Promise<{ ok: boolean; status: number; text: string }> {
+  const response = await fetch(new URL(path, SITE_URL))
+  return {
+    ok: response.ok,
+    status: response.status,
+    text: await response.text()
+  }
+}

--- a/src/lib/mcp/get-page.ts
+++ b/src/lib/mcp/get-page.ts
@@ -1,14 +1,10 @@
 import { SITE_URL } from "@/lib/constants"
 import { markdownRoutes } from "@/service/sanity/markdown-proxy.config"
 
-// Non-content markdown surfaces that aren't in the proxy registry.
 const EXTRA_ALLOWED = new Set(["/sitemap.md", "/llms.txt", "/agents.md"])
 
-/**
- * Allowlist check for `get_page` input. Reusing the proxy registry's anchored
- * regexes doubles as the SSRF guard: only registered `.md` mirrors (whose slug
- * class rejects slashes) can be fetched.
- */
+// SSRF guard: only registered `.md` mirrors (whose anchored regexes reject
+// slashes in slugs) can be fetched.
 export function isKnownMarkdownPath(path: string): boolean {
   return (
     EXTRA_ALLOWED.has(path) ||

--- a/src/lib/mcp/handlers.ts
+++ b/src/lib/mcp/handlers.ts
@@ -13,13 +13,8 @@ export function serveMcpCard() {
   return NextResponse.json(mcpServerCard, { headers: CARD_HEADERS })
 }
 
-/**
- * GET on the live endpoint: strict Streamable-HTTP clients probing for a
- * server-initiated SSE stream get the spec-mandated 405 (serving is
- * stateless); anything else gets the discovery card. Never CDN-cached —
- * Vercel's cache ignores `Vary: Accept`, so a cached card would be served
- * to SSE probes too (verified on a preview deployment).
- */
+// Never CDN-cached: Vercel's cache ignores `Vary: Accept`, so a cached card
+// would also be served to SSE probes that must get the 405.
 export function serveMcpCardOr405(request: Request) {
   const accept = request.headers.get("accept") ?? ""
   if (accept.includes("text/event-stream")) {

--- a/src/lib/mcp/handlers.ts
+++ b/src/lib/mcp/handlers.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server"
+
+import { mcpServerCard } from "./manifest"
+
+export { mcpRequestHandler } from "./server"
+
+const CARD_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Cache-Control": "public, max-age=3600"
+} as const
+
+export function serveMcpCard() {
+  return NextResponse.json(mcpServerCard, { headers: CARD_HEADERS })
+}
+
+/**
+ * GET on the live endpoint: strict Streamable-HTTP clients probing for a
+ * server-initiated SSE stream get the spec-mandated 405 (serving is
+ * stateless); anything else gets the discovery card.
+ */
+export function serveMcpCardOr405(request: Request) {
+  const accept = request.headers.get("accept") ?? ""
+  if (accept.includes("text/event-stream")) {
+    return new NextResponse(null, { status: 405, headers: { Allow: "POST" } })
+  }
+  return serveMcpCard()
+}

--- a/src/lib/mcp/handlers.ts
+++ b/src/lib/mcp/handlers.ts
@@ -16,12 +16,22 @@ export function serveMcpCard() {
 /**
  * GET on the live endpoint: strict Streamable-HTTP clients probing for a
  * server-initiated SSE stream get the spec-mandated 405 (serving is
- * stateless); anything else gets the discovery card.
+ * stateless); anything else gets the discovery card. Never CDN-cached —
+ * Vercel's cache ignores `Vary: Accept`, so a cached card would be served
+ * to SSE probes too (verified on a preview deployment).
  */
 export function serveMcpCardOr405(request: Request) {
   const accept = request.headers.get("accept") ?? ""
   if (accept.includes("text/event-stream")) {
-    return new NextResponse(null, { status: 405, headers: { Allow: "POST" } })
+    return new NextResponse(null, {
+      status: 405,
+      headers: { Allow: "POST", "Cache-Control": "no-store" }
+    })
   }
-  return serveMcpCard()
+  return NextResponse.json(mcpServerCard, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Cache-Control": "no-store"
+    }
+  })
 }

--- a/src/lib/mcp/manifest.ts
+++ b/src/lib/mcp/manifest.ts
@@ -1,0 +1,48 @@
+import { COMPANY_FACTS } from "@/lib/company-facts"
+import { SITE_URL } from "@/lib/constants"
+
+export const MCP_SERVER_NAME = "basement-studio"
+export const MCP_SERVER_VERSION = "1.0.0"
+
+export const MCP_TOOL_SUMMARIES = [
+  {
+    name: "get_studio_info",
+    description:
+      "Canonical facts about basement.studio: services, notable clients, location, contact channels."
+  },
+  {
+    name: "list_content",
+    description:
+      "Index of every page, blog post, showcase project, and open position, with markdown mirror URLs."
+  },
+  {
+    name: "get_page",
+    description:
+      "Fetch any page of the site as markdown by its mirror path, e.g. /services.md or /post/<slug>.md."
+  },
+  {
+    name: "search_content",
+    description: "Search site content by title; returns matching markdown URLs."
+  }
+] as const
+
+/**
+ * Discovery "server card" served at /.well-known/mcp (GET) and
+ * /.well-known/mcp.json. MCP discovery is still a draft (SEP-1649/SEP-1960),
+ * so the card carries the fields both proposals agree on: identity, endpoint,
+ * transport, auth, and the tool list.
+ */
+export const mcpServerCard = {
+  name: MCP_SERVER_NAME,
+  version: MCP_SERVER_VERSION,
+  title: "basement.studio",
+  description: `${COMPANY_FACTS.description} This MCP server exposes the studio's public content — pages, blog posts, showcase projects, and open positions — as read-only tools.`,
+  endpoint: `${SITE_URL}/.well-known/mcp`,
+  transport: ["streamable-http"],
+  authentication: { type: "none" },
+  capabilities: { tools: {} },
+  tools: MCP_TOOL_SUMMARIES,
+  website: SITE_URL,
+  documentation: `${SITE_URL}/llms.txt`,
+  contact: COMPANY_FACTS.contactEmail
+}

--- a/src/lib/mcp/manifest.ts
+++ b/src/lib/mcp/manifest.ts
@@ -26,12 +26,8 @@ export const MCP_TOOL_SUMMARIES = [
   }
 ] as const
 
-/**
- * Discovery "server card" served at /.well-known/mcp (GET) and
- * /.well-known/mcp.json. MCP discovery is still a draft (SEP-1649/SEP-1960),
- * so the card carries the fields both proposals agree on: identity, endpoint,
- * transport, auth, and the tool list.
- */
+// MCP discovery is still a draft (SEP-1649/SEP-1960); the card carries the
+// fields both proposals agree on.
 export const mcpServerCard = {
   name: MCP_SERVER_NAME,
   version: MCP_SERVER_VERSION,

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1,0 +1,107 @@
+import { createMcpHandler } from "mcp-handler"
+import { z } from "zod"
+
+import { COMPANY_FACTS } from "@/lib/company-facts"
+
+import { fetchContentIndex } from "./content"
+import { fetchMarkdownPage, isKnownMarkdownPath } from "./get-page"
+import {
+  MCP_SERVER_NAME,
+  MCP_SERVER_VERSION,
+  MCP_TOOL_SUMMARIES
+} from "./manifest"
+
+const toolDescription = (name: string) =>
+  MCP_TOOL_SUMMARIES.find((tool) => tool.name === name)?.description
+
+const text = (value: string) => ({
+  content: [{ type: "text" as const, text: value }]
+})
+
+const errorText = (value: string) => ({
+  content: [{ type: "text" as const, text: value }],
+  isError: true
+})
+
+export const mcpRequestHandler = createMcpHandler(
+  (server) => {
+    server.registerTool(
+      "get_studio_info",
+      {
+        title: "Studio info",
+        description: toolDescription("get_studio_info"),
+        inputSchema: z.object({})
+      },
+      async () => text(JSON.stringify(COMPANY_FACTS, null, 2))
+    )
+
+    server.registerTool(
+      "list_content",
+      {
+        title: "List content",
+        description: toolDescription("list_content"),
+        inputSchema: z.object({})
+      },
+      async () => {
+        const entries = await fetchContentIndex()
+        return text(JSON.stringify(entries, null, 2))
+      }
+    )
+
+    server.registerTool(
+      "get_page",
+      {
+        title: "Get page as markdown",
+        description: toolDescription("get_page"),
+        inputSchema: z.object({
+          path: z
+            .string()
+            .describe(
+              "Markdown mirror path, e.g. /services.md or /post/<slug>.md — see list_content"
+            )
+        })
+      },
+      async ({ path }) => {
+        if (!isKnownMarkdownPath(path)) {
+          return errorText(
+            `Unknown path "${path}". Valid paths are the markdown mirrors listed by list_content (e.g. /services.md, /post/<slug>.md) plus /sitemap.md, /llms.txt, and /agents.md.`
+          )
+        }
+        const page = await fetchMarkdownPage(path)
+        if (!page.ok) {
+          return errorText(`Fetching "${path}" failed with ${page.status}.`)
+        }
+        return text(page.text)
+      }
+    )
+
+    server.registerTool(
+      "search_content",
+      {
+        title: "Search content",
+        description: toolDescription("search_content"),
+        inputSchema: z.object({
+          query: z.string().describe("Case-insensitive title search")
+        })
+      },
+      async ({ query }) => {
+        const entries = await fetchContentIndex()
+        const needle = query.toLowerCase()
+        const matches = entries.filter((entry) =>
+          entry.title.toLowerCase().includes(needle)
+        )
+        if (matches.length === 0) {
+          return text(
+            `No titles match "${query}". Use list_content for the full index.`
+          )
+        }
+        return text(JSON.stringify(matches, null, 2))
+      }
+    )
+  },
+  {
+    serverInfo: { name: MCP_SERVER_NAME, version: MCP_SERVER_VERSION },
+    instructions:
+      "Read-only access to basement.studio content. Start with list_content or search_content to find a page, then get_page to read it as markdown."
+  }
+)

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -1,8 +1,7 @@
 import { SITE_URL } from "@/lib/constants"
 
-// Note: intentionally untyped — openapi-types' V3_1 definitions reject valid
-// 3.1 documents (V3/V3_1 intersection bug). Validity is asserted with a
-// runtime validator instead (see the verification steps in the PR).
+// Untyped on purpose: openapi-types' V3_1 definitions reject valid 3.1
+// documents (V3/V3_1 intersection bug).
 const MARKDOWN_RESPONSE = {
   description: "Markdown document",
   content: {
@@ -32,12 +31,8 @@ const slugParameter = (kind: string) => ({
   schema: { type: "string" }
 })
 
-/**
- * Machine-readable description of every public endpoint basement.studio
- * serves. Only real surface belongs here — the content mirrors registered in
- * `src/service/sanity/markdown-proxy.config.ts` plus the basketball scores
- * API. Served at /openapi.json by `src/app/openapi.json/route.ts`.
- */
+// Only real surface belongs here: the content mirrors registered in
+// markdown-proxy.config.ts plus the basketball scores API.
 export const openApiDocument = {
   openapi: "3.1.0",
   info: {

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -1,0 +1,356 @@
+import { SITE_URL } from "@/lib/constants"
+
+// Note: intentionally untyped — openapi-types' V3_1 definitions reject valid
+// 3.1 documents (V3/V3_1 intersection bug). Validity is asserted with a
+// runtime validator instead (see the verification steps in the PR).
+const MARKDOWN_RESPONSE = {
+  description: "Markdown document",
+  content: {
+    "text/markdown": { schema: { type: "string" } }
+  }
+}
+
+const MARKDOWN_NOT_FOUND = {
+  description: "Unknown slug — markdown body `# 404 Not Found`",
+  content: {
+    "text/markdown": { schema: { type: "string" } }
+  }
+}
+
+const MARKDOWN_ERROR = {
+  description: "Server error — markdown body `# 500 Error`",
+  content: {
+    "text/markdown": { schema: { type: "string" } }
+  }
+}
+
+const slugParameter = (kind: string) => ({
+  name: "slug",
+  in: "path",
+  required: true,
+  description: `The ${kind} slug, exactly as listed in /sitemap.md.`,
+  schema: { type: "string" }
+})
+
+/**
+ * Machine-readable description of every public endpoint basement.studio
+ * serves. Only real surface belongs here — the content mirrors registered in
+ * `src/service/sanity/markdown-proxy.config.ts` plus the basketball scores
+ * API. Served at /openapi.json by `src/app/openapi.json/route.ts`.
+ */
+export const openApiDocument = {
+  openapi: "3.1.0",
+  info: {
+    title: "basement.studio public API",
+    version: "1.0.0",
+    description:
+      "Read-only content API for basement.studio, a digital design and engineering studio. Every content page has a markdown mirror — append `.md` to its URL or request the HTML URL with `Accept: text/markdown`. A live MCP server with the same content as callable tools is available at /.well-known/mcp (Streamable HTTP, no auth). The only read-write endpoint is the basketball leaderboard used by the on-site mini-game.",
+    contact: {
+      name: "basement.studio",
+      url: `${SITE_URL}/contact`,
+      email: "hello@basement.studio"
+    }
+  },
+  servers: [{ url: SITE_URL }],
+  paths: {
+    "/{page}.md": {
+      get: {
+        operationId: "getPageMarkdown",
+        summary: "Top-level page as markdown",
+        description:
+          "Markdown mirror of a top-level content page. `index` mirrors the homepage.",
+        parameters: [
+          {
+            name: "page",
+            in: "path",
+            required: true,
+            schema: {
+              type: "string",
+              enum: [
+                "index",
+                "services",
+                "people",
+                "showcase",
+                "faq",
+                "blog",
+                "contact",
+                "lab"
+              ]
+            }
+          }
+        ],
+        responses: {
+          "200": MARKDOWN_RESPONSE,
+          "500": MARKDOWN_ERROR
+        }
+      }
+    },
+    "/post/{slug}.md": {
+      get: {
+        operationId: "getPostMarkdown",
+        summary: "Blog post as markdown",
+        description:
+          'Markdown mirror of a blog post. Slugs are listed under "Blog Posts" in /sitemap.md.',
+        parameters: [slugParameter("blog post")],
+        responses: {
+          "200": MARKDOWN_RESPONSE,
+          "404": MARKDOWN_NOT_FOUND,
+          "500": MARKDOWN_ERROR
+        }
+      }
+    },
+    "/showcase/{slug}.md": {
+      get: {
+        operationId: "getProjectMarkdown",
+        summary: "Showcase project as markdown",
+        description:
+          'Markdown mirror of a portfolio project / case study. Slugs are listed under "Projects" in /sitemap.md.',
+        parameters: [slugParameter("project")],
+        responses: {
+          "200": MARKDOWN_RESPONSE,
+          "404": MARKDOWN_NOT_FOUND,
+          "500": MARKDOWN_ERROR
+        }
+      }
+    },
+    "/careers/{slug}.md": {
+      get: {
+        operationId: "getOpenPositionMarkdown",
+        summary: "Open position as markdown",
+        description:
+          'Markdown mirror of an open job position. Slugs are listed under "Open Positions" in /sitemap.md.',
+        parameters: [slugParameter("open position")],
+        responses: {
+          "200": MARKDOWN_RESPONSE,
+          "404": MARKDOWN_NOT_FOUND,
+          "500": MARKDOWN_ERROR
+        }
+      }
+    },
+    "/sitemap.md": {
+      get: {
+        operationId: "listContent",
+        summary: "Content index",
+        description:
+          "Markdown index of every page, blog post, project, and open position, each linking to its markdown mirror. The starting point for content discovery.",
+        responses: {
+          "200": MARKDOWN_RESPONSE,
+          "500": MARKDOWN_ERROR
+        }
+      }
+    },
+    "/llms.txt": {
+      get: {
+        operationId: "getLlmsTxt",
+        summary: "llms.txt link map",
+        description:
+          "Curated link map of the site for LLMs and agents, per the llms.txt convention.",
+        responses: {
+          "200": {
+            description: "Plain-text link map",
+            content: { "text/plain": { schema: { type: "string" } } }
+          }
+        }
+      }
+    },
+    "/agents.md": {
+      get: {
+        operationId: "getAgentsNotes",
+        summary: "Notes for AI agents",
+        description:
+          "When-to-use guidance, contact channels, and crawler notes for AI agents.",
+        responses: { "200": MARKDOWN_RESPONSE }
+      }
+    },
+    "/openapi.json": {
+      get: {
+        operationId: "getOpenApiDocument",
+        summary: "This document",
+        responses: {
+          "200": {
+            description: "OpenAPI 3.1 document",
+            content: { "application/json": { schema: { type: "object" } } }
+          }
+        }
+      }
+    },
+    "/.well-known/mcp.json": {
+      get: {
+        operationId: "getMcpServerCard",
+        summary: "MCP server discovery card",
+        description:
+          "Discovery document for the live MCP server at /.well-known/mcp (Streamable HTTP transport, no authentication).",
+        responses: {
+          "200": {
+            description: "MCP server card",
+            content: { "application/json": { schema: { type: "object" } } }
+          }
+        }
+      }
+    },
+    "/api/scores": {
+      get: {
+        operationId: "getScores",
+        summary: "Basketball leaderboard — top 25",
+        description:
+          "Top 25 scores from the on-site basketball mini-game (/basketball), highest first. Not cached (`Cache-Control: no-store`).",
+        responses: {
+          "200": {
+            description: "Leaderboard entries",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    data: {
+                      type: "array",
+                      items: { $ref: "#/components/schemas/Score" }
+                    }
+                  },
+                  required: ["data"]
+                }
+              }
+            }
+          },
+          "500": {
+            description: "Server error",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ApiError" }
+              }
+            }
+          }
+        }
+      },
+      post: {
+        operationId: "submitScore",
+        summary: "Submit a basketball score",
+        description:
+          "Submits a score for the on-site basketball mini-game. Exists for the game client: submissions must carry a `timeWindowHash` anti-abuse token bound to the current 30-second window, so scores can only be posted from an active game session. Rate limited per `clientId` (3 requests/minute).",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/ScoreSubmission" }
+            }
+          }
+        },
+        responses: {
+          "200": {
+            description: "Score accepted (or an equal/lower score ignored)",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: { success: { type: "boolean" } },
+                  required: ["success"]
+                }
+              }
+            }
+          },
+          "400": {
+            description:
+              "Validation failure — `error` is one of: Invalid time window hash, Invalid timestamp, Invalid time window verification, Invalid player name, Invalid score, Invalid client ID",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ApiError" }
+              }
+            }
+          },
+          "429": {
+            description: "Rate limited (per clientId)",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ApiError" }
+              }
+            }
+          },
+          "500": {
+            description: "Server error",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ApiError" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {
+      Score: {
+        type: "object",
+        description: "A leaderboard row",
+        properties: {
+          id: { type: "integer" },
+          player_name: {
+            type: "string",
+            minLength: 3,
+            maxLength: 3,
+            description: "Three-character arcade-style tag"
+          },
+          score: { type: "integer" },
+          country: {
+            type: "string",
+            description: "Emoji flag of the submitter's country"
+          },
+          created_at: { type: "string", format: "date-time" }
+        },
+        additionalProperties: true
+      },
+      ScoreSubmission: {
+        type: "object",
+        properties: {
+          playerName: {
+            type: "string",
+            minLength: 3,
+            maxLength: 3,
+            description: "Three-character arcade-style tag"
+          },
+          score: { type: "integer", minimum: 0, maximum: 399 },
+          clientId: { type: "string" },
+          timestamp: {
+            type: "integer",
+            description:
+              "Client Unix time in milliseconds; must be within 30 seconds of server time"
+          },
+          timeWindowHash: {
+            type: "string",
+            description:
+              "Anti-abuse token bound to the current 30-second time window, issued to the game client"
+          }
+        },
+        required: [
+          "playerName",
+          "score",
+          "clientId",
+          "timestamp",
+          "timeWindowHash"
+        ]
+      },
+      ApiError: {
+        type: "object",
+        properties: { error: { type: "string" } },
+        required: ["error"]
+      },
+      NotFoundError: {
+        type: "object",
+        description:
+          "Returned for unknown /api/* paths so agents get structure instead of an HTML shell",
+        properties: {
+          error: {
+            type: "object",
+            properties: {
+              code: { type: "string" },
+              message: { type: "string" },
+              hint: { type: "string" }
+            },
+            required: ["code", "message", "hint"]
+          }
+        },
+        required: ["error"]
+      }
+    }
+  }
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,7 @@
 import { isbot } from "isbot"
 import { type NextRequest, NextResponse, userAgent } from "next/server"
 
+import { SITE_URL } from "@/lib/constants"
 import { markdownRoutes } from "@/service/sanity/markdown-proxy.config"
 
 /**
@@ -9,9 +10,15 @@ import { markdownRoutes } from "@/service/sanity/markdown-proxy.config"
  *   1. `/post/<slug>.md`                      → rewrite to the markdown route
  *   2. `/post/<slug>` + `Accept: text/markdown` → rewrite (content negotiation)
  *   3. `/post/<slug>` (HTML)                  → advertise the `.md` alternate
+ *   4. Unknown path + non-HTML client        → markdown 404 with recovery links
  *
  * Routes are declared in `markdown-proxy.config.ts`. The matcher below must be
  * kept in sync with that registry (Next requires a static matcher literal).
+ *
+ * Step 4 exists because the prerendered `[...notFound]` artifact is an empty
+ * client shell (a request-time `notFound()` would lock the status at 200), so
+ * the recovery body for agents has to come from here — the only place that
+ * runs before the response streams.
  */
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
@@ -65,7 +72,82 @@ export function proxy(request: NextRequest) {
     return response
   }
 
-  return NextResponse.next()
+  return handleUnknownPath(request, accept)
+}
+
+/**
+ * Real routes that live outside the markdown registry. A path reaching
+ * `handleUnknownPath` that isn't listed here (and has no file extension) is
+ * genuinely unknown. Add a line when adding a top-level route.
+ */
+const PASS_PREFIXES = [
+  "/ai",
+  "/studio",
+  "/mcp",
+  "/.well-known",
+  "/api",
+  "/blog",
+  "/basketball",
+  "/doom",
+  "/404",
+  "/_next",
+  "/_vercel"
+]
+
+const PASS_EXACT = new Set([
+  "/sitemap.md",
+  "/agents.md",
+  "/llms.txt",
+  "/openapi.json"
+])
+
+const NOT_FOUND_BODY = [
+  "# 404 — Page not found",
+  "",
+  `Nothing exists at this path on basement.studio. Useful entry points:`,
+  "",
+  `- Content index of every page, post, and project: ${SITE_URL}/sitemap.md`,
+  `- Curated link map: ${SITE_URL}/llms.txt`,
+  `- Homepage (markdown): ${SITE_URL}/index.md`,
+  `- Machine view (plain HTML): ${SITE_URL}/ai`,
+  `- API description: ${SITE_URL}/openapi.json`,
+  ""
+].join("\n")
+
+function handleUnknownPath(request: NextRequest, accept: string) {
+  const { pathname } = request.nextUrl
+
+  if (PASS_EXACT.has(pathname)) return NextResponse.next()
+  if (
+    PASS_PREFIXES.some(
+      (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
+    )
+  ) {
+    return NextResponse.next()
+  }
+
+  // Static/public files (any non-.md extension) are not ours to 404.
+  if (/\.[a-z0-9]+$/i.test(pathname) && !pathname.endsWith(".md")) {
+    return NextResponse.next()
+  }
+
+  // Browsers and the client-side router keep the app's own 404 (the
+  // prerendered shell already carries the real 404 status).
+  const isRouterFetch =
+    request.headers.get("rsc") === "1" || accept.includes("text/x-component")
+  if (accept.includes("text/html") || isRouterFetch) {
+    return NextResponse.next()
+  }
+
+  return new NextResponse(NOT_FOUND_BODY, {
+    status: 404,
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Vary: "Accept",
+      "X-Content-Type-Options": "nosniff",
+      "Cache-Control": "no-store"
+    }
+  })
 }
 
 function rewriteToApi(
@@ -101,6 +183,9 @@ export const config = {
     "/contact.md",
     // /lab also runs the mobile user-agent redirect (see top of proxy()).
     "/lab",
-    "/lab.md"
+    "/lab.md",
+    // Everything else, so unknown paths get the markdown 404 (step 4). The
+    // exclusions are cost-only — handleUnknownPath re-checks real routes.
+    "/((?!_next/|_vercel/|api/|studio/|images/|fonts/|3d/|emulators/|dos-programs/|basis-transcoder/|readme/|favicon\\.ico).*)"
   ]
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -14,11 +14,6 @@ import { markdownRoutes } from "@/service/sanity/markdown-proxy.config"
  *
  * Routes are declared in `markdown-proxy.config.ts`. The matcher below must be
  * kept in sync with that registry (Next requires a static matcher literal).
- *
- * Step 4 exists because the prerendered `[...notFound]` artifact is an empty
- * client shell (a request-time `notFound()` would lock the status at 200), so
- * the recovery body for agents has to come from here — the only place that
- * runs before the response streams.
  */
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
@@ -75,11 +70,8 @@ export function proxy(request: NextRequest) {
   return handleUnknownPath(request, accept)
 }
 
-/**
- * Real routes that live outside the markdown registry. A path reaching
- * `handleUnknownPath` that isn't listed here (and has no file extension) is
- * genuinely unknown. Add a line when adding a top-level route.
- */
+// Real routes outside the markdown registry — add a line when adding a
+// top-level route, or its non-HTML traffic gets the 404 below.
 const PASS_PREFIXES = [
   "/ai",
   "/studio",
@@ -126,13 +118,10 @@ function handleUnknownPath(request: NextRequest, accept: string) {
     return NextResponse.next()
   }
 
-  // Static/public files (any non-.md extension) are not ours to 404.
   if (/\.[a-z0-9]+$/i.test(pathname) && !pathname.endsWith(".md")) {
     return NextResponse.next()
   }
 
-  // Browsers and the client-side router keep the app's own 404 (the
-  // prerendered shell already carries the real 404 status).
   const isRouterFetch =
     request.headers.get("rsc") === "1" || accept.includes("text/x-component")
   if (accept.includes("text/html") || isRouterFetch) {
@@ -184,8 +173,8 @@ export const config = {
     // /lab also runs the mobile user-agent redirect (see top of proxy()).
     "/lab",
     "/lab.md",
-    // Everything else, so unknown paths get the markdown 404 (step 4). The
-    // exclusions are cost-only — handleUnknownPath re-checks real routes.
+    // Everything else (step 4). The exclusions are cost-only —
+    // handleUnknownPath re-checks real routes.
     "/((?!_next/|_vercel/|api/|studio/|images/|fonts/|3d/|emulators/|dos-programs/|basis-transcoder/|readme/|favicon\\.ico).*)"
   ]
 }


### PR DESCRIPTION
## Summary

Three agent-readiness fixes from the Is Agentic audit (69/100): agent-friendly 404 bodies, a published OpenAPI spec with structured JSON `/api` errors, and a live MCP server. All verified on the preview deployment.

## Changes

- **404 recovery body** — unknown paths now return a markdown 404 with recovery links (`/sitemap.md`, `/llms.txt`, `/index.md`, `/ai`, `/openapi.json`) for non-HTML clients, served from `src/proxy.ts` (new catch-all matcher entry + `handleUnknownPath()`). Browsers and RSC router fetches keep the prerendered shell + WebGL 404 scene with the same 404 status as today. Why the proxy: the prerendered `[...notFound]` artifact is an empty client shell, and a request-time `notFound()` locks the status at 200 (streamed) — the proxy is the only place that can set both status and body. The `(site)` not-found boundary is now a server wrapper adding an `sr-only` recovery block (covers `/404` and request-time `notFound()` renders, e.g. bad post slugs); the root boundary gets visible links. **Note:** `PASS_PREFIXES` in `src/proxy.ts` must gain a line when a new top-level route is added.
- **OpenAPI + JSON API errors** — `/openapi.json` (route handler, CORS-enabled, document in `src/lib/openapi.ts`) describes the real public surface: the markdown content mirrors and `/api/scores` GET/POST with exact request/response shapes; 11 operations, unique `operationId`s, validates as OpenAPI 3.1. Unmatched `/api/*` paths return `{ error: { code, message, hint } }` JSON 404s via an optional catch-all (`src/app/api/[[...rest]]/route.ts`); existing `/api` routes win by route precedence.
- **Live MCP server** — `mcp-handler@2.1.1` (stateless Streamable HTTP, no sessions/Redis) mounted at `/.well-known/mcp`, aliased at `/mcp`, discovery card on GET and at `/.well-known/mcp.json`. Four read-only tools: `get_studio_info`, `list_content`, `search_content`, `get_page` (the markdown-mirror registry doubles as its path allowlist). The live endpoint's GET is `no-store` because Vercel's edge cache ignores `Vary: Accept` (caught on the preview: the cached card was served to SSE probes instead of the spec-mandated 405).
- `llms.txt`, `agents.md`, and `sitemap.md` advertise the new surfaces. New deps: `mcp-handler`, `@modelcontextprotocol/server`, `zod`.

## Verification (local prod build + preview deployment)

- `curl /<unknown>` → 404 + markdown links; browser Accept → 404 shell (UX unchanged); `/404` → 404 (matches production); unknown `.md` → markdown 404; RSC fetch → passthrough 404
- Real routes unchanged: pages, blog categories, `.md` mirrors, `Accept: text/markdown` negotiation, `Link` alternate headers, `/api/scores`, draft-mode
- `/openapi.json` validates (`@seriousme/openapi-schema-validator`); `/api/<unknown>` → structured JSON 404
- MCP initialize / tools-list / tools-call succeed on `/.well-known/mcp` and `/mcp` on the preview; SSE-probe GET → 405; card cacheable at `/.well-known/mcp.json`

## Checklist

- [x] `pnpm lint` passes (remaining errors are pre-existing on `main`: `scenesConfig.ts`, `inspectables-meta.ts`)
- [x] Tested locally against a prod build and on the Vercel preview deployment
- [x] No breaking changes