### PR TITLE
perf(canvas): keep leva out of the production scene chunk

### DIFF
--- a/src/components/camera/camera-controller.tsx
+++ b/src/components/camera/camera-controller.tsx
@@ -1,26 +1,17 @@
 import { useThree } from "@react-three/fiber"
-import { useControls } from "leva"
-import { useEffect, useState } from "react"
+import { useEffect } from "react"
 import { PerspectiveCamera } from "three"
 
+import { useDebugCameraStore } from "@/components/debug/debug-state"
 import { useNavigationStore } from "@/components/navigation-handler/navigation-store"
 
 import { CustomCamera } from "./camera-controls"
 import { WasdControls } from "./wasd-controls"
 
 export const CameraController = () => {
-  const [isFlyMode, setIsFlyMode] = useState(true)
+  const isFlyMode = useDebugCameraStore((state) => state.flyMode)
   const { camera } = useThree()
   const setMainCamera = useNavigationStore((state) => state.setMainCamera)
-
-  useControls("camera", {
-    flyMode: {
-      value: false,
-      onChange: (value) => {
-        setIsFlyMode(value)
-      }
-    }
-  })
 
   useEffect(() => {
     if (camera instanceof PerspectiveCamera) setMainCamera(camera)

--- a/src/components/debug/debug-state.ts
+++ b/src/components/debug/debug-state.ts
@@ -1,0 +1,79 @@
+import { create } from "zustand"
+
+export const useDebugCameraStore = create<{
+  flyMode: boolean
+  setFlyMode: (flyMode: boolean) => void
+}>((set) => ({
+  flyMode: false,
+  setFlyMode: (flyMode) => set({ flyMode })
+}))
+
+export interface PostprocessingBasics {
+  contrast: number
+  brightness: number
+  exposure: number
+  gamma: number
+}
+
+export interface PostprocessingBloom {
+  strength: number
+  radius: number
+  threshold: number
+}
+
+export interface PostprocessingVignette {
+  radius: number
+  spread: number
+}
+
+export const postprocessingDebug = {
+  hasChanged: { current: false },
+  basics: {
+    current: {
+      contrast: 1,
+      brightness: 1,
+      exposure: 1,
+      gamma: 1
+    } satisfies PostprocessingBasics
+  },
+  bloom: {
+    current: {
+      strength: 1,
+      radius: 1,
+      threshold: 1
+    } satisfies PostprocessingBloom
+  },
+  vignette: {
+    current: {
+      radius: 1,
+      spread: 1
+    } satisfies PostprocessingVignette
+  }
+}
+
+interface LevaSetters {
+  setBasics: (value: PostprocessingBasics) => void
+  setBloom: (value: PostprocessingBloom) => void
+  setVignette: (value: PostprocessingVignette) => void
+}
+
+let levaSetters: Partial<LevaSetters> = {}
+
+export const registerLevaSetters = (setters: Partial<LevaSetters> | null) => {
+  levaSetters = setters ?? {}
+}
+
+export const syncPostprocessingLeva = {
+  setBasics: (value: PostprocessingBasics) => {
+    Object.assign(postprocessingDebug.basics.current, value)
+    levaSetters.setBasics?.(value)
+  },
+  setBloom: (value: PostprocessingBloom) => {
+    Object.assign(postprocessingDebug.bloom.current, value)
+    levaSetters.setBloom?.(value)
+  },
+  setVignette: (value: PostprocessingVignette) => {
+    Object.assign(postprocessingDebug.vignette.current, value)
+    levaSetters.setVignette?.(value)
+  }
+}

--- a/src/components/debug/index.tsx
+++ b/src/components/debug/index.tsx
@@ -1,7 +1,6 @@
-import { Leva } from "leva"
 import dynamic from "next/dynamic"
 import { useSearchParams } from "next/navigation"
-import { memo, Suspense, useEffect, useState } from "react"
+import { memo, Suspense } from "react"
 
 const OnlyDebug = dynamic(
   () => import("./only-debug").then((mod) => mod.OnlyDebug),
@@ -13,18 +12,15 @@ const OnlyDebug = dynamic(
 
 const DebugInner = () => {
   const searchParams = useSearchParams()
-  const [debug, setDebug] = useState(false)
+  const debug = searchParams.has("debug")
 
-  useEffect(() => {
-    const hasDebg = searchParams.has("debug")
-    if (!hasDebg) return
-    setDebug(hasDebg)
-  }, [searchParams])
+  if (!debug) return null
 
   return (
     <div className="w-128 absolute bottom-4 right-4 z-50">
-      <Leva collapsed fill hidden={!debug} />
-      <Suspense fallback={null}>{debug && <OnlyDebug />}</Suspense>
+      <Suspense fallback={null}>
+        <OnlyDebug />
+      </Suspense>
     </div>
   )
 }

--- a/src/components/debug/only-debug.tsx
+++ b/src/components/debug/only-debug.tsx
@@ -1,5 +1,145 @@
-// this module will be dynamically imported only on debug
+"use client"
 
+import { Leva, useControls } from "leva"
+import { useEffect } from "react"
+
+import {
+  postprocessingDebug,
+  registerLevaSetters,
+  useDebugCameraStore
+} from "./debug-state"
 import { ReactScan } from "./react-scan"
 
-export const OnlyDebug = () => <ReactScan />
+const onNumberChange =
+  (write: (value: number) => void) =>
+  (value: number, _path: string, context: { initial: boolean }) => {
+    write(value)
+    if (!context.initial) postprocessingDebug.hasChanged.current = true
+  }
+
+const CameraDebugControls = () => {
+  const setFlyMode = useDebugCameraStore((state) => state.setFlyMode)
+
+  useControls("camera", {
+    flyMode: {
+      value: false,
+      onChange: setFlyMode
+    }
+  })
+
+  useEffect(() => () => setFlyMode(false), [setFlyMode])
+
+  return null
+}
+
+const PostprocessingDebugControls = () => {
+  const [, setBasics] = useControls("Basics", () => ({
+    contrast: {
+      value: postprocessingDebug.basics.current.contrast,
+      min: 0,
+      max: 2,
+      step: 0.01,
+      onChange: onNumberChange((value) => {
+        postprocessingDebug.basics.current.contrast = value
+      })
+    },
+    brightness: {
+      value: postprocessingDebug.basics.current.brightness,
+      min: 0,
+      max: 2,
+      step: 0.01,
+      onChange: onNumberChange((value) => {
+        postprocessingDebug.basics.current.brightness = value
+      })
+    },
+    exposure: {
+      value: postprocessingDebug.basics.current.exposure,
+      min: 0,
+      max: 2,
+      step: 0.01,
+      onChange: onNumberChange((value) => {
+        postprocessingDebug.basics.current.exposure = value
+      })
+    },
+    gamma: {
+      value: postprocessingDebug.basics.current.gamma,
+      min: 0,
+      max: 2,
+      step: 0.01,
+      onChange: onNumberChange((value) => {
+        postprocessingDebug.basics.current.gamma = value
+      })
+    }
+  }))
+
+  const [, setBloom] = useControls("Bloom", () => ({
+    strength: {
+      value: postprocessingDebug.bloom.current.strength,
+      min: 0,
+      max: 10,
+      step: 0.01,
+      onChange: onNumberChange((value) => {
+        postprocessingDebug.bloom.current.strength = value
+      })
+    },
+    radius: {
+      value: postprocessingDebug.bloom.current.radius,
+      min: 0,
+      max: 10,
+      step: 0.01,
+      onChange: onNumberChange((value) => {
+        postprocessingDebug.bloom.current.radius = value
+      })
+    },
+    threshold: {
+      value: postprocessingDebug.bloom.current.threshold,
+      min: 0,
+      max: 10,
+      step: 0.01,
+      onChange: onNumberChange((value) => {
+        postprocessingDebug.bloom.current.threshold = value
+      })
+    }
+  }))
+
+  const [, setVignette] = useControls("Vignette", () => ({
+    radius: {
+      value: postprocessingDebug.vignette.current.radius,
+      min: 0,
+      max: 5,
+      step: 0.01,
+      onChange: onNumberChange((value) => {
+        postprocessingDebug.vignette.current.radius = value
+      })
+    },
+    spread: {
+      value: postprocessingDebug.vignette.current.spread,
+      min: 0,
+      max: 5,
+      step: 0.01,
+      onChange: onNumberChange((value) => {
+        postprocessingDebug.vignette.current.spread = value
+      })
+    }
+  }))
+
+  useEffect(() => {
+    registerLevaSetters({ setBasics, setBloom, setVignette })
+    return () => {
+      registerLevaSetters(null)
+      postprocessingDebug.hasChanged.current = false
+    }
+  }, [setBasics, setBloom, setVignette])
+
+  return null
+}
+
+// Dynamically imported from ./index only when ?debug is present.
+export const OnlyDebug = () => (
+  <>
+    <Leva collapsed fill />
+    <CameraDebugControls />
+    <PostprocessingDebugControls />
+    <ReactScan />
+  </>
+)

--- a/src/components/postprocessing/use-postprocessing-settings.tsx
+++ b/src/components/postprocessing/use-postprocessing-settings.tsx
@@ -1,151 +1,16 @@
-import { useControls } from "leva"
-import { useRef } from "react"
-
-interface Basics {
-  contrast: number
-  brightness: number
-  exposure: number
-  gamma: number
-}
-
-interface Bloom {
-  strength: number
-  radius: number
-  threshold: number
-}
-
-interface Vignette {
-  radius: number
-  spread: number
-}
+import {
+  postprocessingDebug,
+  syncPostprocessingLeva
+} from "@/components/debug/debug-state"
 
 export const usePostprocessingSettings = () => {
-  const hasChanged = useRef(false)
-
-  const basics = useRef<Basics>({
-    contrast: 1,
-    brightness: 1,
-    exposure: 1,
-    gamma: 1
-  })
-
-  const bloom = useRef<Bloom>({
-    strength: 1,
-    radius: 1,
-    threshold: 1
-  })
-
-  const vignette = useRef<Vignette>({
-    radius: 1,
-    spread: 1
-  })
-
-  const [_, setBasics] = useControls("Basics", () => ({
-    contrast: {
-      value: 1,
-      min: 0,
-      max: 2,
-      step: 0.01,
-      onChange: (v) => {
-        basics.current.contrast = v
-        hasChanged.current = true
-      }
-    },
-    brightness: {
-      value: 1,
-      min: 0,
-      max: 2,
-      step: 0.01,
-      onChange: (v) => {
-        basics.current.brightness = v
-        hasChanged.current = true
-      }
-    },
-    exposure: {
-      value: 1,
-      min: 0,
-      max: 2,
-      step: 0.01,
-      onChange: (v) => {
-        basics.current.exposure = v
-        hasChanged.current = true
-      }
-    },
-    gamma: {
-      value: 1,
-      min: 0,
-      max: 2,
-      step: 0.01,
-      onChange: (v) => {
-        basics.current.gamma = v
-        hasChanged.current = true
-      }
-    }
-  }))
-
-  const [__, setBloom] = useControls("Bloom", () => ({
-    strength: {
-      value: 1,
-      min: 0,
-      max: 10,
-      step: 0.01,
-      onChange: (v) => {
-        bloom.current.strength = v
-        hasChanged.current = true
-      }
-    },
-    radius: {
-      value: 1,
-      min: 0,
-      max: 10,
-      step: 0.01,
-      onChange: (v) => {
-        bloom.current.radius = v
-        hasChanged.current = true
-      }
-    },
-    threshold: {
-      value: 1,
-      min: 0,
-      max: 10,
-      step: 0.01,
-      onChange: (v) => {
-        bloom.current.threshold = v
-        hasChanged.current = true
-      }
-    }
-  }))
-
-  const [___, setVignette] = useControls("Vignette", () => ({
-    radius: {
-      value: 1,
-      min: 0,
-      max: 5,
-      step: 0.01,
-      onChange: (v) => {
-        vignette.current.radius = v
-        hasChanged.current = true
-      }
-    },
-    spread: {
-      value: 1,
-      min: 0,
-      max: 5,
-      step: 0.01,
-      onChange: (v) => {
-        vignette.current.spread = v
-        hasChanged.current = true
-      }
-    }
-  }))
-
   return {
-    basics: basics.current,
-    bloom: bloom.current,
-    vignette: vignette.current,
-    setBasics,
-    setBloom,
-    setVignette,
-    hasChanged
+    basics: postprocessingDebug.basics.current,
+    bloom: postprocessingDebug.bloom.current,
+    vignette: postprocessingDebug.vignette.current,
+    setBasics: syncPostprocessingLeva.setBasics,
+    setBloom: syncPostprocessingLeva.setBloom,
+    setVignette: syncPostprocessingLeva.setVignette,
+    hasChanged: postprocessingDebug.hasChanged
   }
 }


### PR DESCRIPTION
## Summary
- Stop shipping the leva debug UI (~40 KB gz) to every canvas visitor. It was statically imported from the Scene graph (`camera-controller`, `use-postprocessing-settings`, `debug/index`).
- Load leva only when `?debug` is present, via the existing dynamic `only-debug` chunk. Production still uses CustomCamera (`flyMode` defaults to false) and scene postprocessing presets.

## Changes
- Gate `debug/index.tsx` on `?debug` and drop the static `Leva` import.
- Move all `useControls` into `only-debug.tsx`; share flyMode / postprocessing refs through a leva-free `debug-state.ts`.
- Production build: leva lives in its own async chunk and is not in the Scene bundle or homepage HTML. Chrome check: no leva without `?debug`; panel + flyMode/Basics/Bloom/Vignette with `/?debug`.

## Checklist
- [x] `pnpm lint` passes (eslint on the touched files)
- [x] Tested locally in production mode (`next start`) with Chrome
- [x] No breaking changes (or documented in summary)