### PR TITLE
perf: load Motion via LazyMotion and swap chrome to m components

### DIFF
--- a/src/app/(site)/(canvas)/(content)/services/awards.tsx
+++ b/src/app/(site)/(canvas)/(content)/services/awards.tsx
@@ -3,7 +3,7 @@
 import throttle from "lodash.throttle"
 import {
   AnimatePresence,
-  motion,
+  m,
   useMotionValue,
   useSpring,
   useTransform,
@@ -279,7 +279,7 @@ const HoverCertificate = memo(
     }, [currentImageId, sortedAwards])
 
     return (
-      <motion.div
+      <m.div
         style={{
           position: "fixed",
           top: 0,
@@ -310,7 +310,7 @@ const HoverCertificate = memo(
                   {isRevealing ? (
                     <>
                       {gridCells.map((cell) => (
-                        <motion.rect
+                        <m.rect
                           key={cell.index}
                           custom={{
                             manhattanDistance: cell.manhattanDistance
@@ -333,7 +333,7 @@ const HoverCertificate = memo(
                           height={certificateDimensions.height / GRID_ROWS + 1}
                         />
                       ))}
-                      <motion.rect
+                      <m.rect
                         key="full-mask"
                         initial={{ opacity: 0 }}
                         animate={{ opacity: 1 }}
@@ -372,7 +372,7 @@ const HoverCertificate = memo(
         >
           {renderCurrentCertificateImage}
         </div>
-      </motion.div>
+      </m.div>
     )
   }
 )

--- a/src/app/(site)/(canvas)/(content)/showcase/list.tsx
+++ b/src/app/(site)/(canvas)/(content)/showcase/list.tsx
@@ -1,5 +1,5 @@
 import * as AccordionPrimitive from "@radix-ui/react-accordion"
-import { motion } from "motion/react"
+import { m } from "motion/react"
 import Image from "next/image"
 import Link from "next/link"
 import { memo, useCallback, useState } from "react"
@@ -149,7 +149,7 @@ const AccordionListItem = memo(
                 )
 
                 return (
-                  <motion.div
+                  <m.div
                     key={imgIndex}
                     initial={{ opacity: 0 }}
                     whileInView={{
@@ -174,7 +174,7 @@ const AccordionListItem = memo(
                     className="relative col-span-2 aspect-video"
                   >
                     {elementToRender}
-                  </motion.div>
+                  </m.div>
                 )
               })}
             </Link>

--- a/src/app/(site)/layout.tsx
+++ b/src/app/(site)/layout.tsx
@@ -10,6 +10,7 @@ import { InspectableProvider } from "@/components/inspectables/context"
 import { CanvasLayer } from "@/components/layout/canvas-layer"
 import { ModeToggle } from "@/components/layout/mode-toggle"
 import { NavigationHandler } from "@/components/navigation-handler"
+import { MotionProvider } from "@/components/primitives/motion-provider"
 import { Transitions } from "@/components/transitions"
 import { HtmlTunnelOut } from "@/components/tunnel"
 
@@ -28,12 +29,14 @@ const SiteLayout = async ({ children }: { children: React.ReactNode }) => {
       <Transitions />
       <AssetsProvider assets={assets}>
         <InspectableProvider>
-          <HtmlTunnelOut />
-          <NavigationHandler />
-          <CanvasLayer />
-          {children}
-          <AppHooks assets={assets} />
-          <Contact />
+          <MotionProvider>
+            <HtmlTunnelOut />
+            <NavigationHandler />
+            <CanvasLayer />
+            {children}
+            <AppHooks assets={assets} />
+            <Contact />
+          </MotionProvider>
         </InspectableProvider>
       </AssetsProvider>
       <ModeToggle mode="human" />

--- a/src/components/brands/index.tsx
+++ b/src/components/brands/index.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { AnimatePresence, motion } from "motion/react"
+import { AnimatePresence, m } from "motion/react"
 import Image from "next/image"
 import { useState } from "react"
 
@@ -30,7 +30,7 @@ const BrandLogo = ({ logo }: { logo: Brand["logo"] }) => {
 export const AnimatedTitle = ({ brandName }: { brandName: string }) => (
   <AnimatePresence mode="wait">
     {brandName ? (
-      <motion.span
+      <m.span
         animate={{ opacity: 1, y: 0 }}
         className="ml-px inline-flex items-center gap-x-2 text-f-h3-mobile text-brand-w1 lg:text-f-h3"
         exit={{ opacity: 0, y: -10 }}
@@ -39,9 +39,9 @@ export const AnimatedTitle = ({ brandName }: { brandName: string }) => (
         transition={{ ease: "easeOut", duration: 0.2 }}
       >
         {brandName} <ExternalLinkIcon className="size-4" />
-      </motion.span>
+      </m.span>
     ) : (
-      <motion.span
+      <m.span
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: -10 }}
         initial={{ opacity: 0, y: 10 }}
@@ -49,7 +49,7 @@ export const AnimatedTitle = ({ brandName }: { brandName: string }) => (
         transition={{ ease: "easeOut", duration: 0.2 }}
       >
         Visionaries
-      </motion.span>
+      </m.span>
     )}
   </AnimatePresence>
 )
@@ -93,7 +93,7 @@ export const BrandsDesktop = ({ brands }: BrandsDesktopProps) => {
       <div className="relative col-span-full">
         <div className="grid-rows-auto group grid grid-cols-6 gap-3 xl:grid-cols-8">
           {filteredBrands.map((brand) => (
-            <motion.a
+            <m.a
               className="aspect-[202/110] text-brand-w1 focus-visible:!ring-offset-0"
               href={brand.website ?? ""}
               key={brand._id}
@@ -120,7 +120,7 @@ export const BrandsDesktop = ({ brands }: BrandsDesktopProps) => {
                 />
                 <BrandLogo logo={brand.logo} />
               </div>
-            </motion.a>
+            </m.a>
           ))}
         </div>
       </div>

--- a/src/components/layout/navbar-content.tsx
+++ b/src/components/layout/navbar-content.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { AnimatePresence, motion } from "motion/react"
+import { AnimatePresence, domMax, LazyMotion, m } from "motion/react"
 import { usePathname } from "next/navigation"
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { mergeRefs } from "react-merge-refs"
@@ -42,7 +42,7 @@ const ContextMenu = memo(({ x, y, onClose, onCopy }: ContextMenuProps) => {
   }
 
   return (
-    <motion.div
+    <m.div
       initial={{ opacity: 0, scale: 0.95 }}
       animate={{ opacity: 1, scale: 1 }}
       exit={{ opacity: 0, scale: 0.95 }}
@@ -55,7 +55,7 @@ const ContextMenu = memo(({ x, y, onClose, onCopy }: ContextMenuProps) => {
       >
         <AnimatePresence mode="wait">
           {copied ? (
-            <motion.span
+            <m.span
               key="copied"
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
@@ -64,9 +64,9 @@ const ContextMenu = memo(({ x, y, onClose, onCopy }: ContextMenuProps) => {
               className="text-brand-w1"
             >
               Copied!
-            </motion.span>
+            </m.span>
           ) : (
-            <motion.span
+            <m.span
               key="copy"
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
@@ -75,11 +75,11 @@ const ContextMenu = memo(({ x, y, onClose, onCopy }: ContextMenuProps) => {
               className="group-hover:text-brand-o"
             >
               Copy logo as SVG
-            </motion.span>
+            </m.span>
           )}
         </AnimatePresence>
       </button>
-    </motion.div>
+    </m.div>
   )
 })
 ContextMenu.displayName = "ContextMenu"
@@ -297,7 +297,7 @@ const MobileContent = memo(
 
       return (
         <Portal id="mobile-menu">
-          <motion.div
+          <m.div
             ref={mergeRefs([mobileMenuRef, focusTrapRef])}
             className={cn(
               "grid-layout fixed left-0 top-[35px] z-navbar h-[calc(100dvh-35px)] w-full origin-top grid-rows-2 bg-brand-k py-6"
@@ -315,7 +315,7 @@ const MobileContent = memo(
               animated={true}
             />
 
-            <motion.div
+            <m.div
               initial={{ opacity: 0 }}
               animate={{ opacity: 1, transition: { delay: 0.4 } }}
               exit={{ opacity: 0 }}
@@ -326,8 +326,8 @@ const MobileContent = memo(
                 <SocialLinks links={socialLinks} />
                 <Copyright year={year} />
               </div>
-            </motion.div>
-          </motion.div>
+            </m.div>
+          </m.div>
         </Portal>
       )
       // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -344,7 +344,7 @@ const MobileContent = memo(
     const Label = useMemo(() => {
       return function Label({ children }: { children: React.ReactNode }) {
         return (
-          <motion.p
+          <m.p
             id="menu-button"
             key={isOpen ? "close" : "menu"}
             className="w-[2.4rem] origin-bottom text-center text-f-p-mobile text-brand-w1"
@@ -354,7 +354,7 @@ const MobileContent = memo(
             transition={{ duration: 0.9, type: "spring", bounce: 0 }}
           >
             {children}
-          </motion.p>
+          </m.p>
         )
       }
     }, [isOpen])
@@ -369,40 +369,42 @@ const MobileContent = memo(
       }
     }
     return (
-      <div className="col-start-3 col-end-5 flex items-center justify-end gap-5 lg:hidden">
-        <MusicToggle />
+      <LazyMotion features={domMax}>
+        <div className="col-start-3 col-end-5 flex items-center justify-end gap-5 lg:hidden">
+          <MusicToggle />
 
-        <button
-          onClick={handleMenuClick}
-          className="flex items-center"
-          aria-label={isOpen ? "Close menu" : "Open menu"}
-        >
-          <AnimatePresence mode="popLayout" initial={false}>
-            {isOpen ? <Label>Close</Label> : <Label>Menu</Label>}
-          </AnimatePresence>
-
-          <span
-            className="relative flex w-5 flex-col items-center justify-center gap-1 overflow-visible pl-1"
-            ref={menuHandlerRef}
-            aria-labelledby="menu-button"
+          <button
+            onClick={handleMenuClick}
+            className="flex items-center"
+            aria-label={isOpen ? "Close menu" : "Open menu"}
           >
-            <span
-              className={cn(
-                "h-[1.5px] w-full origin-center transform bg-brand-w1 transition-[transform,width] duration-300 ease-in-out",
-                { "w-10/12 translate-y-[3px] rotate-[45deg]": isOpen }
-              )}
-            />
-            <span
-              className={cn(
-                "h-[1.5px] w-full origin-center transform bg-brand-w1 transition-[transform,width] duration-300 ease-in-out",
-                { "w-10/12 -translate-y-[2.5px] -rotate-[45deg]": isOpen }
-              )}
-            />
-          </span>
-        </button>
+            <AnimatePresence mode="popLayout" initial={false}>
+              {isOpen ? <Label>Close</Label> : <Label>Menu</Label>}
+            </AnimatePresence>
 
-        <AnimatePresence>{memoizedMenu}</AnimatePresence>
-      </div>
+            <span
+              className="relative flex w-5 flex-col items-center justify-center gap-1 overflow-visible pl-1"
+              ref={menuHandlerRef}
+              aria-labelledby="menu-button"
+            >
+              <span
+                className={cn(
+                  "h-[1.5px] w-full origin-center transform bg-brand-w1 transition-[transform,width] duration-300 ease-in-out",
+                  { "w-10/12 translate-y-[3px] rotate-[45deg]": isOpen }
+                )}
+              />
+              <span
+                className={cn(
+                  "h-[1.5px] w-full origin-center transform bg-brand-w1 transition-[transform,width] duration-300 ease-in-out",
+                  { "w-10/12 -translate-y-[2.5px] -rotate-[45deg]": isOpen }
+                )}
+              />
+            </span>
+          </button>
+
+          <AnimatePresence>{memoizedMenu}</AnimatePresence>
+        </div>
+      </LazyMotion>
     )
   }
 )

--- a/src/components/layout/shared-sections.tsx
+++ b/src/components/layout/shared-sections.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { motion } from "motion/react"
+import { m } from "motion/react"
 import { usePathname } from "next/navigation"
 
 import { Link } from "@/components/primitives/link"
@@ -56,7 +56,7 @@ export const InternalLinks = ({
       )}
     >
       {filteredLinks.map((link, idx) => (
-        <motion.li
+        <m.li
           key={`${link.title}-${idx}`}
           {...animateProps}
           animate={{
@@ -90,10 +90,10 @@ export const InternalLinks = ({
               </sup>
             )}
           </Link>
-        </motion.li>
+        </m.li>
       ))}
 
-      <motion.li
+      <m.li
         {...animateProps}
         animate={{
           ...animateProps.animate,
@@ -123,7 +123,7 @@ export const InternalLinks = ({
         >
           <span className="actionable">Contact Us</span>
         </button>
-      </motion.li>
+      </m.li>
     </ul>
   )
 }

--- a/src/components/layout/stay-connected.tsx
+++ b/src/components/layout/stay-connected.tsx
@@ -2,7 +2,7 @@
 
 import { PortableText } from "@portabletext/react"
 import { track } from "@vercel/analytics"
-import { AnimatePresence, motion } from "motion/react"
+import { AnimatePresence, m } from "motion/react"
 import { startTransition, useEffect, useState } from "react"
 import { useActionState } from "react"
 
@@ -126,7 +126,7 @@ export const StayConnected = ({ content, className }: StayConnectedProps) => {
           disabled={formState !== "idle" || !email}
           className="ml-1 flex w-fit translate-y-1 items-center gap-1 overflow-hidden text-f-h4-mobile lg:text-f-h4"
         >
-          <motion.div
+          <m.div
             animate={{
               color:
                 formState === "success"
@@ -141,7 +141,7 @@ export const StayConnected = ({ content, className }: StayConnectedProps) => {
           >
             <AnimatePresence mode="wait">
               {formState === "success" ? (
-                <motion.span
+                <m.span
                   key="success"
                   initial={{ y: 40, opacity: 0 }}
                   animate={{ y: 0, opacity: 1 }}
@@ -150,16 +150,16 @@ export const StayConnected = ({ content, className }: StayConnectedProps) => {
                   className="flex items-center gap-x-1 text-f-h4-mobile lg:text-f-h4"
                 >
                   Subscribed Successfully
-                  <motion.span
+                  <m.span
                     initial={{ scale: 0 }}
                     animate={{ scale: 1 }}
                     transition={{ duration: 0.2, ease: "easeOut" }}
                   >
                     <Checkmark className="scale-75 text-brand-g" state={true} />
-                  </motion.span>
-                </motion.span>
+                  </m.span>
+                </m.span>
               ) : formState === "error" ? (
-                <motion.span
+                <m.span
                   key="error"
                   initial={{ y: 40, opacity: 0 }}
                   animate={{ y: 0, opacity: 1 }}
@@ -168,9 +168,9 @@ export const StayConnected = ({ content, className }: StayConnectedProps) => {
                   className="flex items-center gap-x-1 text-f-h4-mobile lg:text-f-h4"
                 >
                   {getErrorMessage()}
-                </motion.span>
+                </m.span>
               ) : (
-                <motion.span
+                <m.span
                   key="default"
                   initial={{ y: 40, opacity: 0 }}
                   animate={{ y: 0, opacity: 1 }}
@@ -183,10 +183,10 @@ export const StayConnected = ({ content, className }: StayConnectedProps) => {
                   )}
                 >
                   Roll Me In <Arrow className="size-5" />
-                </motion.span>
+                </m.span>
               )}
             </AnimatePresence>
-          </motion.div>
+          </m.div>
         </button>
       </form>
     </div>

--- a/src/components/primitives/motion-provider.tsx
+++ b/src/components/primitives/motion-provider.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { domAnimation, LazyMotion } from "motion/react"
+
+export const MotionProvider = ({ children }: { children: React.ReactNode }) => (
+  <LazyMotion features={domAnimation}>{children}</LazyMotion>
+)


### PR DESCRIPTION
## Summary

Motion was imported as the full `motion/react` bundle in components that hydrate on every route (navbar, footer/stay-connected, shared sections), paying ~25-35 KB gz for features most of them never use. This switches those components to `m.*` behind a root-level `LazyMotion`, and keeps Motion out of machine (`/ai`) routes.

## Changes

- Add `MotionProvider` (`LazyMotion features={domAnimation}`) in `(site)/layout.tsx` so `/ai` routes never download or hydrate Motion
- Swap `motion.*` → `m.*` in always-hydrated chrome: navbar-content, stay-connected, shared-sections
- Swap `m.*` in brands, showcase list, and services awards pages
- Wrap the navbar mobile menu (uses `AnimatePresence mode="popLayout"`) in a nested `LazyMotion features={domMax}`, since popLayout needs layout projection

## Checklist

- [x] `pnpm lint` passes (touched files clean)
- [ ] Tested locally in dev mode
- [ ] No breaking changes (or documented in summary)
