### PR TITLE
perf(cache): wrap markdown API routes in "use cache" builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - **Sanity data has three fetch modes (`src/service/sanity/index.ts`) — pick by context:**
   - `sanityFetch` — Live; only valid **inside a `"use cache"` scope** (its `cacheTag()` throws otherwise). For draft/preview render.
   - `sanityFetchCached` — Live wrapped in `"use cache"`; the default for published page/route content. Revalidates via Sanity Live tags.
-  - `sanityFetchStatic` — non-Live plain client. Use in every context that is **not** a `"use cache"` scope: `generateStaticParams`, `generateMetadata`, **server actions**, and uncached route handlers.
+  - `sanityFetchStatic` — non-Live plain client. Use in contexts that are **not** a `"use cache"` scope: `generateStaticParams` and **server actions**. Route handlers and `generateMetadata` can use `sanityFetchCached` or a `"use cache"` build wrapper.
   - Gotcha: calling the Live `sanityFetch` outside a `"use cache"` scope 500s with `` `cacheTag()` can only be called inside a "use cache" function ``. When in doubt outside a page render, use `sanityFetchStatic`.
 - **Request-time logic goes in `src/proxy.ts`, not in pages.** Reading `headers()`/`cookies()` at the top of a page forces it dynamic under Cache Components. Keep pages prerenderable; do per-request work (UA redirects, content negotiation) in the matcher-scoped proxy. Example: `/lab`'s mobile redirect lives in the proxy so the page stays static.
 - **Revalidation is tag-based, not time-based.** `<SanityLive />` (root layout) invalidates cached content on publish; the 1-year `cacheLife` is only a backstop. Any new cached fetcher must route through the Sanity helpers above so its tags register.

--- a/src/actions/laboratory-fetch/sanity.ts
+++ b/src/actions/laboratory-fetch/sanity.ts
@@ -1,4 +1,4 @@
-import { sanityFetchStatic } from "@/service/sanity"
+import { sanityFetch, sanityFetchStatic } from "@/service/sanity"
 import { imageFragment } from "@/service/sanity/queries"
 
 export interface LabProject {
@@ -16,16 +16,26 @@ export interface LabProject {
   } | null
 }
 
+const labProjectsQuery = /* groq */ `*[_type == "labProject"] {
+  title,
+  url,
+  description,
+  cover ${imageFragment}
+}`
+
 export async function fetchLabProjects(): Promise<LabProject[]> {
   // Called from a server action (not a `"use cache"` scope), so use the non-Live
   // fetch — the Live `sanityFetch`'s `cacheTag()` throws outside `use cache`.
   return sanityFetchStatic<LabProject[]>({
-    query: /* groq */ `*[_type == "labProject"] {
-      title,
-      url,
-      description,
-      cover ${imageFragment}
-    }`,
+    query: labProjectsQuery,
+    perspective: "published"
+  })
+}
+
+/** For `/api/lab.md` — caller provides a `"use cache"` scope. */
+export async function fetchLabProjectsPublished(): Promise<LabProject[]> {
+  return sanityFetch<LabProject[]>({
+    query: labProjectsQuery,
     perspective: "published"
   })
 }

--- a/src/actions/laboratory-fetch/sanity.ts
+++ b/src/actions/laboratory-fetch/sanity.ts
@@ -23,18 +23,12 @@ const labProjectsQuery = /* groq */ `*[_type == "labProject"] {
   cover ${imageFragment}
 }`
 
-export async function fetchLabProjects(): Promise<LabProject[]> {
-  // Called from a server action (not a `"use cache"` scope), so use the non-Live
-  // fetch — the Live `sanityFetch`'s `cacheTag()` throws outside `use cache`.
-  return sanityFetchStatic<LabProject[]>({
-    query: labProjectsQuery,
-    perspective: "published"
-  })
-}
-
-/** For `/api/lab.md` — caller provides a `"use cache"` scope. */
-export async function fetchLabProjectsPublished(): Promise<LabProject[]> {
-  return sanityFetch<LabProject[]>({
+export async function fetchLabProjects(
+  /** Pass `published: true` inside a `"use cache"` scope (e.g. the `.md` build) — outside one the Live fetch's `cacheTag()` throws, so the default is the non-Live client the server action needs. */
+  options?: { published?: boolean }
+): Promise<LabProject[]> {
+  const fetch = options?.published ? sanityFetch : sanityFetchStatic
+  return fetch<LabProject[]>({
     query: labProjectsQuery,
     perspective: "published"
   })

--- a/src/app/(site)/(plain)/(content)/careers/[slug]/sanity.ts
+++ b/src/app/(site)/(plain)/(content)/careers/[slug]/sanity.ts
@@ -51,16 +51,10 @@ export async function fetchCareerPosition(
       skills[] { title, slug }
     }
   }`
-  if (options?.published) {
-    return sanityFetch<CareerPosition | null>({
-      query,
-      params: { slug },
-      perspective: "published"
-    })
-  }
   return sanityFetch<CareerPosition | null>({
     query,
-    params: { slug }
+    params: { slug },
+    ...(options?.published ? { perspective: "published" as const } : {})
   })
 }
 

--- a/src/app/(site)/(plain)/(content)/careers/[slug]/sanity.ts
+++ b/src/app/(site)/(plain)/(content)/careers/[slug]/sanity.ts
@@ -32,7 +32,7 @@ export interface CareerPosition {
 
 export async function fetchCareerPosition(
   slug: string,
-  /** Pass `published: true` for non-draft contexts (e.g. the `.md` endpoint) — disables stega so output isn't polluted with invisible chars. */
+  /** Pass `published: true` inside a `"use cache"` scope (e.g. the `.md` build) — pins published perspective so stega stays off and no dynamic APIs are touched. */
   options?: { published?: boolean }
 ): Promise<CareerPosition | null> {
   const query = /* groq */ `*[_type == "openPosition" && slug.current == $slug][0]{
@@ -52,9 +52,10 @@ export async function fetchCareerPosition(
     }
   }`
   if (options?.published) {
-    return sanityFetchStatic<CareerPosition | null>({
+    return sanityFetch<CareerPosition | null>({
       query,
-      params: { slug }
+      params: { slug },
+      perspective: "published"
     })
   }
   return sanityFetch<CareerPosition | null>({

--- a/src/app/(site)/(plain)/(content)/post/[slug]/sanity.ts
+++ b/src/app/(site)/(plain)/(content)/post/[slug]/sanity.ts
@@ -42,7 +42,7 @@ export interface RelatedPost {
 
 export async function fetchPostBySlug(
   slug: string,
-  /** Pass `published: true` for non-draft contexts (e.g. the `.md` endpoint) — disables stega so output isn't polluted with invisible chars. */
+  /** Pass `published: true` inside a `"use cache"` scope (e.g. the `.md` build) — pins published perspective so stega stays off and no dynamic APIs are touched. */
   options?: { published?: boolean }
 ): Promise<PostDetail | null> {
   const query = /* groq */ `*[_type == "post" && slug.current == $slug][0]{
@@ -85,9 +85,10 @@ export async function fetchPostBySlug(
     heroVideo
   }`
   if (options?.published) {
-    return sanityFetchStatic<PostDetail | null>({
+    return sanityFetch<PostDetail | null>({
       query,
-      params: { slug }
+      params: { slug },
+      perspective: "published"
     })
   }
   return sanityFetch<PostDetail | null>({
@@ -152,9 +153,8 @@ export interface RelatedPostMarkdown {
 }
 
 /**
- * Same selection as fetchRelatedPosts, minus heroImage, via the non-Live
- * published client — the `.md` route isn't a `"use cache"` scope, so the Live
- * fetch would throw, and published perspective keeps stega out.
+ * Same selection as fetchRelatedPosts, minus heroImage. Published perspective
+ * keeps stega out. Call from a `"use cache"` scope (e.g. the `.md` build).
  */
 export async function fetchRelatedPostsForMarkdown(
   currentSlug: string,
@@ -173,9 +173,7 @@ export async function fetchRelatedPostsForMarkdown(
     date,
     categories[]->{ title, "slug": slug.current }
   }`
-  const posts = await sanityFetchStatic<Array<
-    Omit<RelatedPost, "heroImage">
-  > | null>({
+  const posts = await sanityFetch<Array<Omit<RelatedPost, "heroImage">>>({
     query,
     params: { slug: currentSlug, titles: currentCategoryTitles },
     perspective: "published"

--- a/src/app/(site)/(plain)/(content)/post/[slug]/sanity.ts
+++ b/src/app/(site)/(plain)/(content)/post/[slug]/sanity.ts
@@ -84,16 +84,10 @@ export async function fetchPostBySlug(
     heroImage ${imageFragment},
     heroVideo
   }`
-  if (options?.published) {
-    return sanityFetch<PostDetail | null>({
-      query,
-      params: { slug },
-      perspective: "published"
-    })
-  }
   return sanityFetch<PostDetail | null>({
     query,
-    params: { slug }
+    params: { slug },
+    ...(options?.published ? { perspective: "published" as const } : {})
   })
 }
 
@@ -173,11 +167,13 @@ export async function fetchRelatedPostsForMarkdown(
     date,
     categories[]->{ title, "slug": slug.current }
   }`
-  const posts = await sanityFetch<Array<Omit<RelatedPost, "heroImage">>>({
-    query,
-    params: { slug: currentSlug, titles: currentCategoryTitles },
-    perspective: "published"
-  })
+  const posts = await sanityFetch<Array<Omit<RelatedPost, "heroImage">> | null>(
+    {
+      query,
+      params: { slug: currentSlug, titles: currentCategoryTitles },
+      perspective: "published"
+    }
+  )
   if (!posts) return []
 
   return selectRelatedPosts({

--- a/src/app/(site)/(plain)/(content)/showcase/[slug]/sanity.ts
+++ b/src/app/(site)/(plain)/(content)/showcase/[slug]/sanity.ts
@@ -114,13 +114,14 @@ const relatedProjectsIconsQuery = /* groq */ `
 
 export async function fetchProjectBySlug(
   slug: string,
-  /** Pass `published: true` for non-draft contexts (e.g. the `.md` endpoint) — disables stega so output isn't polluted with invisible chars. */
+  /** Pass `published: true` inside a `"use cache"` scope (e.g. the `.md` build) — pins published perspective so stega stays off and no dynamic APIs are touched. */
   options?: { published?: boolean }
 ): Promise<ShowcaseProjectDetail | null> {
   if (options?.published) {
-    return sanityFetchStatic<ShowcaseProjectDetail | null>({
+    return sanityFetch<ShowcaseProjectDetail | null>({
       query: projectBySlugQuery,
-      params: { slug }
+      params: { slug },
+      perspective: "published"
     })
   }
   return sanityFetch<ShowcaseProjectDetail | null>({

--- a/src/app/(site)/(plain)/(content)/showcase/[slug]/sanity.ts
+++ b/src/app/(site)/(plain)/(content)/showcase/[slug]/sanity.ts
@@ -117,16 +117,10 @@ export async function fetchProjectBySlug(
   /** Pass `published: true` inside a `"use cache"` scope (e.g. the `.md` build) — pins published perspective so stega stays off and no dynamic APIs are touched. */
   options?: { published?: boolean }
 ): Promise<ShowcaseProjectDetail | null> {
-  if (options?.published) {
-    return sanityFetch<ShowcaseProjectDetail | null>({
-      query: projectBySlugQuery,
-      params: { slug },
-      perspective: "published"
-    })
-  }
   return sanityFetch<ShowcaseProjectDetail | null>({
     query: projectBySlugQuery,
-    params: { slug }
+    params: { slug },
+    ...(options?.published ? { perspective: "published" as const } : {})
   })
 }
 

--- a/src/app/api/blog.md/markdown.ts
+++ b/src/app/api/blog.md/markdown.ts
@@ -1,0 +1,57 @@
+import { fetchBlogIndexForMarkdown } from "@/app/(site)/(canvas)/(content)/blog/sanity"
+import { SITE_URL } from "@/lib/constants"
+import { truncateDescription } from "@/utils/seo"
+
+// CMS strings land inside `[label](url)` syntax — escape the delimiters so a
+// bracketed label can't break the link.
+const escapeLinkLabel = (text: string) => text.replace(/[\\[\]]/g, "\\$&")
+
+export async function buildBlogMarkdown(): Promise<{
+  markdown: string
+  status: 200
+}> {
+  "use cache"
+  const { posts, categories } = await fetchBlogIndexForMarkdown()
+
+  // Category pages have no `.md` mirror (filtered lists, no unique content)
+  // — link the HTML pages.
+  const categoriesLine = categories.length
+    ? `**Categories:** ${categories
+        .map((c) => `[${escapeLinkLabel(c.title)}](${SITE_URL}/blog/${c.slug})`)
+        .join(", ")}`
+    : null
+
+  const list = posts
+    .map((post) => {
+      const link = `[${escapeLinkLabel(post.title)}](${SITE_URL}/post/${post.slug}.md)`
+      const date = post.date ? post.date.split("T")[0] : null
+      const postCategories = post.categories?.length
+        ? `(${post.categories.map((c) => c.title).join(", ")})`
+        : null
+      const meta = [date, postCategories].filter(Boolean).join(" ")
+      const detail = [meta || null, truncateDescription(post.excerpt) || null]
+        .filter(Boolean)
+        .join(" — ")
+      return detail ? `- ${link} — ${detail}` : `- ${link}`
+    })
+    .join("\n")
+
+  const parts: Array<string | null> = [
+    "# Blog",
+    "",
+    "Articles and writing from basement.studio.",
+    "",
+    categoriesLine,
+    categoriesLine ? "" : null,
+    list ? "## All Posts" : null,
+    list ? "" : null,
+    list || null,
+    "",
+    "---",
+    "",
+    `[View all content](${SITE_URL}/sitemap.md)`
+  ]
+
+  const markdown = parts.filter((part) => part !== null).join("\n")
+  return { markdown, status: 200 }
+}

--- a/src/app/api/blog.md/markdown.ts
+++ b/src/app/api/blog.md/markdown.ts
@@ -1,15 +1,12 @@
 import { fetchBlogIndexForMarkdown } from "@/app/(site)/(canvas)/(content)/blog/sanity"
 import { SITE_URL } from "@/lib/constants"
+import {
+  escapeLinkLabel,
+  type MarkdownResult
+} from "@/service/markdown/document"
 import { truncateDescription } from "@/utils/seo"
 
-// CMS strings land inside `[label](url)` syntax — escape the delimiters so a
-// bracketed label can't break the link.
-const escapeLinkLabel = (text: string) => text.replace(/[\\[\]]/g, "\\$&")
-
-export async function buildBlogMarkdown(): Promise<{
-  markdown: string
-  status: 200
-}> {
+export async function buildBlogMarkdown(): Promise<MarkdownResult<200>> {
   "use cache"
   const { posts, categories } = await fetchBlogIndexForMarkdown()
 

--- a/src/app/api/blog.md/route.ts
+++ b/src/app/api/blog.md/route.ts
@@ -1,9 +1,9 @@
 import * as Sentry from "@sentry/nextjs"
 import { NextResponse } from "next/server"
 
-import { fetchBlogIndexForMarkdown } from "@/app/(site)/(canvas)/(content)/blog/sanity"
 import { SITE_URL } from "@/lib/constants"
-import { truncateDescription } from "@/utils/seo"
+
+import { buildBlogMarkdown } from "./markdown"
 
 const MD_HEADERS = {
   "Content-Type": "text/markdown; charset=utf-8",
@@ -11,57 +11,9 @@ const MD_HEADERS = {
   "X-Content-Type-Options": "nosniff"
 } as const
 
-// CMS strings land inside `[label](url)` syntax — escape the delimiters so a
-// bracketed label can't break the link.
-const escapeLinkLabel = (text: string) => text.replace(/[\\[\]]/g, "\\$&")
-
 export async function GET() {
   try {
-    const { posts, categories } = await fetchBlogIndexForMarkdown()
-
-    // Category pages have no `.md` mirror (filtered lists, no unique content)
-    // — link the HTML pages.
-    const categoriesLine = categories.length
-      ? `**Categories:** ${categories
-          .map(
-            (c) => `[${escapeLinkLabel(c.title)}](${SITE_URL}/blog/${c.slug})`
-          )
-          .join(", ")}`
-      : null
-
-    const list = posts
-      .map((post) => {
-        const link = `[${escapeLinkLabel(post.title)}](${SITE_URL}/post/${post.slug}.md)`
-        const date = post.date ? post.date.split("T")[0] : null
-        const postCategories = post.categories?.length
-          ? `(${post.categories.map((c) => c.title).join(", ")})`
-          : null
-        const meta = [date, postCategories].filter(Boolean).join(" ")
-        const detail = [meta || null, truncateDescription(post.excerpt) || null]
-          .filter(Boolean)
-          .join(" — ")
-        return detail ? `- ${link} — ${detail}` : `- ${link}`
-      })
-      .join("\n")
-
-    const parts: Array<string | null> = [
-      "# Blog",
-      "",
-      "Articles and writing from basement.studio.",
-      "",
-      categoriesLine,
-      categoriesLine ? "" : null,
-      list ? "## All Posts" : null,
-      list ? "" : null,
-      list || null,
-      "",
-      "---",
-      "",
-      `[View all content](${SITE_URL}/sitemap.md)`
-    ]
-
-    const markdown = parts.filter((part) => part !== null).join("\n")
-
+    const { markdown } = await buildBlogMarkdown()
     return new NextResponse(markdown, {
       headers: {
         ...MD_HEADERS,

--- a/src/app/api/blog.md/route.ts
+++ b/src/app/api/blog.md/route.ts
@@ -1,31 +1,14 @@
-import * as Sentry from "@sentry/nextjs"
-import { NextResponse } from "next/server"
-
-import { SITE_URL } from "@/lib/constants"
+import {
+  markdownErrorResponse,
+  markdownResponse
+} from "@/service/markdown/response"
 
 import { buildBlogMarkdown } from "./markdown"
 
-const MD_HEADERS = {
-  "Content-Type": "text/markdown; charset=utf-8",
-  Vary: "Accept",
-  "X-Content-Type-Options": "nosniff"
-} as const
-
 export async function GET() {
   try {
-    const { markdown } = await buildBlogMarkdown()
-    return new NextResponse(markdown, {
-      headers: {
-        ...MD_HEADERS,
-        Link: `<${SITE_URL}/blog>; rel="canonical"`
-      }
-    })
+    return markdownResponse(await buildBlogMarkdown(), "/blog")
   } catch (error) {
-    console.error("Error building blog markdown:", error)
-    Sentry.captureException(error)
-    return new NextResponse("# 500 Error\n\nFailed to build markdown.", {
-      status: 500,
-      headers: MD_HEADERS
-    })
+    return markdownErrorResponse("blog", error)
   }
 }

--- a/src/app/api/careers/[slug]/markdown.ts
+++ b/src/app/api/careers/[slug]/markdown.ts
@@ -1,0 +1,47 @@
+import { cacheLife } from "next/cache"
+
+import { fetchCareerPosition } from "@/app/(site)/(plain)/(content)/careers/[slug]/sanity"
+import { SITE_URL } from "@/lib/constants"
+import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
+
+export async function buildCareerMarkdown(
+  slug: string
+): Promise<{ markdown: string; status: 200 | 404 }> {
+  "use cache"
+  const position = await fetchCareerPosition(slug, { published: true })
+  // Closed positions 404 here too, mirroring the HTML page's `notFound()`.
+  if (!position) {
+    cacheLife("hours")
+    return { markdown: "# 404 Not Found\n", status: 404 }
+  }
+  if (!position.isOpen) {
+    return { markdown: "# 404 Not Found\n", status: 404 }
+  }
+
+  const skills = position.applyFormSetup?.skills
+    ?.map((s) => s.title)
+    .filter(Boolean)
+
+  const parts: Array<string | null> = [
+    `# ${position.title}`,
+    "",
+    position.type ? `**Type:** ${position.type}` : null,
+    position.employmentType
+      ? `**Employment Type:** ${position.employmentType}`
+      : null,
+    position.location ? `**Location:** ${position.location}` : null,
+    position.applyUrl ? `**Apply:** ${position.applyUrl}` : null,
+    skills?.length ? `**Skills:** ${skills.join(", ")}` : null,
+    "",
+    "---",
+    "",
+    portableTextToMarkdown(position.jobDescription, { baseUrl: SITE_URL }),
+    "",
+    "---",
+    "",
+    `[View all content](${SITE_URL}/sitemap.md)`
+  ]
+
+  const markdown = parts.filter((part) => part !== null).join("\n")
+  return { markdown, status: 200 }
+}

--- a/src/app/api/careers/[slug]/markdown.ts
+++ b/src/app/api/careers/[slug]/markdown.ts
@@ -2,20 +2,22 @@ import { cacheLife } from "next/cache"
 
 import { fetchCareerPosition } from "@/app/(site)/(plain)/(content)/careers/[slug]/sanity"
 import { SITE_URL } from "@/lib/constants"
+import {
+  type MarkdownResult,
+  NOT_FOUND_MARKDOWN
+} from "@/service/markdown/document"
 import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
 
 export async function buildCareerMarkdown(
   slug: string
-): Promise<{ markdown: string; status: 200 | 404 }> {
+): Promise<MarkdownResult> {
   "use cache"
   const position = await fetchCareerPosition(slug, { published: true })
-  // Closed positions 404 here too, mirroring the HTML page's `notFound()`.
-  if (!position) {
-    cacheLife("hours")
-    return { markdown: "# 404 Not Found\n", status: 404 }
-  }
-  if (!position.isOpen) {
-    return { markdown: "# 404 Not Found\n", status: 404 }
+  // A missing doc has no Sanity tag to invalidate its 404, so cap it; a closed
+  // one does. Both 404, mirroring the HTML page's `notFound()`.
+  if (!position) cacheLife("hours")
+  if (!position?.isOpen) {
+    return { markdown: NOT_FOUND_MARKDOWN, status: 404 }
   }
 
   const skills = position.applyFormSetup?.skills

--- a/src/app/api/careers/[slug]/route.ts
+++ b/src/app/api/careers/[slug]/route.ts
@@ -1,42 +1,23 @@
-import * as Sentry from "@sentry/nextjs"
-import { NextResponse } from "next/server"
-
-import { SITE_URL } from "@/lib/constants"
+import {
+  markdownErrorResponse,
+  markdownNotFoundResponse,
+  markdownResponse,
+  markdownSlug
+} from "@/service/markdown/response"
 
 import { buildCareerMarkdown } from "./markdown"
-
-const MD_HEADERS = {
-  "Content-Type": "text/markdown; charset=utf-8",
-  Vary: "Accept",
-  "X-Content-Type-Options": "nosniff"
-} as const
 
 export async function GET(
   _request: Request,
   { params }: { params: Promise<{ slug: string }> }
 ) {
   const { slug: rawSlug } = await params
-
-  // Only the `.md` form is served here; the proxy rewrites to this route.
-  if (!rawSlug.endsWith(".md"))
-    return new NextResponse(null, { status: 404, headers: MD_HEADERS })
-  const slug = rawSlug.slice(0, -3)
+  const slug = markdownSlug(rawSlug)
+  if (slug === null) return markdownNotFoundResponse()
 
   try {
-    const { markdown, status } = await buildCareerMarkdown(slug)
-    return new NextResponse(markdown, {
-      status,
-      headers: {
-        ...MD_HEADERS,
-        Link: `<${SITE_URL}/careers/${slug}>; rel="canonical"`
-      }
-    })
+    return markdownResponse(await buildCareerMarkdown(slug), `/careers/${slug}`)
   } catch (error) {
-    console.error("Error building career position markdown:", error)
-    Sentry.captureException(error)
-    return new NextResponse("# 500 Error\n\nFailed to build markdown.", {
-      status: 500,
-      headers: MD_HEADERS
-    })
+    return markdownErrorResponse("career position", error)
   }
 }

--- a/src/app/api/careers/[slug]/route.ts
+++ b/src/app/api/careers/[slug]/route.ts
@@ -1,9 +1,9 @@
 import * as Sentry from "@sentry/nextjs"
 import { NextResponse } from "next/server"
 
-import { fetchCareerPosition } from "@/app/(site)/(plain)/(content)/careers/[slug]/sanity"
 import { SITE_URL } from "@/lib/constants"
-import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
+
+import { buildCareerMarkdown } from "./markdown"
 
 const MD_HEADERS = {
   "Content-Type": "text/markdown; charset=utf-8",
@@ -23,42 +23,9 @@ export async function GET(
   const slug = rawSlug.slice(0, -3)
 
   try {
-    const position = await fetchCareerPosition(slug, { published: true })
-    // Closed positions 404 here too, mirroring the HTML page's `notFound()`.
-    if (!position || !position.isOpen) {
-      return new NextResponse("# 404 Not Found\n", {
-        status: 404,
-        headers: MD_HEADERS
-      })
-    }
-
-    const skills = position.applyFormSetup?.skills
-      ?.map((s) => s.title)
-      .filter(Boolean)
-
-    const parts: Array<string | null> = [
-      `# ${position.title}`,
-      "",
-      position.type ? `**Type:** ${position.type}` : null,
-      position.employmentType
-        ? `**Employment Type:** ${position.employmentType}`
-        : null,
-      position.location ? `**Location:** ${position.location}` : null,
-      position.applyUrl ? `**Apply:** ${position.applyUrl}` : null,
-      skills?.length ? `**Skills:** ${skills.join(", ")}` : null,
-      "",
-      "---",
-      "",
-      portableTextToMarkdown(position.jobDescription, { baseUrl: SITE_URL }),
-      "",
-      "---",
-      "",
-      `[View all content](${SITE_URL}/sitemap.md)`
-    ]
-
-    const markdown = parts.filter((part) => part !== null).join("\n")
-
+    const { markdown, status } = await buildCareerMarkdown(slug)
     return new NextResponse(markdown, {
+      status,
       headers: {
         ...MD_HEADERS,
         Link: `<${SITE_URL}/careers/${slug}>; rel="canonical"`

--- a/src/app/api/contact.md/markdown.ts
+++ b/src/app/api/contact.md/markdown.ts
@@ -1,11 +1,9 @@
 import { fetchCompanyInfoForMarkdown } from "@/components/layout/sanity"
 import { COMPANY_FACTS } from "@/lib/company-facts"
 import { SITE_URL } from "@/lib/constants"
+import type { MarkdownResult } from "@/service/markdown/document"
 
-export async function buildContactMarkdown(): Promise<{
-  markdown: string
-  status: 200
-}> {
+export async function buildContactMarkdown(): Promise<MarkdownResult<200>> {
   "use cache"
   const companyInfo = await fetchCompanyInfoForMarkdown()
 

--- a/src/app/api/contact.md/markdown.ts
+++ b/src/app/api/contact.md/markdown.ts
@@ -1,0 +1,51 @@
+import { fetchCompanyInfoForMarkdown } from "@/components/layout/sanity"
+import { COMPANY_FACTS } from "@/lib/company-facts"
+import { SITE_URL } from "@/lib/constants"
+
+export async function buildContactMarkdown(): Promise<{
+  markdown: string
+  status: 200
+}> {
+  "use cache"
+  const companyInfo = await fetchCompanyInfoForMarkdown()
+
+  const socials = [
+    { label: "X (Twitter)", url: companyInfo?.twitter },
+    { label: "Instagram", url: companyInfo?.instagram },
+    { label: "GitHub", url: companyInfo?.github },
+    { label: "LinkedIn", url: companyInfo?.linkedIn }
+  ]
+    .filter((social) => social.url)
+    .map((social) => `- [${social.label}](${social.url})`)
+    .join("\n")
+
+  const parts: Array<string | null> = [
+    "# Contact basement.studio",
+    "",
+    "Tell us about your project — brands, websites, 3D experiences, or products — and let's make cool shit that performs.",
+    "",
+    `Based in ${COMPANY_FACTS.locationName} — working worldwide.`,
+    "",
+    "---",
+    "",
+    "## Email",
+    "",
+    `- General & project inquiries: ${COMPANY_FACTS.contactEmail}`,
+    `- New business / sales: ${COMPANY_FACTS.salesEmail}`,
+    "",
+    socials ? "## Social" : null,
+    socials ? "" : null,
+    socials || null,
+    socials ? "" : null,
+    "## Start a project",
+    "",
+    `Use the form at [basement.studio/contact](${SITE_URL}/contact) — it includes project type and budget fields so your inquiry reaches the right people.`,
+    "",
+    "---",
+    "",
+    `[View all content](${SITE_URL}/sitemap.md)`
+  ]
+
+  const markdown = parts.filter((part) => part !== null).join("\n")
+  return { markdown, status: 200 }
+}

--- a/src/app/api/contact.md/route.ts
+++ b/src/app/api/contact.md/route.ts
@@ -1,9 +1,9 @@
 import * as Sentry from "@sentry/nextjs"
 import { NextResponse } from "next/server"
 
-import { fetchCompanyInfoForMarkdown } from "@/components/layout/sanity"
-import { COMPANY_FACTS } from "@/lib/company-facts"
 import { SITE_URL } from "@/lib/constants"
+
+import { buildContactMarkdown } from "./markdown"
 
 const MD_HEADERS = {
   "Content-Type": "text/markdown; charset=utf-8",
@@ -13,47 +13,7 @@ const MD_HEADERS = {
 
 export async function GET() {
   try {
-    const companyInfo = await fetchCompanyInfoForMarkdown()
-
-    const socials = [
-      { label: "X (Twitter)", url: companyInfo?.twitter },
-      { label: "Instagram", url: companyInfo?.instagram },
-      { label: "GitHub", url: companyInfo?.github },
-      { label: "LinkedIn", url: companyInfo?.linkedIn }
-    ]
-      .filter((social) => social.url)
-      .map((social) => `- [${social.label}](${social.url})`)
-      .join("\n")
-
-    const parts: Array<string | null> = [
-      "# Contact basement.studio",
-      "",
-      "Tell us about your project — brands, websites, 3D experiences, or products — and let's make cool shit that performs.",
-      "",
-      `Based in ${COMPANY_FACTS.locationName} — working worldwide.`,
-      "",
-      "---",
-      "",
-      "## Email",
-      "",
-      `- General & project inquiries: ${COMPANY_FACTS.contactEmail}`,
-      `- New business / sales: ${COMPANY_FACTS.salesEmail}`,
-      "",
-      socials ? "## Social" : null,
-      socials ? "" : null,
-      socials || null,
-      socials ? "" : null,
-      "## Start a project",
-      "",
-      `Use the form at [basement.studio/contact](${SITE_URL}/contact) — it includes project type and budget fields so your inquiry reaches the right people.`,
-      "",
-      "---",
-      "",
-      `[View all content](${SITE_URL}/sitemap.md)`
-    ]
-
-    const markdown = parts.filter((part) => part !== null).join("\n")
-
+    const { markdown } = await buildContactMarkdown()
     return new NextResponse(markdown, {
       headers: {
         ...MD_HEADERS,

--- a/src/app/api/contact.md/route.ts
+++ b/src/app/api/contact.md/route.ts
@@ -1,31 +1,14 @@
-import * as Sentry from "@sentry/nextjs"
-import { NextResponse } from "next/server"
-
-import { SITE_URL } from "@/lib/constants"
+import {
+  markdownErrorResponse,
+  markdownResponse
+} from "@/service/markdown/response"
 
 import { buildContactMarkdown } from "./markdown"
 
-const MD_HEADERS = {
-  "Content-Type": "text/markdown; charset=utf-8",
-  Vary: "Accept",
-  "X-Content-Type-Options": "nosniff"
-} as const
-
 export async function GET() {
   try {
-    const { markdown } = await buildContactMarkdown()
-    return new NextResponse(markdown, {
-      headers: {
-        ...MD_HEADERS,
-        Link: `<${SITE_URL}/contact>; rel="canonical"`
-      }
-    })
+    return markdownResponse(await buildContactMarkdown(), "/contact")
   } catch (error) {
-    console.error("Error building contact markdown:", error)
-    Sentry.captureException(error)
-    return new NextResponse("# 500 Error\n\nFailed to build markdown.", {
-      status: 500,
-      headers: MD_HEADERS
-    })
+    return markdownErrorResponse("contact", error)
   }
 }

--- a/src/app/api/faq.md/markdown.ts
+++ b/src/app/api/faq.md/markdown.ts
@@ -1,0 +1,40 @@
+import { cacheLife } from "next/cache"
+
+import { fetchFaqPage } from "@/app/(site)/(plain)/(content)/faq/sanity"
+import { SITE_URL } from "@/lib/constants"
+
+export async function buildFaqMarkdown(): Promise<{
+  markdown: string
+  status: 200 | 404
+}> {
+  "use cache"
+  const faq = await fetchFaqPage({ published: true })
+
+  if (!faq?.entries.length) {
+    cacheLife("hours")
+    return { markdown: "# 404 Not Found\n", status: 404 }
+  }
+
+  const body = faq.entries.flatMap((entry) => [
+    `## ${entry.question}`,
+    "",
+    entry.answer,
+    ""
+  ])
+
+  const parts = [
+    `# ${faq.heading || "FAQ"}`,
+    "",
+    faq.intro,
+    faq.intro ? "" : null,
+    "---",
+    "",
+    ...body,
+    "---",
+    "",
+    `[View all content](${SITE_URL}/sitemap.md)`
+  ]
+
+  const markdown = parts.filter((part) => part !== null).join("\n")
+  return { markdown, status: 200 }
+}

--- a/src/app/api/faq.md/markdown.ts
+++ b/src/app/api/faq.md/markdown.ts
@@ -2,17 +2,18 @@ import { cacheLife } from "next/cache"
 
 import { fetchFaqPage } from "@/app/(site)/(plain)/(content)/faq/sanity"
 import { SITE_URL } from "@/lib/constants"
+import {
+  type MarkdownResult,
+  NOT_FOUND_MARKDOWN
+} from "@/service/markdown/document"
 
-export async function buildFaqMarkdown(): Promise<{
-  markdown: string
-  status: 200 | 404
-}> {
+export async function buildFaqMarkdown(): Promise<MarkdownResult> {
   "use cache"
   const faq = await fetchFaqPage({ published: true })
 
   if (!faq?.entries.length) {
     cacheLife("hours")
-    return { markdown: "# 404 Not Found\n", status: 404 }
+    return { markdown: NOT_FOUND_MARKDOWN, status: 404 }
   }
 
   const body = faq.entries.flatMap((entry) => [

--- a/src/app/api/faq.md/route.ts
+++ b/src/app/api/faq.md/route.ts
@@ -1,8 +1,9 @@
 import * as Sentry from "@sentry/nextjs"
 import { NextResponse } from "next/server"
 
-import { fetchFaqPage } from "@/app/(site)/(plain)/(content)/faq/sanity"
 import { SITE_URL } from "@/lib/constants"
+
+import { buildFaqMarkdown } from "./markdown"
 
 const MD_HEADERS = {
   "Content-Type": "text/markdown; charset=utf-8",
@@ -12,38 +13,9 @@ const MD_HEADERS = {
 
 export async function GET() {
   try {
-    const faq = await fetchFaqPage({ published: true })
-
-    if (!faq?.entries.length) {
-      return new NextResponse("# 404 Not Found\n", {
-        status: 404,
-        headers: MD_HEADERS
-      })
-    }
-
-    const body = faq.entries.flatMap((entry) => [
-      `## ${entry.question}`,
-      "",
-      entry.answer,
-      ""
-    ])
-
-    const parts = [
-      `# ${faq.heading || "FAQ"}`,
-      "",
-      faq.intro,
-      faq.intro ? "" : null,
-      "---",
-      "",
-      ...body,
-      "---",
-      "",
-      `[View all content](${SITE_URL}/sitemap.md)`
-    ]
-
-    const markdown = parts.filter((part) => part !== null).join("\n")
-
+    const { markdown, status } = await buildFaqMarkdown()
     return new NextResponse(markdown, {
+      status,
       headers: {
         ...MD_HEADERS,
         Link: `<${SITE_URL}/faq>; rel="canonical"`

--- a/src/app/api/faq.md/route.ts
+++ b/src/app/api/faq.md/route.ts
@@ -1,32 +1,14 @@
-import * as Sentry from "@sentry/nextjs"
-import { NextResponse } from "next/server"
-
-import { SITE_URL } from "@/lib/constants"
+import {
+  markdownErrorResponse,
+  markdownResponse
+} from "@/service/markdown/response"
 
 import { buildFaqMarkdown } from "./markdown"
 
-const MD_HEADERS = {
-  "Content-Type": "text/markdown; charset=utf-8",
-  Vary: "Accept",
-  "X-Content-Type-Options": "nosniff"
-} as const
-
 export async function GET() {
   try {
-    const { markdown, status } = await buildFaqMarkdown()
-    return new NextResponse(markdown, {
-      status,
-      headers: {
-        ...MD_HEADERS,
-        Link: `<${SITE_URL}/faq>; rel="canonical"`
-      }
-    })
+    return markdownResponse(await buildFaqMarkdown(), "/faq")
   } catch (error) {
-    console.error("Error building FAQ markdown:", error)
-    Sentry.captureException(error)
-    return new NextResponse("# 500 Error\n\nFailed to build markdown.", {
-      status: 500,
-      headers: MD_HEADERS
-    })
+    return markdownErrorResponse("FAQ", error)
   }
 }

--- a/src/app/api/index.md/markdown.ts
+++ b/src/app/api/index.md/markdown.ts
@@ -1,0 +1,120 @@
+import { cacheLife } from "next/cache"
+
+import { fetchHomepage } from "@/app/(site)/(canvas)/(content)/(home)/sanity"
+import { COMPANY_FACTS, formatFactList } from "@/lib/company-facts"
+import { SITE_URL } from "@/lib/constants"
+import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
+
+export async function buildIndexMarkdown(): Promise<{
+  markdown: string
+  status: 200 | 404
+}> {
+  "use cache"
+  const { homepage } = await fetchHomepage({ published: true })
+  if (!homepage) {
+    cacheLife("hours")
+    return { markdown: "# 404 Not Found\n", status: 404 }
+  }
+
+  const featuredWork = homepage.featuredProjects?.length
+    ? homepage.featuredProjects
+        .map((item) => {
+          const label = item.title || item.project?.title || "Untitled"
+          const slug = item.project?.slug?.current
+          const link = slug
+            ? `[${label}](${SITE_URL}/showcase/${slug}.md)`
+            : label
+          return item.excerpt ? `- ${link} — ${item.excerpt}` : `- ${link}`
+        })
+        .join("\n")
+    : null
+
+  const capabilities = homepage.capabilities?.length
+    ? homepage.capabilities
+        .map((cap) => {
+          // Match HTML's title-based filter param (slug isn't used for filtering).
+          const lines = [
+            `### [${cap.title}](${SITE_URL}/showcase?category=${encodeURIComponent(cap.title)})`
+          ]
+          if (cap.description) lines.push("", cap.description)
+          if (cap.subcategories?.length) {
+            lines.push("", ...cap.subcategories.map((s) => `- ${s.title}`))
+          }
+          return lines.join("\n")
+        })
+        .join("\n\n")
+    : null
+
+  const clients = homepage.clients?.length
+    ? homepage.clients
+        .map((c) => (c.website ? `[${c.title}](${c.website})` : c.title))
+        .join(", ")
+    : null
+
+  const whatWeDoIntro =
+    portableTextToMarkdown(homepage.capabilitiesIntro, {
+      baseUrl: SITE_URL
+    }) || null
+  const hasWhatWeDo = Boolean(whatWeDoIntro || capabilities)
+  const hasBody = Boolean(featuredWork || hasWhatWeDo || clients)
+
+  const parts: Array<string | null> = [
+    "# basement.studio",
+    "",
+    portableTextToMarkdown(homepage.introTitle, { baseUrl: SITE_URL }) || null,
+    "",
+    portableTextToMarkdown(homepage.introSubtitle, { baseUrl: SITE_URL }) ||
+      null,
+    "",
+    hasBody ? "---" : null,
+    hasBody ? "" : null,
+    featuredWork ? "## Selected Work" : null,
+    featuredWork ? "" : null,
+    featuredWork,
+    featuredWork ? "" : null,
+    hasWhatWeDo ? "## What We Do" : null,
+    hasWhatWeDo ? "" : null,
+    whatWeDoIntro,
+    capabilities ? "" : null,
+    capabilities,
+    capabilities ? "" : null,
+    clients ? "## Clients" : null,
+    clients ? "" : null,
+    clients,
+    "",
+    // Entity block mirroring the homepage's crawlable about section.
+    "## About basement.studio",
+    "",
+    COMPANY_FACTS.description,
+    "",
+    `Founded in ${COMPANY_FACTS.foundingDate} and based in ${COMPANY_FACTS.locationName}, the studio works primarily with technology companies in the San Francisco Bay Area and has partnered with startups and enterprise brands including ${formatFactList(COMPANY_FACTS.notableClients)}.`,
+    "",
+    `Services: ${formatFactList(COMPANY_FACTS.services)}.`,
+    "",
+    COMPANY_FACTS.awardsSummary,
+    "",
+    COMPANY_FACTS.geistAttribution,
+    "",
+    "## Contact",
+    "",
+    `- General & project inquiries: ${COMPANY_FACTS.contactEmail}`,
+    `- New business / sales: ${COMPANY_FACTS.salesEmail}`,
+    `- [Contact page](${SITE_URL}/contact.md)`,
+    "",
+    "## More",
+    "",
+    `- [Services](${SITE_URL}/services.md)`,
+    `- [Showcase](${SITE_URL}/showcase.md)`,
+    `- [Blog](${SITE_URL}/blog.md)`,
+    `- [People](${SITE_URL}/people.md)`,
+    `- [Lab](${SITE_URL}/lab.md)`,
+    `- [FAQ](${SITE_URL}/faq.md)`,
+    "",
+    "---",
+    "",
+    `[View all content](${SITE_URL}/sitemap.md)`
+  ]
+
+  const markdown = parts.filter((part) => part !== null).join("\n")
+  return { markdown, status: 200 }
+}

--- a/src/app/api/index.md/markdown.ts
+++ b/src/app/api/index.md/markdown.ts
@@ -3,17 +3,18 @@ import { cacheLife } from "next/cache"
 import { fetchHomepage } from "@/app/(site)/(canvas)/(content)/(home)/sanity"
 import { COMPANY_FACTS, formatFactList } from "@/lib/company-facts"
 import { SITE_URL } from "@/lib/constants"
+import {
+  type MarkdownResult,
+  NOT_FOUND_MARKDOWN
+} from "@/service/markdown/document"
 import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
 
-export async function buildIndexMarkdown(): Promise<{
-  markdown: string
-  status: 200 | 404
-}> {
+export async function buildIndexMarkdown(): Promise<MarkdownResult> {
   "use cache"
   const { homepage } = await fetchHomepage({ published: true })
   if (!homepage) {
     cacheLife("hours")
-    return { markdown: "# 404 Not Found\n", status: 404 }
+    return { markdown: NOT_FOUND_MARKDOWN, status: 404 }
   }
 
   const featuredWork = homepage.featuredProjects?.length

--- a/src/app/api/index.md/route.ts
+++ b/src/app/api/index.md/route.ts
@@ -1,29 +1,15 @@
-import * as Sentry from "@sentry/nextjs"
-import { NextResponse } from "next/server"
-
-import { SITE_URL } from "@/lib/constants"
+import {
+  markdownErrorResponse,
+  markdownResponse
+} from "@/service/markdown/response"
 
 import { buildIndexMarkdown } from "./markdown"
 
-const MD_HEADERS = {
-  "Content-Type": "text/markdown; charset=utf-8",
-  Vary: "Accept",
-  "X-Content-Type-Options": "nosniff"
-} as const
-
 export async function GET() {
   try {
-    const { markdown, status } = await buildIndexMarkdown()
-    return new NextResponse(markdown, {
-      status,
-      headers: { ...MD_HEADERS, Link: `<${SITE_URL}>; rel="canonical"` }
-    })
+    // The homepage's HTML twin is the site root.
+    return markdownResponse(await buildIndexMarkdown(), "")
   } catch (error) {
-    console.error("Error building homepage markdown:", error)
-    Sentry.captureException(error)
-    return new NextResponse("# 500 Error\n\nFailed to build markdown.", {
-      status: 500,
-      headers: MD_HEADERS
-    })
+    return markdownErrorResponse("homepage", error)
   }
 }

--- a/src/app/api/index.md/route.ts
+++ b/src/app/api/index.md/route.ts
@@ -1,10 +1,9 @@
 import * as Sentry from "@sentry/nextjs"
 import { NextResponse } from "next/server"
 
-import { fetchHomepage } from "@/app/(site)/(canvas)/(content)/(home)/sanity"
-import { COMPANY_FACTS, formatFactList } from "@/lib/company-facts"
 import { SITE_URL } from "@/lib/constants"
-import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
+
+import { buildIndexMarkdown } from "./markdown"
 
 const MD_HEADERS = {
   "Content-Type": "text/markdown; charset=utf-8",
@@ -14,117 +13,9 @@ const MD_HEADERS = {
 
 export async function GET() {
   try {
-    const { homepage } = await fetchHomepage({ published: true })
-    if (!homepage) {
-      return new NextResponse("# 404 Not Found\n", {
-        status: 404,
-        headers: MD_HEADERS
-      })
-    }
-
-    const featuredWork = homepage.featuredProjects?.length
-      ? homepage.featuredProjects
-          .map((item) => {
-            const label = item.title || item.project?.title || "Untitled"
-            const slug = item.project?.slug?.current
-            const link = slug
-              ? `[${label}](${SITE_URL}/showcase/${slug}.md)`
-              : label
-            return item.excerpt ? `- ${link} — ${item.excerpt}` : `- ${link}`
-          })
-          .join("\n")
-      : null
-
-    const capabilities = homepage.capabilities?.length
-      ? homepage.capabilities
-          .map((cap) => {
-            // Match HTML's title-based filter param (slug isn't used for filtering).
-            const lines = [
-              `### [${cap.title}](${SITE_URL}/showcase?category=${encodeURIComponent(cap.title)})`
-            ]
-            if (cap.description) lines.push("", cap.description)
-            if (cap.subcategories?.length) {
-              lines.push("", ...cap.subcategories.map((s) => `- ${s.title}`))
-            }
-            return lines.join("\n")
-          })
-          .join("\n\n")
-      : null
-
-    const clients = homepage.clients?.length
-      ? homepage.clients
-          .map((c) => (c.website ? `[${c.title}](${c.website})` : c.title))
-          .join(", ")
-      : null
-
-    const whatWeDoIntro =
-      portableTextToMarkdown(homepage.capabilitiesIntro, {
-        baseUrl: SITE_URL
-      }) || null
-    const hasWhatWeDo = Boolean(whatWeDoIntro || capabilities)
-    const hasBody = Boolean(featuredWork || hasWhatWeDo || clients)
-
-    const parts: Array<string | null> = [
-      "# basement.studio",
-      "",
-      portableTextToMarkdown(homepage.introTitle, { baseUrl: SITE_URL }) ||
-        null,
-      "",
-      portableTextToMarkdown(homepage.introSubtitle, { baseUrl: SITE_URL }) ||
-        null,
-      "",
-      hasBody ? "---" : null,
-      hasBody ? "" : null,
-      featuredWork ? "## Selected Work" : null,
-      featuredWork ? "" : null,
-      featuredWork,
-      featuredWork ? "" : null,
-      hasWhatWeDo ? "## What We Do" : null,
-      hasWhatWeDo ? "" : null,
-      whatWeDoIntro,
-      capabilities ? "" : null,
-      capabilities,
-      capabilities ? "" : null,
-      clients ? "## Clients" : null,
-      clients ? "" : null,
-      clients,
-      "",
-      // Entity block mirroring the homepage's crawlable about section.
-      "## About basement.studio",
-      "",
-      COMPANY_FACTS.description,
-      "",
-      `Founded in ${COMPANY_FACTS.foundingDate} and based in ${COMPANY_FACTS.locationName}, the studio works primarily with technology companies in the San Francisco Bay Area and has partnered with startups and enterprise brands including ${formatFactList(COMPANY_FACTS.notableClients)}.`,
-      "",
-      `Services: ${formatFactList(COMPANY_FACTS.services)}.`,
-      "",
-      COMPANY_FACTS.awardsSummary,
-      "",
-      COMPANY_FACTS.geistAttribution,
-      "",
-      "## Contact",
-      "",
-      `- General & project inquiries: ${COMPANY_FACTS.contactEmail}`,
-      `- New business / sales: ${COMPANY_FACTS.salesEmail}`,
-      `- [Contact page](${SITE_URL}/contact.md)`,
-      "",
-      "## More",
-      "",
-      `- [Services](${SITE_URL}/services.md)`,
-      `- [Showcase](${SITE_URL}/showcase.md)`,
-      `- [Blog](${SITE_URL}/blog.md)`,
-      `- [People](${SITE_URL}/people.md)`,
-      `- [Lab](${SITE_URL}/lab.md)`,
-      `- [FAQ](${SITE_URL}/faq.md)`,
-      "",
-      "---",
-      "",
-      `[View all content](${SITE_URL}/sitemap.md)`
-    ]
-
-    const markdown = parts.filter((part) => part !== null).join("\n")
-
+    const { markdown, status } = await buildIndexMarkdown()
     return new NextResponse(markdown, {
+      status,
       headers: { ...MD_HEADERS, Link: `<${SITE_URL}>; rel="canonical"` }
     })
   } catch (error) {

--- a/src/app/api/lab.md/markdown.ts
+++ b/src/app/api/lab.md/markdown.ts
@@ -1,0 +1,48 @@
+import { fetchLabProjectsPublished } from "@/actions/laboratory-fetch/sanity"
+import { SITE_URL } from "@/lib/constants"
+
+// CMS strings land inside `[label](url)` syntax — escape the delimiters so a
+// bracketed label or a parenthesized URL can't break the link.
+const escapeLinkLabel = (text: string) => text.replace(/[\\[\]]/g, "\\$&")
+const escapeLinkUrl = (url: string) =>
+  url.replace(/\(/g, "%28").replace(/\)/g, "%29")
+
+export async function buildLabMarkdown(): Promise<{
+  markdown: string
+  status: 200
+}> {
+  "use cache"
+  const projects = await fetchLabProjectsPublished()
+
+  // `url` is the experiment's source path (e.g. "30.wireframe-reveal.js");
+  // the live demo lives under lab.basement.studio (see arcade-labs-list.tsx).
+  const list = projects
+    .map((project) => {
+      const link = `[${escapeLinkLabel(project.title)}](https://lab.basement.studio/experiments/${escapeLinkUrl(project.url)})`
+      return project.description
+        ? `- ${link} — ${project.description}`
+        : `- ${link}`
+    })
+    .join("\n")
+
+  const parts: Array<string | null> = [
+    "# Lab",
+    "",
+    "Experiments and interactive demos built by basement.studio.",
+    "",
+    `The arcade at [basement.studio/lab](${SITE_URL}/lab) is a desktop WebGL experience; a lightweight mirror lives at [lab.basement.studio](https://lab.basement.studio/).`,
+    "",
+    "---",
+    "",
+    list ? "## Experiments" : null,
+    list ? "" : null,
+    list || null,
+    "",
+    "---",
+    "",
+    `[View all content](${SITE_URL}/sitemap.md)`
+  ]
+
+  const markdown = parts.filter((part) => part !== null).join("\n")
+  return { markdown, status: 200 }
+}

--- a/src/app/api/lab.md/markdown.ts
+++ b/src/app/api/lab.md/markdown.ts
@@ -1,18 +1,14 @@
-import { fetchLabProjectsPublished } from "@/actions/laboratory-fetch/sanity"
+import { fetchLabProjects } from "@/actions/laboratory-fetch/sanity"
 import { SITE_URL } from "@/lib/constants"
+import {
+  escapeLinkLabel,
+  escapeLinkUrl,
+  type MarkdownResult
+} from "@/service/markdown/document"
 
-// CMS strings land inside `[label](url)` syntax — escape the delimiters so a
-// bracketed label or a parenthesized URL can't break the link.
-const escapeLinkLabel = (text: string) => text.replace(/[\\[\]]/g, "\\$&")
-const escapeLinkUrl = (url: string) =>
-  url.replace(/\(/g, "%28").replace(/\)/g, "%29")
-
-export async function buildLabMarkdown(): Promise<{
-  markdown: string
-  status: 200
-}> {
+export async function buildLabMarkdown(): Promise<MarkdownResult<200>> {
   "use cache"
-  const projects = await fetchLabProjectsPublished()
+  const projects = await fetchLabProjects({ published: true })
 
   // `url` is the experiment's source path (e.g. "30.wireframe-reveal.js");
   // the live demo lives under lab.basement.studio (see arcade-labs-list.tsx).

--- a/src/app/api/lab.md/route.ts
+++ b/src/app/api/lab.md/route.ts
@@ -1,8 +1,9 @@
 import * as Sentry from "@sentry/nextjs"
 import { NextResponse } from "next/server"
 
-import { fetchLabProjects } from "@/actions/laboratory-fetch/sanity"
 import { SITE_URL } from "@/lib/constants"
+
+import { buildLabMarkdown } from "./markdown"
 
 const MD_HEADERS = {
   "Content-Type": "text/markdown; charset=utf-8",
@@ -10,47 +11,9 @@ const MD_HEADERS = {
   "X-Content-Type-Options": "nosniff"
 } as const
 
-// CMS strings land inside `[label](url)` syntax — escape the delimiters so a
-// bracketed label or a parenthesized URL can't break the link.
-const escapeLinkLabel = (text: string) => text.replace(/[\\[\]]/g, "\\$&")
-const escapeLinkUrl = (url: string) =>
-  url.replace(/\(/g, "%28").replace(/\)/g, "%29")
-
 export async function GET() {
   try {
-    const projects = await fetchLabProjects()
-
-    // `url` is the experiment's source path (e.g. "30.wireframe-reveal.js");
-    // the live demo lives under lab.basement.studio (see arcade-labs-list.tsx).
-    const list = projects
-      .map((project) => {
-        const link = `[${escapeLinkLabel(project.title)}](https://lab.basement.studio/experiments/${escapeLinkUrl(project.url)})`
-        return project.description
-          ? `- ${link} — ${project.description}`
-          : `- ${link}`
-      })
-      .join("\n")
-
-    const parts: Array<string | null> = [
-      "# Lab",
-      "",
-      "Experiments and interactive demos built by basement.studio.",
-      "",
-      `The arcade at [basement.studio/lab](${SITE_URL}/lab) is a desktop WebGL experience; a lightweight mirror lives at [lab.basement.studio](https://lab.basement.studio/).`,
-      "",
-      "---",
-      "",
-      list ? "## Experiments" : null,
-      list ? "" : null,
-      list || null,
-      "",
-      "---",
-      "",
-      `[View all content](${SITE_URL}/sitemap.md)`
-    ]
-
-    const markdown = parts.filter((part) => part !== null).join("\n")
-
+    const { markdown } = await buildLabMarkdown()
     return new NextResponse(markdown, {
       headers: {
         ...MD_HEADERS,

--- a/src/app/api/lab.md/route.ts
+++ b/src/app/api/lab.md/route.ts
@@ -1,31 +1,14 @@
-import * as Sentry from "@sentry/nextjs"
-import { NextResponse } from "next/server"
-
-import { SITE_URL } from "@/lib/constants"
+import {
+  markdownErrorResponse,
+  markdownResponse
+} from "@/service/markdown/response"
 
 import { buildLabMarkdown } from "./markdown"
 
-const MD_HEADERS = {
-  "Content-Type": "text/markdown; charset=utf-8",
-  Vary: "Accept",
-  "X-Content-Type-Options": "nosniff"
-} as const
-
 export async function GET() {
   try {
-    const { markdown } = await buildLabMarkdown()
-    return new NextResponse(markdown, {
-      headers: {
-        ...MD_HEADERS,
-        Link: `<${SITE_URL}/lab>; rel="canonical"`
-      }
-    })
+    return markdownResponse(await buildLabMarkdown(), "/lab")
   } catch (error) {
-    console.error("Error building lab markdown:", error)
-    Sentry.captureException(error)
-    return new NextResponse("# 500 Error\n\nFailed to build markdown.", {
-      status: 500,
-      headers: MD_HEADERS
-    })
+    return markdownErrorResponse("lab", error)
   }
 }

--- a/src/app/api/people.md/markdown.ts
+++ b/src/app/api/people.md/markdown.ts
@@ -7,22 +7,19 @@ import {
   fetchValuesForMarkdown
 } from "@/app/(site)/(canvas)/(content)/people/sanity"
 import { SITE_URL } from "@/lib/constants"
+import {
+  escapeLinkLabel,
+  escapeLinkUrl,
+  type MarkdownResult,
+  NOT_FOUND_MARKDOWN
+} from "@/service/markdown/document"
 import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
 import { displayPlatform } from "@/utils/social-platform"
 
 // Same department whitelist and order the HTML crew page renders (see crew.tsx)
 const CREW_DEPARTMENTS = ["Management", "Design", "Development"]
 
-// CMS strings land inside `[label](url)` syntax — escape the delimiters so a
-// bracketed label or a parenthesized URL can't break the link.
-const escapeLinkLabel = (text: string) => text.replace(/[\\[\]]/g, "\\$&")
-const escapeLinkUrl = (url: string) =>
-  url.replace(/\(/g, "%28").replace(/\)/g, "%29")
-
-export async function buildPeopleMarkdown(): Promise<{
-  markdown: string
-  status: 200 | 404
-}> {
+export async function buildPeopleMarkdown(): Promise<MarkdownResult> {
   "use cache"
   const [page, people, positions, values] = await Promise.all([
     fetchPeoplePage({ published: true }),
@@ -33,7 +30,7 @@ export async function buildPeopleMarkdown(): Promise<{
 
   if (!page) {
     cacheLife("hours")
-    return { markdown: "# 404 Not Found\n", status: 404 }
+    return { markdown: NOT_FOUND_MARKDOWN, status: 404 }
   }
 
   const crew = people.filter(

--- a/src/app/api/people.md/markdown.ts
+++ b/src/app/api/people.md/markdown.ts
@@ -1,0 +1,134 @@
+import { cacheLife } from "next/cache"
+
+import {
+  fetchOpenPositions,
+  fetchPeopleForMarkdown,
+  fetchPeoplePage,
+  fetchValuesForMarkdown
+} from "@/app/(site)/(canvas)/(content)/people/sanity"
+import { SITE_URL } from "@/lib/constants"
+import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
+import { displayPlatform } from "@/utils/social-platform"
+
+// Same department whitelist and order the HTML crew page renders (see crew.tsx)
+const CREW_DEPARTMENTS = ["Management", "Design", "Development"]
+
+// CMS strings land inside `[label](url)` syntax — escape the delimiters so a
+// bracketed label or a parenthesized URL can't break the link.
+const escapeLinkLabel = (text: string) => text.replace(/[\\[\]]/g, "\\$&")
+const escapeLinkUrl = (url: string) =>
+  url.replace(/\(/g, "%28").replace(/\)/g, "%29")
+
+export async function buildPeopleMarkdown(): Promise<{
+  markdown: string
+  status: 200 | 404
+}> {
+  "use cache"
+  const [page, people, positions, values] = await Promise.all([
+    fetchPeoplePage({ published: true }),
+    fetchPeopleForMarkdown({ published: true }),
+    fetchOpenPositions({ published: true }),
+    fetchValuesForMarkdown({ published: true })
+  ])
+
+  if (!page) {
+    cacheLife("hours")
+    return { markdown: "# 404 Not Found\n", status: 404 }
+  }
+
+  const crew = people.filter(
+    (person) =>
+      person.department?.title &&
+      CREW_DEPARTMENTS.includes(person.department.title)
+  )
+
+  // Grouped under department sub-headings to mirror crew.tsx.
+  const teamSections = CREW_DEPARTMENTS.map((dept) => {
+    const deptPeople = crew.filter(
+      (person) => person.department?.title === dept
+    )
+    if (!deptPeople.length) return null
+
+    const lines = deptPeople
+      .map((person) => {
+        const socials = person.socialNetworks?.length
+          ? person.socialNetworks
+              .map(
+                (s) =>
+                  ` — [${escapeLinkLabel(displayPlatform(s.platform))}](${escapeLinkUrl(s.url)})`
+              )
+              .join("")
+          : ""
+        const base = person.role
+          ? `- **${person.title}** — ${person.role}`
+          : `- **${person.title}**`
+        return `${base}${socials}`
+      })
+      .join("\n")
+
+    return [`### ${dept}`, "", lines].join("\n")
+  }).filter((section): section is string => section !== null)
+
+  const team = teamSections.length ? teamSections.join("\n\n") : null
+
+  // Mirrors the HTML order: crew → values → open positions (see page.tsx).
+  const valuesList = values.length
+    ? values
+        .map((value) =>
+          [
+            `### ${value.title}`,
+            "",
+            portableTextToMarkdown(value.description, { baseUrl: SITE_URL })
+          ]
+            .filter(Boolean)
+            .join("\n")
+        )
+        .join("\n\n")
+    : null
+
+  // Closed roles are dropped — /careers/[slug].md 404s on them, so
+  // linking one would be a dead link.
+  const openPositions = positions.filter((p) => p.isOpen)
+  const openPositionsList = openPositions.length
+    ? openPositions
+        .map((p) => {
+          const detail = [p.type, p.location].filter(Boolean).join(", ")
+          const link = `[${escapeLinkLabel(p.title)}](${SITE_URL}/careers/${p.slug}.md)`
+          return detail ? `- ${link} — ${detail}` : `- ${link}`
+        })
+        .join("\n")
+    : "none currently open"
+
+  const parts: Array<string | null> = [
+    `# ${page.title || "People"}`,
+    "",
+    portableTextToMarkdown(page.subheading1, { baseUrl: SITE_URL }) || null,
+    "",
+    portableTextToMarkdown(page.subheading2, { baseUrl: SITE_URL }) || null,
+    "",
+    "---",
+    "",
+    team ? "## Team" : null,
+    team ? "" : null,
+    team,
+    team ? "" : null,
+    valuesList ? "## Values" : null,
+    valuesList ? "" : null,
+    valuesList,
+    valuesList ? "" : null,
+    portableTextToMarkdown(page.preOpenPositionsText, {
+      baseUrl: SITE_URL
+    }) || null,
+    "",
+    "## Open Positions",
+    "",
+    openPositionsList,
+    "",
+    "---",
+    "",
+    `[View all content](${SITE_URL}/sitemap.md)`
+  ]
+
+  const markdown = parts.filter((part) => part !== null).join("\n")
+  return { markdown, status: 200 }
+}

--- a/src/app/api/people.md/route.ts
+++ b/src/app/api/people.md/route.ts
@@ -1,32 +1,14 @@
-import * as Sentry from "@sentry/nextjs"
-import { NextResponse } from "next/server"
-
-import { SITE_URL } from "@/lib/constants"
+import {
+  markdownErrorResponse,
+  markdownResponse
+} from "@/service/markdown/response"
 
 import { buildPeopleMarkdown } from "./markdown"
 
-const MD_HEADERS = {
-  "Content-Type": "text/markdown; charset=utf-8",
-  Vary: "Accept",
-  "X-Content-Type-Options": "nosniff"
-} as const
-
 export async function GET() {
   try {
-    const { markdown, status } = await buildPeopleMarkdown()
-    return new NextResponse(markdown, {
-      status,
-      headers: {
-        ...MD_HEADERS,
-        Link: `<${SITE_URL}/people>; rel="canonical"`
-      }
-    })
+    return markdownResponse(await buildPeopleMarkdown(), "/people")
   } catch (error) {
-    console.error("Error building people markdown:", error)
-    Sentry.captureException(error)
-    return new NextResponse("# 500 Error\n\nFailed to build markdown.", {
-      status: 500,
-      headers: MD_HEADERS
-    })
+    return markdownErrorResponse("people", error)
   }
 }

--- a/src/app/api/people.md/route.ts
+++ b/src/app/api/people.md/route.ts
@@ -1,15 +1,9 @@
 import * as Sentry from "@sentry/nextjs"
 import { NextResponse } from "next/server"
 
-import {
-  fetchOpenPositions,
-  fetchPeopleForMarkdown,
-  fetchPeoplePage,
-  fetchValuesForMarkdown
-} from "@/app/(site)/(canvas)/(content)/people/sanity"
 import { SITE_URL } from "@/lib/constants"
-import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
-import { displayPlatform } from "@/utils/social-platform"
+
+import { buildPeopleMarkdown } from "./markdown"
 
 const MD_HEADERS = {
   "Content-Type": "text/markdown; charset=utf-8",
@@ -17,127 +11,11 @@ const MD_HEADERS = {
   "X-Content-Type-Options": "nosniff"
 } as const
 
-// Same department whitelist and order the HTML crew page renders (see crew.tsx)
-const CREW_DEPARTMENTS = ["Management", "Design", "Development"]
-
-// CMS strings land inside `[label](url)` syntax — escape the delimiters so a
-// bracketed label or a parenthesized URL can't break the link.
-const escapeLinkLabel = (text: string) => text.replace(/[\\[\]]/g, "\\$&")
-const escapeLinkUrl = (url: string) =>
-  url.replace(/\(/g, "%28").replace(/\)/g, "%29")
-
 export async function GET() {
   try {
-    const [page, people, positions, values] = await Promise.all([
-      fetchPeoplePage({ published: true }),
-      fetchPeopleForMarkdown({ published: true }),
-      fetchOpenPositions({ published: true }),
-      fetchValuesForMarkdown({ published: true })
-    ])
-
-    if (!page) {
-      return new NextResponse("# 404 Not Found\n", {
-        status: 404,
-        headers: MD_HEADERS
-      })
-    }
-
-    const crew = people.filter(
-      (person) =>
-        person.department?.title &&
-        CREW_DEPARTMENTS.includes(person.department.title)
-    )
-
-    // Grouped under department sub-headings to mirror crew.tsx.
-    const teamSections = CREW_DEPARTMENTS.map((dept) => {
-      const deptPeople = crew.filter(
-        (person) => person.department?.title === dept
-      )
-      if (!deptPeople.length) return null
-
-      const lines = deptPeople
-        .map((person) => {
-          const socials = person.socialNetworks?.length
-            ? person.socialNetworks
-                .map(
-                  (s) =>
-                    ` — [${escapeLinkLabel(displayPlatform(s.platform))}](${escapeLinkUrl(s.url)})`
-                )
-                .join("")
-            : ""
-          const base = person.role
-            ? `- **${person.title}** — ${person.role}`
-            : `- **${person.title}**`
-          return `${base}${socials}`
-        })
-        .join("\n")
-
-      return [`### ${dept}`, "", lines].join("\n")
-    }).filter((section): section is string => section !== null)
-
-    const team = teamSections.length ? teamSections.join("\n\n") : null
-
-    // Mirrors the HTML order: crew → values → open positions (see page.tsx).
-    const valuesList = values.length
-      ? values
-          .map((value) =>
-            [
-              `### ${value.title}`,
-              "",
-              portableTextToMarkdown(value.description, { baseUrl: SITE_URL })
-            ]
-              .filter(Boolean)
-              .join("\n")
-          )
-          .join("\n\n")
-      : null
-
-    // Closed roles are dropped — /careers/[slug].md 404s on them, so
-    // linking one would be a dead link.
-    const openPositions = positions.filter((p) => p.isOpen)
-    const openPositionsList = openPositions.length
-      ? openPositions
-          .map((p) => {
-            const detail = [p.type, p.location].filter(Boolean).join(", ")
-            const link = `[${escapeLinkLabel(p.title)}](${SITE_URL}/careers/${p.slug}.md)`
-            return detail ? `- ${link} — ${detail}` : `- ${link}`
-          })
-          .join("\n")
-      : "none currently open"
-
-    const parts: Array<string | null> = [
-      `# ${page.title || "People"}`,
-      "",
-      portableTextToMarkdown(page.subheading1, { baseUrl: SITE_URL }) || null,
-      "",
-      portableTextToMarkdown(page.subheading2, { baseUrl: SITE_URL }) || null,
-      "",
-      "---",
-      "",
-      team ? "## Team" : null,
-      team ? "" : null,
-      team,
-      team ? "" : null,
-      valuesList ? "## Values" : null,
-      valuesList ? "" : null,
-      valuesList,
-      valuesList ? "" : null,
-      portableTextToMarkdown(page.preOpenPositionsText, {
-        baseUrl: SITE_URL
-      }) || null,
-      "",
-      "## Open Positions",
-      "",
-      openPositionsList,
-      "",
-      "---",
-      "",
-      `[View all content](${SITE_URL}/sitemap.md)`
-    ]
-
-    const markdown = parts.filter((part) => part !== null).join("\n")
-
+    const { markdown, status } = await buildPeopleMarkdown()
     return new NextResponse(markdown, {
+      status,
       headers: {
         ...MD_HEADERS,
         Link: `<${SITE_URL}/people>; rel="canonical"`

--- a/src/app/api/post/[slug]/markdown.ts
+++ b/src/app/api/post/[slug]/markdown.ts
@@ -1,0 +1,64 @@
+import { cacheLife } from "next/cache"
+
+import {
+  fetchPostBySlug,
+  fetchRelatedPostsForMarkdown
+} from "@/app/(site)/(plain)/(content)/post/[slug]/sanity"
+import { SITE_URL } from "@/lib/constants"
+import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
+
+export async function buildPostMarkdown(
+  slug: string
+): Promise<{ markdown: string; status: 200 | 404 }> {
+  "use cache"
+  const post = await fetchPostBySlug(slug, { published: true })
+  if (!post) {
+    cacheLife("hours")
+    return { markdown: "# 404 Not Found\n", status: 404 }
+  }
+
+  // Sequential, not Promise.all: related posts need `post.categories`.
+  const relatedPosts = await fetchRelatedPostsForMarkdown(
+    slug,
+    post.categories?.map((c) => c.title) ?? []
+  )
+
+  const parts: Array<string | null> = [
+    `# ${post.title}`,
+    "",
+    post.authors?.length
+      ? `**Author:** ${post.authors.map((a) => a.title).join(", ")}`
+      : null,
+    post.date
+      ? `**Published:** ${new Date(post.date).toLocaleDateString()}`
+      : null,
+    post.categories?.length
+      ? `**Categories:** ${post.categories.map((c) => c.title).join(", ")}`
+      : null,
+    "",
+    "---",
+    "",
+    portableTextToMarkdown(post.intro, { baseUrl: SITE_URL }),
+    "",
+    portableTextToMarkdown(post.content, { baseUrl: SITE_URL }),
+    "",
+    relatedPosts.length ? "## Related Posts" : null,
+    relatedPosts.length ? "" : null,
+    relatedPosts.length
+      ? relatedPosts
+          .map((related) => {
+            const link = `[${related.title}](${SITE_URL}/post/${related.slug}.md)`
+            const date = related.date ? related.date.split("T")[0] : null
+            return date ? `- ${link} — ${date}` : `- ${link}`
+          })
+          .join("\n")
+      : null,
+    relatedPosts.length ? "" : null,
+    "---",
+    "",
+    `[View all content](${SITE_URL}/sitemap.md)`
+  ]
+
+  const markdown = parts.filter((part) => part !== null).join("\n")
+  return { markdown, status: 200 }
+}

--- a/src/app/api/post/[slug]/markdown.ts
+++ b/src/app/api/post/[slug]/markdown.ts
@@ -5,16 +5,18 @@ import {
   fetchRelatedPostsForMarkdown
 } from "@/app/(site)/(plain)/(content)/post/[slug]/sanity"
 import { SITE_URL } from "@/lib/constants"
+import {
+  type MarkdownResult,
+  NOT_FOUND_MARKDOWN
+} from "@/service/markdown/document"
 import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
 
-export async function buildPostMarkdown(
-  slug: string
-): Promise<{ markdown: string; status: 200 | 404 }> {
+export async function buildPostMarkdown(slug: string): Promise<MarkdownResult> {
   "use cache"
   const post = await fetchPostBySlug(slug, { published: true })
   if (!post) {
     cacheLife("hours")
-    return { markdown: "# 404 Not Found\n", status: 404 }
+    return { markdown: NOT_FOUND_MARKDOWN, status: 404 }
   }
 
   // Sequential, not Promise.all: related posts need `post.categories`.

--- a/src/app/api/post/[slug]/route.ts
+++ b/src/app/api/post/[slug]/route.ts
@@ -1,42 +1,23 @@
-import * as Sentry from "@sentry/nextjs"
-import { NextResponse } from "next/server"
-
-import { SITE_URL } from "@/lib/constants"
+import {
+  markdownErrorResponse,
+  markdownNotFoundResponse,
+  markdownResponse,
+  markdownSlug
+} from "@/service/markdown/response"
 
 import { buildPostMarkdown } from "./markdown"
-
-const MD_HEADERS = {
-  "Content-Type": "text/markdown; charset=utf-8",
-  Vary: "Accept",
-  "X-Content-Type-Options": "nosniff"
-} as const
 
 export async function GET(
   _request: Request,
   { params }: { params: Promise<{ slug: string }> }
 ) {
   const { slug: rawSlug } = await params
-
-  // Only the `.md` form is served here; the proxy rewrites to this route.
-  if (!rawSlug.endsWith(".md"))
-    return new NextResponse(null, { status: 404, headers: MD_HEADERS })
-  const slug = rawSlug.slice(0, -3)
+  const slug = markdownSlug(rawSlug)
+  if (slug === null) return markdownNotFoundResponse()
 
   try {
-    const { markdown, status } = await buildPostMarkdown(slug)
-    return new NextResponse(markdown, {
-      status,
-      headers: {
-        ...MD_HEADERS,
-        Link: `<${SITE_URL}/post/${slug}>; rel="canonical"`
-      }
-    })
+    return markdownResponse(await buildPostMarkdown(slug), `/post/${slug}`)
   } catch (error) {
-    console.error("Error building post markdown:", error)
-    Sentry.captureException(error)
-    return new NextResponse("# 500 Error\n\nFailed to build markdown.", {
-      status: 500,
-      headers: MD_HEADERS
-    })
+    return markdownErrorResponse("post", error)
   }
 }

--- a/src/app/api/post/[slug]/route.ts
+++ b/src/app/api/post/[slug]/route.ts
@@ -1,12 +1,9 @@
 import * as Sentry from "@sentry/nextjs"
 import { NextResponse } from "next/server"
 
-import {
-  fetchPostBySlug,
-  fetchRelatedPostsForMarkdown
-} from "@/app/(site)/(plain)/(content)/post/[slug]/sanity"
 import { SITE_URL } from "@/lib/constants"
-import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
+
+import { buildPostMarkdown } from "./markdown"
 
 const MD_HEADERS = {
   "Content-Type": "text/markdown; charset=utf-8",
@@ -26,58 +23,9 @@ export async function GET(
   const slug = rawSlug.slice(0, -3)
 
   try {
-    const post = await fetchPostBySlug(slug, { published: true })
-    if (!post) {
-      return new NextResponse("# 404 Not Found\n", {
-        status: 404,
-        headers: MD_HEADERS
-      })
-    }
-
-    const relatedPosts = await fetchRelatedPostsForMarkdown(
-      slug,
-      post.categories?.map((c) => c.title) ?? []
-    )
-
-    const parts: Array<string | null> = [
-      `# ${post.title}`,
-      "",
-      post.authors?.length
-        ? `**Author:** ${post.authors.map((a) => a.title).join(", ")}`
-        : null,
-      post.date
-        ? `**Published:** ${new Date(post.date).toLocaleDateString()}`
-        : null,
-      post.categories?.length
-        ? `**Categories:** ${post.categories.map((c) => c.title).join(", ")}`
-        : null,
-      "",
-      "---",
-      "",
-      portableTextToMarkdown(post.intro, { baseUrl: SITE_URL }),
-      "",
-      portableTextToMarkdown(post.content, { baseUrl: SITE_URL }),
-      "",
-      relatedPosts.length ? "## Related Posts" : null,
-      relatedPosts.length ? "" : null,
-      relatedPosts.length
-        ? relatedPosts
-            .map((related) => {
-              const link = `[${related.title}](${SITE_URL}/post/${related.slug}.md)`
-              const date = related.date ? related.date.split("T")[0] : null
-              return date ? `- ${link} — ${date}` : `- ${link}`
-            })
-            .join("\n")
-        : null,
-      relatedPosts.length ? "" : null,
-      "---",
-      "",
-      `[View all content](${SITE_URL}/sitemap.md)`
-    ]
-
-    const markdown = parts.filter((part) => part !== null).join("\n")
-
+    const { markdown, status } = await buildPostMarkdown(slug)
     return new NextResponse(markdown, {
+      status,
       headers: {
         ...MD_HEADERS,
         Link: `<${SITE_URL}/post/${slug}>; rel="canonical"`

--- a/src/app/api/services.md/markdown.ts
+++ b/src/app/api/services.md/markdown.ts
@@ -6,16 +6,14 @@ import {
   fetchTestimonial
 } from "@/app/(site)/(canvas)/(content)/services/sanity"
 import { SITE_URL } from "@/lib/constants"
+import {
+  escapeLinkLabel,
+  type MarkdownResult,
+  NOT_FOUND_MARKDOWN
+} from "@/service/markdown/document"
 import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
 
-// CMS strings land inside `[label](url)` syntax — escape the delimiters so a
-// bracketed label can't break the link.
-const escapeLinkLabel = (text: string) => text.replace(/[\\[\]]/g, "\\$&")
-
-export async function buildServicesMarkdown(): Promise<{
-  markdown: string
-  status: 200 | 404
-}> {
+export async function buildServicesMarkdown(): Promise<MarkdownResult> {
   "use cache"
   const [services, awards, testimonial] = await Promise.all([
     fetchServicesPage({ published: true }),
@@ -24,7 +22,7 @@ export async function buildServicesMarkdown(): Promise<{
   ])
   if (!services) {
     cacheLife("hours")
-    return { markdown: "# 404 Not Found\n", status: 404 }
+    return { markdown: NOT_FOUND_MARKDOWN, status: 404 }
   }
 
   const serviceCategories = services.serviceCategories?.length

--- a/src/app/api/services.md/markdown.ts
+++ b/src/app/api/services.md/markdown.ts
@@ -1,0 +1,124 @@
+import { cacheLife } from "next/cache"
+
+import {
+  fetchAwardsForMarkdown,
+  fetchServicesPage,
+  fetchTestimonial
+} from "@/app/(site)/(canvas)/(content)/services/sanity"
+import { SITE_URL } from "@/lib/constants"
+import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
+
+// CMS strings land inside `[label](url)` syntax — escape the delimiters so a
+// bracketed label can't break the link.
+const escapeLinkLabel = (text: string) => text.replace(/[\\[\]]/g, "\\$&")
+
+export async function buildServicesMarkdown(): Promise<{
+  markdown: string
+  status: 200 | 404
+}> {
+  "use cache"
+  const [services, awards, testimonial] = await Promise.all([
+    fetchServicesPage({ published: true }),
+    fetchAwardsForMarkdown(),
+    fetchTestimonial({ published: true })
+  ])
+  if (!services) {
+    cacheLife("hours")
+    return { markdown: "# 404 Not Found\n", status: 404 }
+  }
+
+  const serviceCategories = services.serviceCategories?.length
+    ? services.serviceCategories
+        .map((cat) =>
+          [
+            `### ${cat.title}`,
+            "",
+            portableTextToMarkdown(cat.description, { baseUrl: SITE_URL })
+          ]
+            .filter(Boolean)
+            .join("\n")
+        )
+        .join("\n\n")
+    : null
+
+  // HTML (ventures.tsx) only shows the first venture — match that.
+  const venture = services.ventures?.[0]
+  const ventures = venture
+    ? [
+        `### ${venture.title}`,
+        "",
+        portableTextToMarkdown(venture.content, { baseUrl: SITE_URL })
+      ]
+        .filter(Boolean)
+        .join("\n")
+    : null
+
+  const awardsList = awards.length
+    ? awards
+        .map((award) => {
+          const label = award.awardUrl
+            ? `[${escapeLinkLabel(award.title)}](${award.awardUrl})`
+            : award.title
+          const year = award.date ? new Date(award.date).getFullYear() : null
+          const detail = [award.projectName, year].filter(Boolean).join(", ")
+          return detail ? `- ${label} — ${detail}` : `- ${label}`
+        })
+        .join("\n")
+    : null
+
+  // `role` is Portable Text or a plain string depending on document age.
+  const testimonialRole = testimonial
+    ? (Array.isArray(testimonial.role)
+        ? portableTextToMarkdown(testimonial.role, { baseUrl: SITE_URL })
+        : (testimonial.role ?? "")
+      )
+        .replace(/\s+/g, " ")
+        .trim()
+    : ""
+  const testimonialBlock = testimonial?.content
+    ? [
+        `> ${testimonial.content.replace(/\n/g, "\n> ")}`,
+        ">",
+        `> — ${[
+          testimonial.name,
+          testimonial.handle
+            ? `(${testimonial.handle.startsWith("@") ? testimonial.handle : `@${testimonial.handle}`})`
+            : null,
+          testimonialRole ? `— ${testimonialRole}` : null
+        ]
+          .filter(Boolean)
+          .join(" ")}`
+      ].join("\n")
+    : null
+
+  const parts: Array<string | null> = [
+    "# Services",
+    "",
+    portableTextToMarkdown(services.intro, { baseUrl: SITE_URL }) || null,
+    "",
+    "---",
+    "",
+    serviceCategories ? "## What We Offer" : null,
+    serviceCategories ? "" : null,
+    serviceCategories,
+    serviceCategories ? "" : null,
+    ventures ? "## Ventures" : null,
+    ventures ? "" : null,
+    ventures,
+    ventures ? "" : null,
+    awardsList ? "## Awards" : null,
+    awardsList ? "" : null,
+    awardsList,
+    awardsList ? "" : null,
+    testimonialBlock ? "## Testimonial" : null,
+    testimonialBlock ? "" : null,
+    testimonialBlock,
+    "",
+    "---",
+    "",
+    `[View all content](${SITE_URL}/sitemap.md)`
+  ]
+
+  const markdown = parts.filter((part) => part !== null).join("\n")
+  return { markdown, status: 200 }
+}

--- a/src/app/api/services.md/route.ts
+++ b/src/app/api/services.md/route.ts
@@ -1,32 +1,14 @@
-import * as Sentry from "@sentry/nextjs"
-import { NextResponse } from "next/server"
-
-import { SITE_URL } from "@/lib/constants"
+import {
+  markdownErrorResponse,
+  markdownResponse
+} from "@/service/markdown/response"
 
 import { buildServicesMarkdown } from "./markdown"
 
-const MD_HEADERS = {
-  "Content-Type": "text/markdown; charset=utf-8",
-  Vary: "Accept",
-  "X-Content-Type-Options": "nosniff"
-} as const
-
 export async function GET() {
   try {
-    const { markdown, status } = await buildServicesMarkdown()
-    return new NextResponse(markdown, {
-      status,
-      headers: {
-        ...MD_HEADERS,
-        Link: `<${SITE_URL}/services>; rel="canonical"`
-      }
-    })
+    return markdownResponse(await buildServicesMarkdown(), "/services")
   } catch (error) {
-    console.error("Error building services markdown:", error)
-    Sentry.captureException(error)
-    return new NextResponse("# 500 Error\n\nFailed to build markdown.", {
-      status: 500,
-      headers: MD_HEADERS
-    })
+    return markdownErrorResponse("services", error)
   }
 }

--- a/src/app/api/services.md/route.ts
+++ b/src/app/api/services.md/route.ts
@@ -1,13 +1,9 @@
 import * as Sentry from "@sentry/nextjs"
 import { NextResponse } from "next/server"
 
-import {
-  fetchAwardsForMarkdown,
-  fetchServicesPage,
-  fetchTestimonial
-} from "@/app/(site)/(canvas)/(content)/services/sanity"
 import { SITE_URL } from "@/lib/constants"
-import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
+
+import { buildServicesMarkdown } from "./markdown"
 
 const MD_HEADERS = {
   "Content-Type": "text/markdown; charset=utf-8",
@@ -15,119 +11,11 @@ const MD_HEADERS = {
   "X-Content-Type-Options": "nosniff"
 } as const
 
-// CMS strings land inside `[label](url)` syntax — escape the delimiters so a
-// bracketed label can't break the link.
-const escapeLinkLabel = (text: string) => text.replace(/[\\[\]]/g, "\\$&")
-
 export async function GET() {
   try {
-    const [services, awards, testimonial] = await Promise.all([
-      fetchServicesPage({ published: true }),
-      fetchAwardsForMarkdown(),
-      fetchTestimonial({ published: true })
-    ])
-    if (!services) {
-      return new NextResponse("# 404 Not Found\n", {
-        status: 404,
-        headers: MD_HEADERS
-      })
-    }
-
-    const serviceCategories = services.serviceCategories?.length
-      ? services.serviceCategories
-          .map((cat) =>
-            [
-              `### ${cat.title}`,
-              "",
-              portableTextToMarkdown(cat.description, { baseUrl: SITE_URL })
-            ]
-              .filter(Boolean)
-              .join("\n")
-          )
-          .join("\n\n")
-      : null
-
-    // HTML (ventures.tsx) only shows the first venture — match that.
-    const venture = services.ventures?.[0]
-    const ventures = venture
-      ? [
-          `### ${venture.title}`,
-          "",
-          portableTextToMarkdown(venture.content, { baseUrl: SITE_URL })
-        ]
-          .filter(Boolean)
-          .join("\n")
-      : null
-
-    const awardsList = awards.length
-      ? awards
-          .map((award) => {
-            const label = award.awardUrl
-              ? `[${escapeLinkLabel(award.title)}](${award.awardUrl})`
-              : award.title
-            const year = award.date ? new Date(award.date).getFullYear() : null
-            const detail = [award.projectName, year].filter(Boolean).join(", ")
-            return detail ? `- ${label} — ${detail}` : `- ${label}`
-          })
-          .join("\n")
-      : null
-
-    // `role` is Portable Text or a plain string depending on document age.
-    const testimonialRole = testimonial
-      ? (Array.isArray(testimonial.role)
-          ? portableTextToMarkdown(testimonial.role, { baseUrl: SITE_URL })
-          : (testimonial.role ?? "")
-        )
-          .replace(/\s+/g, " ")
-          .trim()
-      : ""
-    const testimonialBlock = testimonial?.content
-      ? [
-          `> ${testimonial.content.replace(/\n/g, "\n> ")}`,
-          ">",
-          `> — ${[
-            testimonial.name,
-            testimonial.handle
-              ? `(${testimonial.handle.startsWith("@") ? testimonial.handle : `@${testimonial.handle}`})`
-              : null,
-            testimonialRole ? `— ${testimonialRole}` : null
-          ]
-            .filter(Boolean)
-            .join(" ")}`
-        ].join("\n")
-      : null
-
-    const parts: Array<string | null> = [
-      "# Services",
-      "",
-      portableTextToMarkdown(services.intro, { baseUrl: SITE_URL }) || null,
-      "",
-      "---",
-      "",
-      serviceCategories ? "## What We Offer" : null,
-      serviceCategories ? "" : null,
-      serviceCategories,
-      serviceCategories ? "" : null,
-      ventures ? "## Ventures" : null,
-      ventures ? "" : null,
-      ventures,
-      ventures ? "" : null,
-      awardsList ? "## Awards" : null,
-      awardsList ? "" : null,
-      awardsList,
-      awardsList ? "" : null,
-      testimonialBlock ? "## Testimonial" : null,
-      testimonialBlock ? "" : null,
-      testimonialBlock,
-      "",
-      "---",
-      "",
-      `[View all content](${SITE_URL}/sitemap.md)`
-    ]
-
-    const markdown = parts.filter((part) => part !== null).join("\n")
-
+    const { markdown, status } = await buildServicesMarkdown()
     return new NextResponse(markdown, {
+      status,
       headers: {
         ...MD_HEADERS,
         Link: `<${SITE_URL}/services>; rel="canonical"`

--- a/src/app/api/showcase.md/markdown.ts
+++ b/src/app/api/showcase.md/markdown.ts
@@ -1,0 +1,50 @@
+import { fetchShowcaseListForMarkdown } from "@/app/(site)/(canvas)/(content)/showcase/sanity"
+import { SITE_URL } from "@/lib/constants"
+import { truncateDescription } from "@/utils/seo"
+
+// CMS strings land inside `[label](url)` syntax — escape the delimiters so a
+// bracketed label can't break the link.
+const escapeLinkLabel = (text: string) => text.replace(/[\\[\]]/g, "\\$&")
+
+export async function buildShowcaseListMarkdown(): Promise<{
+  markdown: string
+  status: 200
+}> {
+  "use cache"
+  const projects = await fetchShowcaseListForMarkdown()
+
+  const list = projects
+    .map((project) => {
+      const clientYear = [project.client, project.year]
+        .filter(Boolean)
+        .join(", ")
+      const categories = project.categories?.length
+        ? `(${project.categories.join(", ")})`
+        : null
+      const meta = [clientYear || null, categories].filter(Boolean).join(" ")
+      const detail = [
+        meta || null,
+        truncateDescription(project.description) || null
+      ]
+        .filter(Boolean)
+        .join(" — ")
+      const link = `[${escapeLinkLabel(project.title)}](${SITE_URL}/showcase/${project.slug}.md)`
+      return detail ? `- ${link} — ${detail}` : `- ${link}`
+    })
+    .join("\n")
+
+  const parts: Array<string | null> = [
+    "# Showcase",
+    "",
+    "Selected projects by basement.studio.",
+    list ? "" : null,
+    list || null,
+    "",
+    "---",
+    "",
+    `[View all content](${SITE_URL}/sitemap.md)`
+  ]
+
+  const markdown = parts.filter((part) => part !== null).join("\n")
+  return { markdown, status: 200 }
+}

--- a/src/app/api/showcase.md/markdown.ts
+++ b/src/app/api/showcase.md/markdown.ts
@@ -1,15 +1,14 @@
 import { fetchShowcaseListForMarkdown } from "@/app/(site)/(canvas)/(content)/showcase/sanity"
 import { SITE_URL } from "@/lib/constants"
+import {
+  escapeLinkLabel,
+  type MarkdownResult
+} from "@/service/markdown/document"
 import { truncateDescription } from "@/utils/seo"
 
-// CMS strings land inside `[label](url)` syntax — escape the delimiters so a
-// bracketed label can't break the link.
-const escapeLinkLabel = (text: string) => text.replace(/[\\[\]]/g, "\\$&")
-
-export async function buildShowcaseListMarkdown(): Promise<{
-  markdown: string
-  status: 200
-}> {
+export async function buildShowcaseListMarkdown(): Promise<
+  MarkdownResult<200>
+> {
   "use cache"
   const projects = await fetchShowcaseListForMarkdown()
 

--- a/src/app/api/showcase.md/route.ts
+++ b/src/app/api/showcase.md/route.ts
@@ -1,31 +1,14 @@
-import * as Sentry from "@sentry/nextjs"
-import { NextResponse } from "next/server"
-
-import { SITE_URL } from "@/lib/constants"
+import {
+  markdownErrorResponse,
+  markdownResponse
+} from "@/service/markdown/response"
 
 import { buildShowcaseListMarkdown } from "./markdown"
 
-const MD_HEADERS = {
-  "Content-Type": "text/markdown; charset=utf-8",
-  Vary: "Accept",
-  "X-Content-Type-Options": "nosniff"
-} as const
-
 export async function GET() {
   try {
-    const { markdown } = await buildShowcaseListMarkdown()
-    return new NextResponse(markdown, {
-      headers: {
-        ...MD_HEADERS,
-        Link: `<${SITE_URL}/showcase>; rel="canonical"`
-      }
-    })
+    return markdownResponse(await buildShowcaseListMarkdown(), "/showcase")
   } catch (error) {
-    console.error("Error building showcase markdown:", error)
-    Sentry.captureException(error)
-    return new NextResponse("# 500 Error\n\nFailed to build markdown.", {
-      status: 500,
-      headers: MD_HEADERS
-    })
+    return markdownErrorResponse("showcase", error)
   }
 }

--- a/src/app/api/showcase.md/route.ts
+++ b/src/app/api/showcase.md/route.ts
@@ -1,9 +1,9 @@
 import * as Sentry from "@sentry/nextjs"
 import { NextResponse } from "next/server"
 
-import { fetchShowcaseListForMarkdown } from "@/app/(site)/(canvas)/(content)/showcase/sanity"
 import { SITE_URL } from "@/lib/constants"
-import { truncateDescription } from "@/utils/seo"
+
+import { buildShowcaseListMarkdown } from "./markdown"
 
 const MD_HEADERS = {
   "Content-Type": "text/markdown; charset=utf-8",
@@ -11,48 +11,9 @@ const MD_HEADERS = {
   "X-Content-Type-Options": "nosniff"
 } as const
 
-// CMS strings land inside `[label](url)` syntax — escape the delimiters so a
-// bracketed label can't break the link.
-const escapeLinkLabel = (text: string) => text.replace(/[\\[\]]/g, "\\$&")
-
 export async function GET() {
   try {
-    const projects = await fetchShowcaseListForMarkdown()
-
-    const list = projects
-      .map((project) => {
-        const clientYear = [project.client, project.year]
-          .filter(Boolean)
-          .join(", ")
-        const categories = project.categories?.length
-          ? `(${project.categories.join(", ")})`
-          : null
-        const meta = [clientYear || null, categories].filter(Boolean).join(" ")
-        const detail = [
-          meta || null,
-          truncateDescription(project.description) || null
-        ]
-          .filter(Boolean)
-          .join(" — ")
-        const link = `[${escapeLinkLabel(project.title)}](${SITE_URL}/showcase/${project.slug}.md)`
-        return detail ? `- ${link} — ${detail}` : `- ${link}`
-      })
-      .join("\n")
-
-    const parts: Array<string | null> = [
-      "# Showcase",
-      "",
-      "Selected projects by basement.studio.",
-      list ? "" : null,
-      list || null,
-      "",
-      "---",
-      "",
-      `[View all content](${SITE_URL}/sitemap.md)`
-    ]
-
-    const markdown = parts.filter((part) => part !== null).join("\n")
-
+    const { markdown } = await buildShowcaseListMarkdown()
     return new NextResponse(markdown, {
       headers: {
         ...MD_HEADERS,

--- a/src/app/api/showcase/[slug]/markdown.ts
+++ b/src/app/api/showcase/[slug]/markdown.ts
@@ -5,11 +5,15 @@ import {
   fetchRelatedProjectsForMarkdown
 } from "@/app/(site)/(plain)/(content)/showcase/[slug]/sanity"
 import { SITE_URL } from "@/lib/constants"
+import {
+  type MarkdownResult,
+  NOT_FOUND_MARKDOWN
+} from "@/service/markdown/document"
 import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
 
 export async function buildShowcaseMarkdown(
   slug: string
-): Promise<{ markdown: string; status: 200 | 404 }> {
+): Promise<MarkdownResult> {
   "use cache"
   const [project, relatedProjects] = await Promise.all([
     fetchProjectBySlug(slug, { published: true }),
@@ -17,7 +21,7 @@ export async function buildShowcaseMarkdown(
   ])
   if (!project) {
     cacheLife("hours")
-    return { markdown: "# 404 Not Found\n", status: 404 }
+    return { markdown: NOT_FOUND_MARKDOWN, status: 404 }
   }
 
   const clientLine = project.client

--- a/src/app/api/showcase/[slug]/markdown.ts
+++ b/src/app/api/showcase/[slug]/markdown.ts
@@ -1,0 +1,72 @@
+import { cacheLife } from "next/cache"
+
+import {
+  fetchProjectBySlug,
+  fetchRelatedProjectsForMarkdown
+} from "@/app/(site)/(plain)/(content)/showcase/[slug]/sanity"
+import { SITE_URL } from "@/lib/constants"
+import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
+
+export async function buildShowcaseMarkdown(
+  slug: string
+): Promise<{ markdown: string; status: 200 | 404 }> {
+  "use cache"
+  const [project, relatedProjects] = await Promise.all([
+    fetchProjectBySlug(slug, { published: true }),
+    fetchRelatedProjectsForMarkdown(slug)
+  ])
+  if (!project) {
+    cacheLife("hours")
+    return { markdown: "# 404 Not Found\n", status: 404 }
+  }
+
+  const clientLine = project.client
+    ? project.client.website
+      ? `**Client:** [${project.client.title}](${project.client.website})`
+      : `**Client:** ${project.client.title}`
+    : null
+
+  const parts: Array<string | null> = [
+    `# ${project.title}`,
+    "",
+    clientLine,
+    project.year ? `**Year:** ${project.year}` : null,
+    project.categories?.length
+      ? `**Categories:** ${project.categories.map((c) => c.title).join(", ")}`
+      : null,
+    project.projectWebsite ? `**Website:** ${project.projectWebsite}` : null,
+    project.caseStudy ? `**Case Study:** ${project.caseStudy}` : null,
+    project.people?.length
+      ? `**Team:** ${project.people
+          .map((p) =>
+            p.department ? `${p.title} (${p.department.title})` : p.title
+          )
+          .join(", ")}`
+      : null,
+    project.awards?.length
+      ? `**Awards:** ${project.awards.map((a) => a.title).join(", ")}`
+      : null,
+    "",
+    "---",
+    "",
+    portableTextToMarkdown(project.content, { baseUrl: SITE_URL }),
+    "",
+    relatedProjects.length ? "## Related Projects" : null,
+    relatedProjects.length ? "" : null,
+    relatedProjects.length
+      ? relatedProjects
+          .map(
+            (related) =>
+              `- [${related.title}](${SITE_URL}/showcase/${related.slug}.md)`
+          )
+          .join("\n")
+      : null,
+    relatedProjects.length ? "" : null,
+    "---",
+    "",
+    `[View all content](${SITE_URL}/sitemap.md)`
+  ]
+
+  const markdown = parts.filter((part) => part !== null).join("\n")
+  return { markdown, status: 200 }
+}

--- a/src/app/api/showcase/[slug]/route.ts
+++ b/src/app/api/showcase/[slug]/route.ts
@@ -1,42 +1,26 @@
-import * as Sentry from "@sentry/nextjs"
-import { NextResponse } from "next/server"
-
-import { SITE_URL } from "@/lib/constants"
+import {
+  markdownErrorResponse,
+  markdownNotFoundResponse,
+  markdownResponse,
+  markdownSlug
+} from "@/service/markdown/response"
 
 import { buildShowcaseMarkdown } from "./markdown"
-
-const MD_HEADERS = {
-  "Content-Type": "text/markdown; charset=utf-8",
-  Vary: "Accept",
-  "X-Content-Type-Options": "nosniff"
-} as const
 
 export async function GET(
   _request: Request,
   { params }: { params: Promise<{ slug: string }> }
 ) {
   const { slug: rawSlug } = await params
-
-  // Only the `.md` form is served here; the proxy rewrites to this route.
-  if (!rawSlug.endsWith(".md"))
-    return new NextResponse(null, { status: 404, headers: MD_HEADERS })
-  const slug = rawSlug.slice(0, -3)
+  const slug = markdownSlug(rawSlug)
+  if (slug === null) return markdownNotFoundResponse()
 
   try {
-    const { markdown, status } = await buildShowcaseMarkdown(slug)
-    return new NextResponse(markdown, {
-      status,
-      headers: {
-        ...MD_HEADERS,
-        Link: `<${SITE_URL}/showcase/${slug}>; rel="canonical"`
-      }
-    })
+    return markdownResponse(
+      await buildShowcaseMarkdown(slug),
+      `/showcase/${slug}`
+    )
   } catch (error) {
-    console.error("Error building project markdown:", error)
-    Sentry.captureException(error)
-    return new NextResponse("# 500 Error\n\nFailed to build markdown.", {
-      status: 500,
-      headers: MD_HEADERS
-    })
+    return markdownErrorResponse("project", error)
   }
 }

--- a/src/app/api/showcase/[slug]/route.ts
+++ b/src/app/api/showcase/[slug]/route.ts
@@ -1,12 +1,9 @@
 import * as Sentry from "@sentry/nextjs"
 import { NextResponse } from "next/server"
 
-import {
-  fetchProjectBySlug,
-  fetchRelatedProjectsForMarkdown
-} from "@/app/(site)/(plain)/(content)/showcase/[slug]/sanity"
 import { SITE_URL } from "@/lib/constants"
-import { portableTextToMarkdown } from "@/service/sanity/portable-text-to-markdown"
+
+import { buildShowcaseMarkdown } from "./markdown"
 
 const MD_HEADERS = {
   "Content-Type": "text/markdown; charset=utf-8",
@@ -26,67 +23,9 @@ export async function GET(
   const slug = rawSlug.slice(0, -3)
 
   try {
-    const [project, relatedProjects] = await Promise.all([
-      fetchProjectBySlug(slug, { published: true }),
-      fetchRelatedProjectsForMarkdown(slug)
-    ])
-    if (!project) {
-      return new NextResponse("# 404 Not Found\n", {
-        status: 404,
-        headers: MD_HEADERS
-      })
-    }
-
-    const clientLine = project.client
-      ? project.client.website
-        ? `**Client:** [${project.client.title}](${project.client.website})`
-        : `**Client:** ${project.client.title}`
-      : null
-
-    const parts: Array<string | null> = [
-      `# ${project.title}`,
-      "",
-      clientLine,
-      project.year ? `**Year:** ${project.year}` : null,
-      project.categories?.length
-        ? `**Categories:** ${project.categories.map((c) => c.title).join(", ")}`
-        : null,
-      project.projectWebsite ? `**Website:** ${project.projectWebsite}` : null,
-      project.caseStudy ? `**Case Study:** ${project.caseStudy}` : null,
-      project.people?.length
-        ? `**Team:** ${project.people
-            .map((p) =>
-              p.department ? `${p.title} (${p.department.title})` : p.title
-            )
-            .join(", ")}`
-        : null,
-      project.awards?.length
-        ? `**Awards:** ${project.awards.map((a) => a.title).join(", ")}`
-        : null,
-      "",
-      "---",
-      "",
-      portableTextToMarkdown(project.content, { baseUrl: SITE_URL }),
-      "",
-      relatedProjects.length ? "## Related Projects" : null,
-      relatedProjects.length ? "" : null,
-      relatedProjects.length
-        ? relatedProjects
-            .map(
-              (related) =>
-                `- [${related.title}](${SITE_URL}/showcase/${related.slug}.md)`
-            )
-            .join("\n")
-        : null,
-      relatedProjects.length ? "" : null,
-      "---",
-      "",
-      `[View all content](${SITE_URL}/sitemap.md)`
-    ]
-
-    const markdown = parts.filter((part) => part !== null).join("\n")
-
+    const { markdown, status } = await buildShowcaseMarkdown(slug)
     return new NextResponse(markdown, {
+      status,
       headers: {
         ...MD_HEADERS,
         Link: `<${SITE_URL}/showcase/${slug}>; rel="canonical"`

--- a/src/app/sitemap.md/markdown.ts
+++ b/src/app/sitemap.md/markdown.ts
@@ -2,11 +2,9 @@ import { fetchAllOpenPositionsForIndex } from "@/app/(site)/(plain)/(content)/ca
 import { fetchAllPostsForIndex } from "@/app/(site)/(plain)/(content)/post/[slug]/sanity"
 import { fetchAllProjectsForIndex } from "@/app/(site)/(plain)/(content)/showcase/[slug]/sanity"
 import { SITE_URL } from "@/lib/constants"
+import type { MarkdownResult } from "@/service/markdown/document"
 
-export async function buildSitemapMarkdown(): Promise<{
-  markdown: string
-  status: 200
-}> {
+export async function buildSitemapMarkdown(): Promise<MarkdownResult<200>> {
   "use cache"
   const [posts, projects, positions] = await Promise.all([
     fetchAllPostsForIndex(),

--- a/src/app/sitemap.md/markdown.ts
+++ b/src/app/sitemap.md/markdown.ts
@@ -1,0 +1,74 @@
+import { fetchAllOpenPositionsForIndex } from "@/app/(site)/(plain)/(content)/careers/[slug]/sanity"
+import { fetchAllPostsForIndex } from "@/app/(site)/(plain)/(content)/post/[slug]/sanity"
+import { fetchAllProjectsForIndex } from "@/app/(site)/(plain)/(content)/showcase/[slug]/sanity"
+import { SITE_URL } from "@/lib/constants"
+
+export async function buildSitemapMarkdown(): Promise<{
+  markdown: string
+  status: 200
+}> {
+  "use cache"
+  const [posts, projects, positions] = await Promise.all([
+    fetchAllPostsForIndex(),
+    fetchAllProjectsForIndex(),
+    fetchAllOpenPositionsForIndex()
+  ])
+
+  const parts: string[] = ["# basement.studio — Content Index", ""]
+
+  parts.push(
+    "## Pages",
+    "",
+    `- [Home](${SITE_URL}/index.md)`,
+    `- [Services](${SITE_URL}/services.md)`,
+    `- [People](${SITE_URL}/people.md)`,
+    `- [Showcase](${SITE_URL}/showcase.md)`,
+    `- [Blog](${SITE_URL}/blog.md)`,
+    `- [Lab](${SITE_URL}/lab.md)`,
+    `- [FAQ](${SITE_URL}/faq.md)`,
+    `- [Contact](${SITE_URL}/contact.md)`,
+    ""
+  )
+
+  if (posts.length > 0) {
+    parts.push("## Blog Posts", "")
+    for (const post of posts) {
+      parts.push(`- [${post.title}](${SITE_URL}/post/${post.slug}.md)`)
+    }
+    parts.push("")
+  }
+
+  if (projects.length > 0) {
+    parts.push("## Projects", "")
+    for (const project of projects) {
+      parts.push(
+        `- [${project.title}](${SITE_URL}/showcase/${project.slug}.md)`
+      )
+    }
+    parts.push("")
+  }
+
+  if (positions.length > 0) {
+    parts.push("## Open Positions", "")
+    for (const position of positions) {
+      parts.push(
+        `- [${position.title}](${SITE_URL}/careers/${position.slug}.md)`
+      )
+    }
+    parts.push("")
+  }
+
+  parts.push(
+    "## Other Resources",
+    "",
+    `- [Machine view](${SITE_URL}/ai) — single-page plain-HTML index of the entire site`,
+    `- [llms.txt](${SITE_URL}/llms.txt) — curated link map for LLMs`,
+    `- [agents.md](${SITE_URL}/agents.md) — notes for AI agents and crawlers`,
+    `- [XML sitemap](${SITE_URL}/sitemap.xml)`,
+    `- [Basketball](${SITE_URL}/basketball) — interactive experience, HTML only`,
+    `- [Doom](${SITE_URL}/doom) — interactive experience, HTML only`,
+    ""
+  )
+
+  return { markdown: parts.join("\n"), status: 200 }
+}

--- a/src/app/sitemap.md/route.ts
+++ b/src/app/sitemap.md/route.ts
@@ -1,10 +1,7 @@
 import * as Sentry from "@sentry/nextjs"
 import { NextResponse } from "next/server"
 
-import { fetchAllOpenPositionsForIndex } from "@/app/(site)/(plain)/(content)/careers/[slug]/sanity"
-import { fetchAllPostsForIndex } from "@/app/(site)/(plain)/(content)/post/[slug]/sanity"
-import { fetchAllProjectsForIndex } from "@/app/(site)/(plain)/(content)/showcase/[slug]/sanity"
-import { SITE_URL } from "@/lib/constants"
+import { buildSitemapMarkdown } from "./markdown"
 
 const MD_HEADERS = {
   "Content-Type": "text/markdown; charset=utf-8",
@@ -14,69 +11,8 @@ const MD_HEADERS = {
 
 export async function GET() {
   try {
-    const [posts, projects, positions] = await Promise.all([
-      fetchAllPostsForIndex(),
-      fetchAllProjectsForIndex(),
-      fetchAllOpenPositionsForIndex()
-    ])
-
-    const parts: string[] = ["# basement.studio — Content Index", ""]
-
-    parts.push(
-      "## Pages",
-      "",
-      `- [Home](${SITE_URL}/index.md)`,
-      `- [Services](${SITE_URL}/services.md)`,
-      `- [People](${SITE_URL}/people.md)`,
-      `- [Showcase](${SITE_URL}/showcase.md)`,
-      `- [Blog](${SITE_URL}/blog.md)`,
-      `- [Lab](${SITE_URL}/lab.md)`,
-      `- [FAQ](${SITE_URL}/faq.md)`,
-      `- [Contact](${SITE_URL}/contact.md)`,
-      ""
-    )
-
-    if (posts.length > 0) {
-      parts.push("## Blog Posts", "")
-      for (const post of posts) {
-        parts.push(`- [${post.title}](${SITE_URL}/post/${post.slug}.md)`)
-      }
-      parts.push("")
-    }
-
-    if (projects.length > 0) {
-      parts.push("## Projects", "")
-      for (const project of projects) {
-        parts.push(
-          `- [${project.title}](${SITE_URL}/showcase/${project.slug}.md)`
-        )
-      }
-      parts.push("")
-    }
-
-    if (positions.length > 0) {
-      parts.push("## Open Positions", "")
-      for (const position of positions) {
-        parts.push(
-          `- [${position.title}](${SITE_URL}/careers/${position.slug}.md)`
-        )
-      }
-      parts.push("")
-    }
-
-    parts.push(
-      "## Other Resources",
-      "",
-      `- [Machine view](${SITE_URL}/ai) — single-page plain-HTML index of the entire site`,
-      `- [llms.txt](${SITE_URL}/llms.txt) — curated link map for LLMs`,
-      `- [agents.md](${SITE_URL}/agents.md) — notes for AI agents and crawlers`,
-      `- [XML sitemap](${SITE_URL}/sitemap.xml)`,
-      `- [Basketball](${SITE_URL}/basketball) — interactive experience, HTML only`,
-      `- [Doom](${SITE_URL}/doom) — interactive experience, HTML only`,
-      ""
-    )
-
-    return new NextResponse(parts.join("\n"), {
+    const { markdown } = await buildSitemapMarkdown()
+    return new NextResponse(markdown, {
       headers: MD_HEADERS
     })
   } catch (error) {

--- a/src/app/sitemap.md/route.ts
+++ b/src/app/sitemap.md/route.ts
@@ -1,26 +1,15 @@
-import * as Sentry from "@sentry/nextjs"
-import { NextResponse } from "next/server"
+import {
+  markdownErrorResponse,
+  markdownResponse
+} from "@/service/markdown/response"
 
 import { buildSitemapMarkdown } from "./markdown"
 
-const MD_HEADERS = {
-  "Content-Type": "text/markdown; charset=utf-8",
-  Vary: "Accept",
-  "X-Content-Type-Options": "nosniff"
-} as const
-
 export async function GET() {
   try {
-    const { markdown } = await buildSitemapMarkdown()
-    return new NextResponse(markdown, {
-      headers: MD_HEADERS
-    })
+    // No canonical `Link` — the content index has no HTML twin.
+    return markdownResponse(await buildSitemapMarkdown())
   } catch (error) {
-    console.error("Error building markdown sitemap:", error)
-    Sentry.captureException(error)
-    return new NextResponse("# 500 Error\n\nFailed to build content index.", {
-      status: 500,
-      headers: MD_HEADERS
-    })
+    return markdownErrorResponse("sitemap", error)
   }
 }

--- a/src/service/markdown/document.ts
+++ b/src/service/markdown/document.ts
@@ -1,0 +1,17 @@
+/**
+ * What every `.md` builder returns. Narrow `Status` to `200` when the content
+ * can't be missing — the type is the only signal a route has a 404 path.
+ */
+export interface MarkdownResult<Status extends 200 | 404 = 200 | 404> {
+  markdown: string
+  status: Status
+}
+
+export const NOT_FOUND_MARKDOWN = "# 404 Not Found\n"
+
+// CMS strings land inside `[label](url)` syntax — escape the delimiters so a
+// bracketed label or a parenthesized URL can't break the link.
+export const escapeLinkLabel = (text: string) =>
+  text.replace(/[\\[\]]/g, "\\$&")
+export const escapeLinkUrl = (url: string) =>
+  url.replace(/\(/g, "%28").replace(/\)/g, "%29")

--- a/src/service/markdown/response.ts
+++ b/src/service/markdown/response.ts
@@ -1,0 +1,54 @@
+import * as Sentry from "@sentry/nextjs"
+import { NextResponse } from "next/server"
+
+import { SITE_URL } from "@/lib/constants"
+
+import type { MarkdownResult } from "./document"
+
+const MD_HEADERS = {
+  "Content-Type": "text/markdown; charset=utf-8",
+  Vary: "Accept",
+  "X-Content-Type-Options": "nosniff"
+} as const
+
+/** `canonicalPath` is appended to `SITE_URL`; omit it when there's no HTML twin. */
+export function markdownResponse(
+  { markdown, status }: MarkdownResult,
+  canonicalPath?: string
+) {
+  return new NextResponse(markdown, {
+    status,
+    headers:
+      canonicalPath === undefined
+        ? MD_HEADERS
+        : {
+            ...MD_HEADERS,
+            Link: `<${SITE_URL}${canonicalPath}>; rel="canonical"`
+          }
+  })
+}
+
+export function markdownNotFoundResponse() {
+  return new NextResponse(null, { status: 404, headers: MD_HEADERS })
+}
+
+/**
+ * Route handlers are auto-instrumented by the Sentry build plugin, but only for
+ * errors that propagate — a caught one still needs the explicit capture.
+ */
+export function markdownErrorResponse(label: string, error: unknown) {
+  console.error(`Error building ${label} markdown:`, error)
+  Sentry.captureException(error)
+  return new NextResponse("# 500 Error\n\nFailed to build markdown.", {
+    status: 500,
+    headers: MD_HEADERS
+  })
+}
+
+/**
+ * Strips the `.md` suffix the proxy rewrites into the slug param. Null means a
+ * direct hit on the internal API path, which isn't served.
+ */
+export function markdownSlug(rawSlug: string): string | null {
+  return rawSlug.endsWith(".md") ? rawSlug.slice(0, -3) : null
+}

--- a/src/service/sanity/index.ts
+++ b/src/service/sanity/index.ts
@@ -60,8 +60,9 @@ export async function sanityFetchCached<T>(opts: {
 
 /**
  * Non-Live fetch for contexts outside a `"use cache"` scope (`generateStaticParams`,
- * `generateMetadata`): the Live `sanityFetch`'s `cacheTag()` is illegal there.
- * Always reads published, stega-free data.
+ * server actions). The bare Live `sanityFetch` needs an enclosing `"use cache"` scope
+ * for its `cacheTag()`; `sanityFetchCached` opens its own and is legal from route
+ * handlers and `generateMetadata`. Always reads published, stega-free data.
  */
 export async function sanityFetchStatic<T>({
   query,


### PR DESCRIPTION
## Summary
- Wrap all 12 `.md` route handlers in sibling `"use cache"` build modules that cache Sanity reads and markdown serialization as a single tag-invalidated entry per route.
- Switch the four remaining per-request `sanityFetchStatic` reads (`fetchPostBySlug`, `fetchRelatedPostsForMarkdown`, `fetchProjectBySlug`, `fetchCareerPosition`) to Live `sanityFetch` with `perspective: "published"` inside those scopes, and split `fetchLabProjects` so the server action path stays static.
- Route handlers are thin wrappers; 404 misses use `cacheLife("hours")`; errors stay outside cache scopes. Doc/comment fixes in `AGENTS.md` and `src/service/sanity/index.ts`.

## Test plan
- [x] `npx next build` — no `cacheTag()` or dynamic-usage errors; markdown routes prerender with `1y` revalidate
- [x] Byte-identical `.md` output vs production for all 12 routes (11/12 exact; post `Published` dates differ by one day vs UTC production because `toLocaleDateString()` is timezone-local — pre-existing, not from this wrap)
- [x] `curl` 200s: `Content-Type`, `Vary: Accept`, `Link rel=canonical` on `/post/$S.md`, `/showcase/$P.md`, `/careers/$C.md`, `/lab.md`, `/index.md`, `/blog.md`, `/sitemap.md` (also `/services.md`, `/people.md`, `/faq.md`, `/contact.md`, `/showcase.md`)
- [x] Content negotiation via proxy: `curl -H 'Accept: text/markdown' http://localhost:3000/post/$S`
- [x] 404 paths return `# 404 Not Found` (not 200/500) for missing post and career slugs
- [x] Stega regression: no zero-width chars in published `.md` output
- [ ] Sanity outage returns 500 and is not cached on recovery (Invariant 5)
- [ ] Confirm Sanity webhook is a Vercel Deploy Hook (or verify tag invalidation on publish)
