### PR TITLE
fix(redirects): keep the old xmcp 0.8 post URL alive after the v1 retitle

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -165,6 +165,13 @@ const nextConfig: NextConfig = {
         permanent: true
       },
 
+      // Renamed blog posts
+      {
+        source: "/post/from-experiment-to-framework-the-road-to-xmcp-08",
+        destination: "/post/from-experiment-to-framework-the-road-to-xmcp-v1",
+        permanent: true
+      },
+
       // Webby
       {
         source: "/webby",


### PR DESCRIPTION
## What

Adds a permanent redirect from the xmcp post's old slug to its new one:

```
/post/from-experiment-to-framework-the-road-to-xmcp-08
  → /post/from-experiment-to-framework-the-road-to-xmcp-v1
```

## Why

The post has been retitled from *"From Experiment to Framework: The Road to xmcp 0.8"* to *"…The Road to xmcp v1"*, and its Sanity slug changed to match. The post went up on Aug 20 and has been shared since, so the old URL needs to keep resolving rather than 404.

## The content side

The post body itself lives in Sanity, not in this repo, so it isn't part of this diff. Those edits are staged as a **draft** on `post-xmcp-0-8-road` and need review + publish in the Studio:

- New hero plaque (the `xmcp v1` lockup from Figma)
- New *"Reaching v1"* section covering the 2026-07-28 protocol revision / SDK v2 split and `extra.sample()` in 1.1
- 0.8 reframed as a step toward 1.0 rather than the destination
- `Upgrading to 0.8` → `Upgrading to v1`, install commands now use `@latest`

**Merge this together with publishing the draft** — landing the redirect before the slug changes sends the live URL to a 404, and publishing the draft before this merges leaves the old URL dead.