### PR TITLE
fix(careers): report and recover from failed application submits

### DIFF
--- a/src/actions/career-application/index.ts
+++ b/src/actions/career-application/index.ts
@@ -11,8 +11,26 @@ import {
 } from "@/lib/notion"
 import { isSuspiciousSubmission } from "@/lib/suspicious-submission"
 
-const GENERIC_SUBMISSION_ERROR =
-  "There was a problem submitting your application. Please try again in a moment or contact us."
+/** `reason` tells the caller which failures are already in Sentry. */
+export type CareerApplicationResult =
+  | { success: true }
+  | {
+      success: false
+      error: string
+      reason: FailureReason
+    }
+
+type FailureReason = "validation" | "rate_limited" | "upstream"
+
+// Rendered at heading size next to the submit button, so one short sentence.
+const SUBMISSION_ERRORS: Record<FailureReason, string> = {
+  // Retrying won't help: the client accepted input the action then rejected.
+  validation:
+    "Something went wrong on our end. Please email hello@basement.studio.",
+  rate_limited: "Too many attempts. Please wait a few minutes and try again.",
+  upstream: "We couldn't save your application. Please try again in a moment."
+}
+
 const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1_000
 const MAX_SUBMISSIONS_PER_WINDOW = 5
 
@@ -74,13 +92,17 @@ function validateCareerFormData(formData: CareerFormData) {
   return true
 }
 
-export async function submitCareerApplication(formData: CareerFormData) {
+export async function submitCareerApplication(
+  formData: CareerFormData
+): Promise<CareerApplicationResult> {
   return Sentry.withServerActionInstrumentation("submitCareerApplication", () =>
     runCareerApplication(formData)
   )
 }
 
-async function runCareerApplication(formData: CareerFormData) {
+async function runCareerApplication(
+  formData: CareerFormData
+): Promise<CareerApplicationResult> {
   try {
     const now = Date.now()
 
@@ -103,7 +125,11 @@ async function runCareerApplication(formData: CareerFormData) {
         email: formData.email,
         salaryExpectations: formData.salaryExpectations
       })
-      return { success: false, error: GENERIC_SUBMISSION_ERROR }
+      return {
+        success: false,
+        error: SUBMISSION_ERRORS.validation,
+        reason: "validation"
+      }
     }
 
     const headerList = await headers()
@@ -111,7 +137,11 @@ async function runCareerApplication(formData: CareerFormData) {
 
     if (isRateLimited(clientIdentifier, now)) {
       console.error("Career application rate limited:", clientIdentifier)
-      return { success: false, error: GENERIC_SUBMISSION_ERROR }
+      return {
+        success: false,
+        error: SUBMISSION_ERRORS.rate_limited,
+        reason: "rate_limited"
+      }
     }
 
     const applicationData = buildApplicationData(formData)
@@ -130,11 +160,16 @@ async function runCareerApplication(formData: CareerFormData) {
 
     return {
       success: false,
-      error: GENERIC_SUBMISSION_ERROR
+      error: SUBMISSION_ERRORS.upstream,
+      reason: "upstream"
     }
   } catch (error) {
     console.error("Error submitting career application:", error)
     Sentry.captureException(error)
-    return { success: false, error: GENERIC_SUBMISSION_ERROR }
+    return {
+      success: false,
+      error: SUBMISSION_ERRORS.upstream,
+      reason: "upstream"
+    }
   }
 }

--- a/src/app/(site)/(plain)/(content)/careers/[slug]/application-form.tsx
+++ b/src/app/(site)/(plain)/(content)/careers/[slug]/application-form.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import * as Sentry from "@sentry/nextjs"
 import { track } from "@vercel/analytics"
 import { type KeyboardEventHandler, useEffect, useRef, useState } from "react"
 import { Controller, type SubmitHandler, useForm } from "react-hook-form"
@@ -216,21 +217,38 @@ export const ApplicationForm = ({
     // Brief spinner, then optimistic success
     await new Promise((r) => setTimeout(r, 250))
     setFormState("submitted")
-    reset(getDefaultFormValues(positionSlug))
 
     // Fire API in background — revert on failure
     submitCareerApplication(submissionData)
       .then((result) => {
-        if (!result.success) {
+        if (result.success) {
+          // Only on success, so a failed retry keeps the typed data.
+          reset(getDefaultFormValues(positionSlug))
+        } else {
           setFormState("idle")
           setSubmitError(
             result.error || "Submission failed \u2014 please try again"
           )
+          // The one failure the action doesn't report itself.
+          if (result.reason === "validation") {
+            Sentry.captureMessage(
+              "Career application rejected by server validation",
+              {
+                level: "error",
+                tags: { form: "career-application", position: positionSlug }
+              }
+            )
+          }
         }
       })
-      .catch(() => {
+      .catch((error) => {
         setFormState("idle")
         setSubmitError("Submission failed \u2014 please try again")
+        // Own fingerprint, else this merges into Next's "Failed to fetch" pile.
+        Sentry.captureException(error, {
+          tags: { form: "career-application", position: positionSlug },
+          fingerprint: ["career-application-dropped"]
+        })
       })
       .finally(() => {
         apiInFlightRef.current = false


### PR DESCRIPTION
## Summary

Every failure of the careers application form returned the same generic message, and the form was reset before the server action resolved — so a failed submit left the applicant with an empty form, a disabled button, and "please try again". This tags each failure with a reason, gives each its own message, holds the reset until success, and reports the two failures nothing else was catching.

## Changes

- Add a `reason` discriminator (`validation` / `rate_limited` / `upstream`) to the action's failure results
- Replace the single generic error with a per-reason message
- Move `reset()` into the success branch so a failed submit keeps the typed data
- Report transport failures with their own Sentry fingerprint, so a dropped application doesn't merge into Next's shared "Failed to fetch" issue
- Report server-side validation rejections, the one failure neither the action nor `onRequestError` covers

## Checklist

- [ ] `pnpm lint` passes
- [x] Tested locally in dev mode
- [x] No breaking changes (or documented in summary)

## Notes

Verified end to end against a local dev server: on failure all fields, the select, and the checked skill survive and the submit button stays enabled. No Notion records were created during testing.

Unrelated and pre-existing, found while verifying:

- The pre-prod Notion DB (`219b7f88…`, used by Preview + Development) is not connected to the "Basement Careers" integration, so submissions 404 on local and every preview deploy. Production (`8b647d83…`) is fine — schema validated, all 15 properties present, zero `integration:notion` errors in Sentry over 90d. Fixing it needs a Notion UI action: pre-prod DB → `···` → Connections → add Basement Careers.
- `tsc` reports ~97 errors across ~28 unrelated files on a clean tree, so `pnpm lint` is unverified here — eslint and prettier both OOM in this environment.
