### PR TITLE
feat(home): raise the brands grid cap for a fifth logo row

### DIFF
--- a/src/components/brands/index.tsx
+++ b/src/components/brands/index.tsx
@@ -74,7 +74,7 @@ export const BrandsDesktop = ({ brands }: BrandsDesktopProps) => {
 
   // Cap is visual only (logo grid needs full rows) — /index.md lists every
   // client on purpose, don't "fix" that to match this number.
-  const max = isLargeDesktop ? 32 : 30
+  const max = isLargeDesktop ? 40 : 36
   const groupSize = isLargeDesktop ? 8 : 6
   const available = Math.min(brands.length, max)
   const count = Math.floor(available / groupSize) * groupSize


### PR DESCRIPTION
The homepage clients array in Sanity now has 40 entries (8 new brands: SpaceX AI, USAvionix, Serval, Latent, General Catalyst, Accel, Greylock, a16z Infra), but the grid's visual cap slices the list at 32 (xl) / 30→24 (lg), so the new row never renders.

Raises the cap to 40 (xl) and 36 (lg): exactly 5 full rows of 8 at xl and 6 full rows of 6 at lg. Content-only counterpart (client docs, logo assets, homepage references) is already live in Sanity.