### PR TITLE
feat(home): wrap brands grid to 6 columns below 1536px

### DIFF
--- a/src/components/brands/index.tsx
+++ b/src/components/brands/index.tsx
@@ -60,7 +60,7 @@ interface BrandsDesktopProps {
 
 export const BrandsDesktop = ({ brands }: BrandsDesktopProps) => {
   const [hoveredBrandId, setHoveredBrandId] = useState<string | null>(null)
-  const isLargeDesktop = useMedia("(min-width: 1280px)")
+  const isLargeDesktop = useMedia("(min-width: 1536px)")
   const isDesktop = useMedia("(min-width: 1024px)")
 
   const debouncedHoveredBrandId = useDebounceValue(
@@ -91,7 +91,7 @@ export const BrandsDesktop = ({ brands }: BrandsDesktopProps) => {
       </div>
 
       <div className="relative col-span-full">
-        <div className="grid-rows-auto group grid grid-cols-6 gap-3 xl:grid-cols-8">
+        <div className="grid-rows-auto group grid grid-cols-6 gap-3 2xl:grid-cols-8">
           {filteredBrands.map((brand) => (
             <m.a
               className="aspect-[202/110] text-brand-w1 focus-visible:!ring-offset-0"

--- a/src/components/brands/index.tsx
+++ b/src/components/brands/index.tsx
@@ -74,7 +74,7 @@ export const BrandsDesktop = ({ brands }: BrandsDesktopProps) => {
 
   // Cap is visual only (logo grid needs full rows) — /index.md lists every
   // client on purpose, don't "fix" that to match this number.
-  const max = isLargeDesktop ? 32 : 30
+  const max = isLargeDesktop ? 40 : 36
   const groupSize = isLargeDesktop ? 8 : 6
   const available = Math.min(brands.length, max)
   const count = Math.floor(available / groupSize) * groupSize


### PR DESCRIPTION
On 14" laptops (1280-1535px) the 8-column brand rows feel cramped. This moves the 8-column layout up to the 2xl breakpoint (1536px), so 14" screens get the roomier 6-col x 6-row layout (36 logos, full-rows rule) and larger screens keep 8 x 5 with all 40.