### PR TITLE
feat(basketball): ghost mode — live opponents' balls via Supabase Realtime

### DIFF
--- a/src/app/(site)/(canvas)/basketball/client.tsx
+++ b/src/app/(site)/(canvas)/basketball/client.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { ArcadeNameInput } from "@/components/basketball/arcade-name-input"
-import { LedLeaderboard } from "@/components/basketball/led-leaderboard"
 import { Scoreboard } from "@/components/basketball/scoreboard"
 import { useHandleNavigation } from "@/hooks/use-handle-navigation"
 import { useMedia } from "@/hooks/use-media"
@@ -15,12 +14,8 @@ const Basketball = () => {
 
   return (
     <>
-      {!hasPlayed ? (
-        isMobile ? (
-          <MobileUI handleNavigation={handleNavigation} />
-        ) : (
-          <DesktopUI />
-        )
+      {!hasPlayed && isMobile ? (
+        <MobileUI handleNavigation={handleNavigation} />
       ) : null}
 
       {(hasPlayed && !playerName) || (hasPlayed && !isGameActive) ? (
@@ -35,14 +30,6 @@ const Basketball = () => {
 }
 
 export default Basketball
-
-const DesktopUI = () => (
-  <div className="pointer-events-none fixed left-0 top-0 h-screen w-full animate-fade-in p-3.5">
-    <div className="grid-layout mt-24 h-full">
-      <LedLeaderboard className="col-span-2 col-start-10 ml-auto" />
-    </div>
-  </div>
-)
 
 interface MobileUIProps {
   handleNavigation: (route: string) => void

--- a/src/app/(site)/(canvas)/basketball/client.tsx
+++ b/src/app/(site)/(canvas)/basketball/client.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { ArcadeNameInput } from "@/components/basketball/arcade-name-input"
+import { LedLeaderboard } from "@/components/basketball/led-leaderboard"
 import { Scoreboard } from "@/components/basketball/scoreboard"
 import { useHandleNavigation } from "@/hooks/use-handle-navigation"
 import { useMedia } from "@/hooks/use-media"
@@ -38,7 +39,7 @@ export default Basketball
 const DesktopUI = () => (
   <div className="pointer-events-none fixed left-0 top-0 h-screen w-full animate-fade-in p-3.5">
     <div className="grid-layout mt-24 h-full">
-      <Scoreboard className="col-span-2 col-start-10 ml-auto w-32 text-f-p-mobile lg:text-f-p" />
+      <LedLeaderboard className="col-span-2 col-start-10 ml-auto" />
     </div>
   </div>
 )

--- a/src/app/(site)/(canvas)/basketball/client.tsx
+++ b/src/app/(site)/(canvas)/basketball/client.tsx
@@ -1,53 +1,24 @@
 "use client"
 
-import { Geist_Mono } from "next/font/google"
-
 import { ArcadeNameInput } from "@/components/basketball/arcade-name-input"
 import { Scoreboard } from "@/components/basketball/scoreboard"
 import { useHandleNavigation } from "@/hooks/use-handle-navigation"
 import { useMedia } from "@/hooks/use-media"
 import { useMinigameStore } from "@/store/minigame-store"
 
-const geistMono = Geist_Mono({ subsets: ["latin"], weight: "variable" })
-
 const Basketball = () => {
-  const {
-    playerName,
-    hasPlayed,
-    score,
-    isGameActive,
-    timeRemaining,
-    scoreMultiplier
-  } = useMinigameStore()
+  const { playerName, hasPlayed, isGameActive } = useMinigameStore()
 
   const { handleNavigation } = useHandleNavigation()
   const isMobile = useMedia("(max-width: 1024px)")
-
-  const formatTime = (seconds: number) => {
-    const minutes = Math.floor(seconds / 60)
-    const remainingSeconds = seconds % 60
-    return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`
-  }
 
   return (
     <>
       {!hasPlayed ? (
         isMobile ? (
-          <MobileUI
-            handleNavigation={handleNavigation}
-            formatTime={formatTime}
-            timeRemaining={timeRemaining}
-            score={score}
-            scoreMultiplier={scoreMultiplier}
-          />
+          <MobileUI handleNavigation={handleNavigation} />
         ) : (
-          <DesktopUI
-            handleNavigation={handleNavigation}
-            formatTime={formatTime}
-            timeRemaining={timeRemaining}
-            score={score}
-            scoreMultiplier={scoreMultiplier}
-          />
+          <DesktopUI />
         )
       ) : null}
 
@@ -64,49 +35,9 @@ const Basketball = () => {
 
 export default Basketball
 
-interface DesktopUIProps {
-  handleNavigation: (route: string) => void
-  formatTime: (time: number) => string
-  timeRemaining: number
-  score: number
-  scoreMultiplier: number
-}
-
-const DesktopUI = ({
-  handleNavigation,
-  formatTime,
-  timeRemaining,
-  score,
-  scoreMultiplier
-}: DesktopUIProps) => (
+const DesktopUI = () => (
   <div className="pointer-events-none fixed left-0 top-0 h-screen w-full animate-fade-in p-3.5">
     <div className="grid-layout mt-24 h-full">
-      <button
-        onClick={() => handleNavigation("/")}
-        className="pointer-events-auto col-span-2 col-start-2 h-max text-f-p-mobile text-brand-w1 lg:text-f-p"
-      >
-        Close Game [ESC]
-      </button>
-      <div
-        className={`${geistMono.className} col-span-2 col-start-6 flex h-10 select-none text-f-p-mobile uppercase text-brand-w2 lg:text-f-p`}
-      >
-        <div className="corner-borders relative flex w-1/2 translate-x-[0.5px] items-center justify-center">
-          <p>{formatTime(timeRemaining)}</p>
-        </div>
-
-        <div className="corner-borders relative flex w-1/2 -translate-x-[0.5px] items-center justify-center">
-          <p>{Math.floor(score)} Pts.</p>
-        </div>
-      </div>
-
-      <div className="col-span-1 col-start-8 flex h-10 items-center justify-center">
-        <p
-          className={`${geistMono.className} text-f-p-mobile text-brand-w1 lg:text-f-p`}
-        >
-          {scoreMultiplier}x
-        </p>
-      </div>
-
       <Scoreboard className="col-span-2 col-start-10 ml-auto w-32 text-f-p-mobile lg:text-f-p" />
     </div>
   </div>
@@ -114,19 +45,9 @@ const DesktopUI = ({
 
 interface MobileUIProps {
   handleNavigation: (route: string) => void
-  formatTime: (time: number) => string
-  timeRemaining: number
-  score: number
-  scoreMultiplier: number
 }
 
-const MobileUI = ({
-  handleNavigation,
-  formatTime,
-  timeRemaining,
-  score,
-  scoreMultiplier
-}: MobileUIProps) => (
+const MobileUI = ({ handleNavigation }: MobileUIProps) => (
   <div className="pointer-events-none fixed left-0 top-0 h-screen w-full animate-fade-in flex-col px-4 py-12">
     <div className="grid grid-cols-4 place-items-start gap-4">
       <button
@@ -135,18 +56,6 @@ const MobileUI = ({
       >
         [Close]
       </button>
-
-      <div className="col-span-2 col-start-2 flex w-full items-center justify-center gap-4 font-mono text-f-p-mobile text-brand-w2">
-        <div className="relative flex items-center justify-center">
-          <p className="uppercase">{formatTime(timeRemaining)}</p>
-        </div>
-        <div className="relative flex items-center justify-center">
-          <p className="uppercase">{Math.floor(score)} Pts.</p>
-        </div>
-        <div className="relative flex items-center justify-center">
-          <p>{scoreMultiplier}x</p>
-        </div>
-      </div>
 
       <div className="col-span-1 col-start-4 w-full">
         <Scoreboard isMobile />

--- a/src/app/(site)/api/scores/route.ts
+++ b/src/app/(site)/api/scores/route.ts
@@ -128,12 +128,7 @@ export async function POST(request: Request) {
       )
     }
 
-    if (
-      typeof score !== "number" ||
-      score < 0 ||
-      score >= 400 ||
-      !Number.isInteger(score)
-    ) {
+    if (typeof score !== "number" || score < 0 || !Number.isInteger(score)) {
       return NextResponse.json({ error: "Invalid score" }, { status: 400 })
     }
 

--- a/src/components/basketball/ghost-balls.tsx
+++ b/src/components/basketball/ghost-balls.tsx
@@ -1,0 +1,304 @@
+import type { RapierRigidBody } from "@react-three/rapier"
+import * as Sentry from "@sentry/nextjs"
+import type { RealtimeChannel } from "@supabase/supabase-js"
+import throttle from "lodash.throttle"
+import { RefObject, useEffect, useMemo, useRef } from "react"
+import { Group, Mesh, MeshStandardMaterial, Quaternion, Vector3 } from "three"
+
+import {
+  getClientId,
+  REALTIME_ENABLED,
+  REALTIME_ENV
+} from "@/components/realtime/realtime-store"
+import { useKTX2GLTF } from "@/hooks/use-ktx2-gltf"
+import { useFrameCallback } from "@/hooks/use-pausable-time"
+import { createClient } from "@/service/supabase/client"
+import {
+  createGlobalShaderMaterial,
+  useCustomShaderMaterial
+} from "@/shaders/material-global-shader"
+import { useMinigameStore } from "@/store/minigame-store"
+
+import { useAssets } from "../assets-provider"
+
+const GHOST_BROADCAST_MS = 100
+const MAX_GHOSTS = 5
+const STALE_MS = 2500
+const EVICT_MS = 10000
+const IDLE_DIST = 0.05
+const GHOST_OPACITY = 0.35
+const GHOST_DAMPING = 12
+
+// Loose bounding box around the court; packets outside it are dropped (the
+// channel is public, so payloads are untrusted)
+const COURT_BOUNDS = {
+  x: [-5, 15],
+  y: [-2, 15],
+  z: [-25, 0]
+} as const
+
+interface GhostTarget {
+  pos: Vector3
+  quat: Quaternion
+  lastSeen: number
+  seeded: boolean
+  slot: number
+}
+
+interface BallPayload {
+  id: string
+  p: [number, number, number]
+  q: [number, number, number, number]
+}
+
+const isFiniteVec = (value: unknown, length: number): value is number[] =>
+  Array.isArray(value) &&
+  value.length === length &&
+  value.every((n) => typeof n === "number" && Number.isFinite(n))
+
+const inCourtBounds = (p: number[]) =>
+  p[0] >= COURT_BOUNDS.x[0] &&
+  p[0] <= COURT_BOUNDS.x[1] &&
+  p[1] >= COURT_BOUNDS.y[0] &&
+  p[1] <= COURT_BOUNDS.y[1] &&
+  p[2] >= COURT_BOUNDS.z[0] &&
+  p[2] <= COURT_BOUNDS.z[1]
+
+const round3 = (n: number) => Math.round(n * 1000) / 1000
+
+const noRaycast = () => null
+
+interface GhostBallsProps {
+  ballRef: RefObject<RapierRigidBody | null>
+}
+
+export const GhostBalls = ({ ballRef }: GhostBallsProps) => {
+  if (!REALTIME_ENABLED) return null
+  return <GhostBallsImpl ballRef={ballRef} />
+}
+
+const GhostBallsImpl = ({ ballRef }: GhostBallsProps) => {
+  const { basketball } = useAssets()
+  const basketballModel = useKTX2GLTF(basketball)
+  const supabase = useMemo(() => createClient(), [])
+
+  const subscribedRef = useRef(false)
+  const peerCountRef = useRef(1)
+  const wasMovingRef = useRef(false)
+  const sendRef = useRef<ReturnType<typeof throttle> | null>(null)
+  const targetsRef = useRef<Map<string, GhostTarget>>(new Map())
+  // slot index -> client id occupying it; ghosts render from a fixed mesh pool
+  const slotsRef = useRef<(string | null)[]>(Array(MAX_GHOSTS).fill(null))
+  const poolRefs = useRef<(Group | null)[]>(Array(MAX_GHOSTS).fill(null))
+
+  const geometry = useMemo(
+    () => (basketballModel.scene.children[0] as Mesh).geometry,
+    [basketballModel]
+  )
+
+  const ghostMaterial = useMemo(() => {
+    const base = (
+      (basketballModel.scene.children[0] as Mesh)
+        .material as MeshStandardMaterial
+    ).clone()
+    base.transparent = true
+    base.opacity = GHOST_OPACITY
+    const mat = createGlobalShaderMaterial(base, {
+      LIGHT: true,
+      BASKETBALL: true
+    })
+    mat.uniforms.lightDirection.value = new Vector3(0, 1, -1)
+    mat.uniforms.backLightDirection.value = new Vector3(0, 0, 1)
+    mat.depthWrite = false
+    return mat
+  }, [basketballModel])
+
+  useEffect(() => {
+    return () => {
+      useCustomShaderMaterial.getState().removeMaterial(ghostMaterial.id)
+      ghostMaterial.dispose()
+    }
+  }, [ghostMaterial])
+
+  useEffect(() => {
+    const freeGhost = (id: string) => {
+      const target = targetsRef.current.get(id)
+      if (!target) return
+      const group = poolRefs.current[target.slot]
+      if (group) group.visible = false
+      slotsRef.current[target.slot] = null
+      targetsRef.current.delete(id)
+    }
+
+    const upsertTarget = (payload: BallPayload) => {
+      const now = performance.now()
+      let target = targetsRef.current.get(payload.id)
+      if (!target) {
+        const slot = slotsRef.current.indexOf(null)
+        if (slot === -1) return
+        slotsRef.current[slot] = payload.id
+        target = {
+          pos: new Vector3(),
+          quat: new Quaternion(),
+          lastSeen: now,
+          seeded: false,
+          slot
+        }
+        targetsRef.current.set(payload.id, target)
+      } else if (now - target.lastSeen > STALE_MS) {
+        // Sender went quiet (idle ball, tab-out); snap instead of zooming
+        // across the court when it comes back
+        target.seeded = false
+      }
+      target.pos.set(payload.p[0], payload.p[1], payload.p[2])
+      target.quat.set(payload.q[0], payload.q[1], payload.q[2], payload.q[3])
+      target.lastSeen = now
+    }
+
+    let channel: RealtimeChannel
+    try {
+      channel = supabase.channel(`${REALTIME_ENV}:basketball`, {
+        config: {
+          presence: { key: getClientId() },
+          broadcast: { self: false, ack: false }
+        }
+      })
+
+      channel
+        .on("broadcast", { event: "ball" }, ({ payload }) => {
+          if (!payload || typeof payload.id !== "string") return
+          if (payload.id === getClientId()) return
+          if (!isFiniteVec(payload.p, 3) || !isFiniteVec(payload.q, 4)) return
+          if (!inCourtBounds(payload.p)) return
+          upsertTarget(payload as BallPayload)
+        })
+        .on("presence", { event: "sync" }, () => {
+          peerCountRef.current = Object.keys(channel.presenceState()).length
+        })
+        .on("presence", { event: "leave" }, ({ key }) => {
+          freeGhost(key)
+        })
+        .subscribe(async (status) => {
+          if (status === "SUBSCRIBED") {
+            subscribedRef.current = true
+            await channel.track({ id: getClientId(), joinedAt: Date.now() })
+          }
+        })
+    } catch (error) {
+      Sentry.captureException(error)
+      return
+    }
+
+    const send = throttle(
+      (p: [number, number, number], q: [number, number, number, number]) => {
+        if (!subscribedRef.current) return
+        channel.send({
+          type: "broadcast",
+          event: "ball",
+          payload: { id: getClientId(), p, q }
+        })
+      },
+      GHOST_BROADCAST_MS
+    )
+    sendRef.current = send
+
+    return () => {
+      send.cancel()
+      sendRef.current = null
+      subscribedRef.current = false
+      peerCountRef.current = 1
+      wasMovingRef.current = false
+      targetsRef.current.clear()
+      slotsRef.current.fill(null)
+      poolRefs.current.forEach((group) => {
+        if (group) group.visible = false
+      })
+      supabase.removeChannel(channel)
+    }
+  }, [supabase])
+
+  useFrameCallback((_, delta) => {
+    // Send: sample the local rapier ball, but only when someone is listening
+    // and the ball is actually in play (quota stays at zero for solo visitors)
+    const ball = ballRef.current
+    if (subscribedRef.current && ball && peerCountRef.current > 1) {
+      const t = ball.translation()
+      if (
+        Number.isFinite(t.x) &&
+        Number.isFinite(t.y) &&
+        Number.isFinite(t.z)
+      ) {
+        const { isDragging, isResetting, initialPosition } =
+          useMinigameStore.getState()
+        const dx = t.x - initialPosition.x
+        const dy = t.y - initialPosition.y
+        const dz = t.z - initialPosition.z
+        const moving =
+          isDragging ||
+          isResetting ||
+          dx * dx + dy * dy + dz * dz > IDLE_DIST * IDLE_DIST
+        // One trailing packet when the ball settles, then silence; receivers
+        // hide the ghost via the stale timeout
+        if (moving || wasMovingRef.current) {
+          const r = ball.rotation()
+          sendRef.current?.(
+            [round3(t.x), round3(t.y), round3(t.z)],
+            [round3(r.x), round3(r.y), round3(r.z), round3(r.w)]
+          )
+        }
+        wasMovingRef.current = moving
+      }
+    }
+
+    // Receive: chase the latest network target for each ghost
+    const now = performance.now()
+    for (const [id, target] of targetsRef.current) {
+      const group = poolRefs.current[target.slot]
+      if (!group) continue
+      const age = now - target.lastSeen
+      if (age > STALE_MS) {
+        group.visible = false
+        if (age > EVICT_MS) {
+          slotsRef.current[target.slot] = null
+          targetsRef.current.delete(id)
+        }
+        continue
+      }
+      if (!target.seeded) {
+        group.position.copy(target.pos)
+        group.quaternion.copy(target.quat)
+        target.seeded = true
+      } else {
+        const alpha = 1 - Math.exp(-GHOST_DAMPING * delta)
+        group.position.lerp(target.pos, alpha)
+        group.quaternion.slerp(target.quat, alpha)
+      }
+      group.visible = true
+    }
+  })
+
+  return (
+    <>
+      {Array.from({ length: MAX_GHOSTS }, (_, i) => (
+        <group
+          key={i}
+          ref={(el) => {
+            poolRefs.current[i] = el
+          }}
+          visible={false}
+        >
+          {/* Network quat applies to the group; the mesh keeps the same fixed
+              rotation the real ball nests inside its RigidBody */}
+          <mesh
+            scale={1.25}
+            geometry={geometry}
+            material={ghostMaterial}
+            rotation={[-Math.PI / 2, 0, -Math.PI / 2]}
+            raycast={noRaycast}
+            userData={{ hasGlobalMaterial: true }}
+          />
+        </group>
+      ))}
+    </>
+  )
+}

--- a/src/components/basketball/ghost-balls.tsx
+++ b/src/components/basketball/ghost-balls.tsx
@@ -168,6 +168,9 @@ const GhostBallsImpl = ({ ballRef }: GhostBallsProps) => {
         .on("broadcast", { event: "ball" }, ({ payload }) => {
           if (!payload || typeof payload.id !== "string") return
           if (payload.id === getClientId()) return
+          // Only ghost ids that are tracked presence members, so a sender
+          // can't exhaust the pool with arbitrary ids
+          if (!(payload.id in channel.presenceState())) return
           if (!isFiniteVec(payload.p, 3) || !isFiniteVec(payload.q, 4)) return
           if (!inCourtBounds(payload.p)) return
           upsertTarget(payload as BallPayload)

--- a/src/components/basketball/ghost-balls.tsx
+++ b/src/components/basketball/ghost-balls.tsx
@@ -26,7 +26,7 @@ const MAX_GHOSTS = 5
 const STALE_MS = 2500
 const EVICT_MS = 10000
 const IDLE_DIST = 0.05
-const GHOST_OPACITY = 0.35
+const GHOST_OPACITY = 0.5
 const GHOST_DAMPING = 12
 
 // Loose bounding box around the court; packets outside it are dropped (the

--- a/src/components/basketball/hoop-minigame.tsx
+++ b/src/components/basketball/hoop-minigame.tsx
@@ -20,6 +20,7 @@ import { useMinigameStore } from "@/store/minigame-store"
 import { easeInOutCubic } from "@/utils/animations"
 
 import { Basketball } from "./basketball"
+import { GhostBalls } from "./ghost-balls"
 import { RigidBodies } from "./rigid-bodies"
 
 const HoopMinigameInner = () => {
@@ -697,6 +698,8 @@ const HoopMinigameInner = () => {
           />
         </>
       )}
+
+      <GhostBalls ballRef={ballRef} />
 
       <RigidBodies hoopPosition={hoopPosition} />
     </>

--- a/src/components/basketball/led-leaderboard.tsx
+++ b/src/components/basketball/led-leaderboard.tsx
@@ -19,12 +19,11 @@ import { useLeaderboardScores } from "./scoreboard"
 
 const MAX_ENTRIES = 10
 
-// Hangs from the mezzanine railing to the right of the hoop
-const PANEL_POSITION: [number, number, number] = [7.05, 3.52, -14.412]
-const PANEL_HEIGHT = 1.45
-const ROD_HEIGHT = 0.22
-const ROD_RADIUS = 0.008
-const ROD_INSET = 0.09
+// Wide three-column board on the wall band above the neon basement sign
+// (SM_LogoBasement sits at [8.44, 2.6, -14.6]; the panel floats just proud
+// of that wall)
+const PANEL_POSITION: [number, number, number] = [8.3, 3.25, -14.35]
+const PANEL_WIDTH = 2.2
 
 const CELL = 16
 const BEZEL = 12
@@ -32,22 +31,24 @@ const MARGIN = 24
 const CORNER_RADIUS = 24
 const PAD = BEZEL + MARGIN
 
-// 3-letter name block (17 cols), 2-col gap, right-aligned 3-digit score block
+// Three columns of four entry slots (10 filled); each column is a 3-letter
+// name block (17 cols), 2-col gap, right-aligned 3-digit score block
 const NAME_COLS = 17
 const GAP_COLS = 2
 const SCORE_COLS = 17
-const GRID_COLS = NAME_COLS + GAP_COLS + SCORE_COLS
-const HEADER_ROWS = 9
+const COLUMN_COLS = NAME_COLS + GAP_COLS + SCORE_COLS
+const COLUMN_GAP = 6
+const COLUMNS = 3
+const ROWS_PER_COLUMN = 4
+const GRID_COLS = COLUMN_COLS * COLUMNS + COLUMN_GAP * (COLUMNS - 1)
 const ROW_STRIDE = 9
-const GRID_ROWS = HEADER_ROWS + MAX_ENTRIES * ROW_STRIDE - 2
+const GRID_ROWS = ROWS_PER_COLUMN * ROW_STRIDE - 2
 
 const CANVAS_WIDTH = GRID_COLS * CELL + PAD * 2
 const CANVAS_HEIGHT = GRID_ROWS * CELL + PAD * 2
-const PANEL_WIDTH = PANEL_HEIGHT * (CANVAS_WIDTH / CANVAS_HEIGHT)
+const PANEL_HEIGHT = PANEL_WIDTH * (CANVAS_HEIGHT / CANVAS_WIDTH)
 
 const SPEC: MatrixSpec = { cell: CELL, pad: PAD }
-
-const HEADER = "TOP 10"
 
 export const LedLeaderboard = () => {
   const isBasketball = useNavigationStore(
@@ -70,33 +71,25 @@ export const LedLeaderboard = () => {
     if (!ctx) return
 
     drawPanel(ctx, CANVAS_WIDTH, CANVAS_HEIGHT, BEZEL, CORNER_RADIUS)
-    drawGhostGrid(ctx, SPEC, GRID_COLS, GRID_ROWS, (row, col) =>
-      row < HEADER_ROWS - 2 || col < NAME_COLS + GAP_COLS
-        ? AMBER_GHOST
-        : SCORE_GHOST
-    )
-
-    drawGlyphRow(
-      ctx,
-      SPEC,
-      HEADER,
-      0,
-      AMBER,
-      Math.floor((GRID_COLS - textCols(HEADER)) / 2)
-    )
+    drawGhostGrid(ctx, SPEC, GRID_COLS, GRID_ROWS, (_, col) => {
+      const colInColumn = col % (COLUMN_COLS + COLUMN_GAP)
+      return colInColumn >= NAME_COLS + GAP_COLS ? SCORE_GHOST : AMBER_GHOST
+    })
 
     highScores.slice(0, MAX_ENTRIES).forEach((entry, i) => {
-      const row = HEADER_ROWS + i * ROW_STRIDE
+      const column = Math.floor(i / ROWS_PER_COLUMN)
+      const columnStart = column * (COLUMN_COLS + COLUMN_GAP)
+      const row = (i % ROWS_PER_COLUMN) * ROW_STRIDE
       const name = entry.player_name.toUpperCase().slice(0, 3)
       const score = String(Math.max(0, Math.min(Math.floor(entry.score), 999)))
-      drawGlyphRow(ctx, SPEC, name, row, AMBER, 0)
+      drawGlyphRow(ctx, SPEC, name, row, AMBER, columnStart)
       drawGlyphRow(
         ctx,
         SPEC,
         score,
         row,
         SCORE_COLOR,
-        GRID_COLS - textCols(score)
+        columnStart + COLUMN_COLS - textCols(score)
       )
     })
 
@@ -109,24 +102,9 @@ export const LedLeaderboard = () => {
   if (!isBasketball) return null
 
   return (
-    <group position={PANEL_POSITION}>
-      <mesh>
-        <planeGeometry args={[PANEL_WIDTH, PANEL_HEIGHT]} />
-        <meshBasicMaterial map={texture} transparent />
-      </mesh>
-      {[-1, 1].map((side) => (
-        <mesh
-          key={side}
-          position={[
-            side * (PANEL_WIDTH / 2 - ROD_INSET),
-            PANEL_HEIGHT / 2 + ROD_HEIGHT / 2,
-            0
-          ]}
-        >
-          <cylinderGeometry args={[ROD_RADIUS, ROD_RADIUS, ROD_HEIGHT, 6]} />
-          <meshBasicMaterial color="#ffffff" />
-        </mesh>
-      ))}
-    </group>
+    <mesh position={PANEL_POSITION}>
+      <planeGeometry args={[PANEL_WIDTH, PANEL_HEIGHT]} />
+      <meshBasicMaterial map={texture} transparent />
+    </mesh>
   )
 }

--- a/src/components/basketball/led-leaderboard.tsx
+++ b/src/components/basketball/led-leaderboard.tsx
@@ -10,6 +10,8 @@ import {
   drawGhostGrid,
   drawGlyphRow,
   drawPanel,
+  GLYPHS,
+  LED_GLOW,
   MatrixSpec,
   SCORE_COLOR,
   SCORE_GHOST,
@@ -22,12 +24,12 @@ const MAX_ENTRIES = 12
 // Wide three-column board on the wall band above the neon basement sign
 // (SM_LogoBasement sits at [8.44, 2.6, -14.6]; the panel floats just proud
 // of that wall)
-const PANEL_POSITION: [number, number, number] = [8.3, 3.45, -14.35]
-const PANEL_WIDTH = 2.2
+const PANEL_POSITION: [number, number, number] = [8.3, 3.69, -14.35]
+const PANEL_WIDTH = 1.9
 
 const CELL = 16
 const BEZEL = 12
-const MARGIN = 44
+const MARGIN = 80
 const CORNER_RADIUS = 24
 const PAD = BEZEL + MARGIN
 
@@ -41,9 +43,9 @@ const COLUMN_GAP = 6
 const COLUMNS = 3
 const ROWS_PER_COLUMN = 4
 const GRID_COLS = COLUMN_COLS * COLUMNS + COLUMN_GAP * (COLUMNS - 1)
-const ROW_STRIDE = 9
-const HEADER_ROWS = 9
-const GRID_ROWS = HEADER_ROWS + ROWS_PER_COLUMN * ROW_STRIDE - 2
+const ROW_STRIDE = 11
+const HEADER_ROWS = 13
+const GRID_ROWS = HEADER_ROWS + ROWS_PER_COLUMN * ROW_STRIDE - 4
 
 const CANVAS_WIDTH = GRID_COLS * CELL + PAD * 2
 const CANVAS_HEIGHT = GRID_ROWS * CELL + PAD * 2
@@ -51,7 +53,7 @@ const PANEL_HEIGHT = PANEL_WIDTH * (CANVAS_HEIGHT / CANVAS_WIDTH)
 
 const SPEC: MatrixSpec = { cell: CELL, pad: PAD }
 
-const HEADER = "HIGH SCORES"
+const HEADER = "HIGH-SCORES"
 
 export const LedLeaderboard = () => {
   const isBasketball = useNavigationStore(
@@ -73,7 +75,16 @@ export const LedLeaderboard = () => {
   useEffect(() => {
     if (!ctx) return
 
-    drawPanel(ctx, CANVAS_WIDTH, CANVAS_HEIGHT, BEZEL, CORNER_RADIUS)
+    // Near-opaque face: the animated white lamp doodle sits right behind
+    // this wall band and would glow through the default translucent panel
+    drawPanel(
+      ctx,
+      CANVAS_WIDTH,
+      CANVAS_HEIGHT,
+      BEZEL,
+      CORNER_RADIUS,
+      "rgba(10, 10, 12, 1)"
+    )
     drawGhostGrid(ctx, SPEC, GRID_COLS, GRID_ROWS, (row, col) => {
       if (row < HEADER_ROWS - 2) return AMBER_GHOST
       const colInColumn = col % (COLUMN_COLS + COLUMN_GAP)
@@ -89,7 +100,15 @@ export const LedLeaderboard = () => {
       Math.floor((GRID_COLS - textCols(HEADER)) / 2)
     )
 
-    highScores.slice(0, MAX_ENTRIES).forEach((entry, i) => {
+    // Skip entries whose name has no renderable glyphs (legacy symbol-only
+    // names would show as a blank slot); the next score takes their place
+    const renderable = highScores.filter((entry) =>
+      [...entry.player_name.toUpperCase()].some(
+        (char) => char !== " " && GLYPHS[char]
+      )
+    )
+
+    renderable.slice(0, MAX_ENTRIES).forEach((entry, i) => {
       const column = Math.floor(i / ROWS_PER_COLUMN)
       const columnStart = column * (COLUMN_COLS + COLUMN_GAP)
       const row = HEADER_ROWS + (i % ROWS_PER_COLUMN) * ROW_STRIDE
@@ -117,7 +136,10 @@ export const LedLeaderboard = () => {
   return (
     <mesh position={PANEL_POSITION}>
       <planeGeometry args={[PANEL_WIDTH, PANEL_HEIGHT]} />
-      <meshBasicMaterial map={texture} transparent />
+      {/* Over-bright multiplier pushes lit dots and the bezel past the
+          bloom luminance threshold so they glow like the neon sign; the
+          near-black face stays below it */}
+      <meshBasicMaterial map={texture} transparent color={LED_GLOW} />
     </mesh>
   )
 }

--- a/src/components/basketball/led-leaderboard.tsx
+++ b/src/components/basketball/led-leaderboard.tsx
@@ -22,7 +22,7 @@ const MAX_ENTRIES = 10
 // Wide three-column board on the wall band above the neon basement sign
 // (SM_LogoBasement sits at [8.44, 2.6, -14.6]; the panel floats just proud
 // of that wall)
-const PANEL_POSITION: [number, number, number] = [8.3, 3.25, -14.35]
+const PANEL_POSITION: [number, number, number] = [8.3, 3.33, -14.35]
 const PANEL_WIDTH = 2.2
 
 const CELL = 16
@@ -42,13 +42,16 @@ const COLUMNS = 3
 const ROWS_PER_COLUMN = 4
 const GRID_COLS = COLUMN_COLS * COLUMNS + COLUMN_GAP * (COLUMNS - 1)
 const ROW_STRIDE = 9
-const GRID_ROWS = ROWS_PER_COLUMN * ROW_STRIDE - 2
+const HEADER_ROWS = 9
+const GRID_ROWS = HEADER_ROWS + ROWS_PER_COLUMN * ROW_STRIDE - 2
 
 const CANVAS_WIDTH = GRID_COLS * CELL + PAD * 2
 const CANVAS_HEIGHT = GRID_ROWS * CELL + PAD * 2
 const PANEL_HEIGHT = PANEL_WIDTH * (CANVAS_HEIGHT / CANVAS_WIDTH)
 
 const SPEC: MatrixSpec = { cell: CELL, pad: PAD }
+
+const HEADER = "TOP 10"
 
 export const LedLeaderboard = () => {
   const isBasketball = useNavigationStore(
@@ -71,15 +74,25 @@ export const LedLeaderboard = () => {
     if (!ctx) return
 
     drawPanel(ctx, CANVAS_WIDTH, CANVAS_HEIGHT, BEZEL, CORNER_RADIUS)
-    drawGhostGrid(ctx, SPEC, GRID_COLS, GRID_ROWS, (_, col) => {
+    drawGhostGrid(ctx, SPEC, GRID_COLS, GRID_ROWS, (row, col) => {
+      if (row < HEADER_ROWS - 2) return AMBER_GHOST
       const colInColumn = col % (COLUMN_COLS + COLUMN_GAP)
       return colInColumn >= NAME_COLS + GAP_COLS ? SCORE_GHOST : AMBER_GHOST
     })
 
+    drawGlyphRow(
+      ctx,
+      SPEC,
+      HEADER,
+      0,
+      AMBER,
+      Math.floor((GRID_COLS - textCols(HEADER)) / 2)
+    )
+
     highScores.slice(0, MAX_ENTRIES).forEach((entry, i) => {
       const column = Math.floor(i / ROWS_PER_COLUMN)
       const columnStart = column * (COLUMN_COLS + COLUMN_GAP)
-      const row = (i % ROWS_PER_COLUMN) * ROW_STRIDE
+      const row = HEADER_ROWS + (i % ROWS_PER_COLUMN) * ROW_STRIDE
       const name = entry.player_name.toUpperCase().slice(0, 3)
       const score = String(Math.max(0, Math.min(Math.floor(entry.score), 999)))
       drawGlyphRow(ctx, SPEC, name, row, AMBER, columnStart)

--- a/src/components/basketball/led-leaderboard.tsx
+++ b/src/components/basketball/led-leaderboard.tsx
@@ -84,7 +84,7 @@ export const LedLeaderboard = () => {
       CANVAS_HEIGHT,
       BEZEL,
       CORNER_RADIUS,
-      "rgba(3, 3, 4, 1)"
+      "rgba(1, 1, 2, 1)"
     )
     // Continue the dot lattice through the margin so the screen reaches the
     // bezel with no dead black band; clip keeps dots inside the rounded face

--- a/src/components/basketball/led-leaderboard.tsx
+++ b/src/components/basketball/led-leaderboard.tsx
@@ -75,21 +75,43 @@ export const LedLeaderboard = () => {
   useEffect(() => {
     if (!ctx) return
 
-    // Near-opaque face: the animated white lamp doodle sits right behind
-    // this wall band and would glow through the default translucent panel
+    // Opaque near-black face (darker than the shared default to offset the
+    // LED_GLOW multiplier): the animated white lamp doodle sits right behind
+    // this wall band and would glow through a translucent panel
     drawPanel(
       ctx,
       CANVAS_WIDTH,
       CANVAS_HEIGHT,
       BEZEL,
       CORNER_RADIUS,
-      "rgba(10, 10, 12, 1)"
+      "rgba(3, 3, 4, 1)"
     )
-    drawGhostGrid(ctx, SPEC, GRID_COLS, GRID_ROWS, (row, col) => {
-      if (row < HEADER_ROWS - 2) return AMBER_GHOST
-      const colInColumn = col % (COLUMN_COLS + COLUMN_GAP)
-      return colInColumn >= NAME_COLS + GAP_COLS ? SCORE_GHOST : AMBER_GHOST
-    })
+    // Continue the dot lattice through the margin so the screen reaches the
+    // bezel with no dead black band; clip keeps dots inside the rounded face
+    ctx.save()
+    ctx.beginPath()
+    ctx.roundRect(
+      BEZEL,
+      BEZEL,
+      CANVAS_WIDTH - BEZEL * 2,
+      CANVAS_HEIGHT - BEZEL * 2,
+      CORNER_RADIUS - BEZEL
+    )
+    ctx.clip()
+    drawGhostGrid(
+      ctx,
+      SPEC,
+      GRID_COLS,
+      GRID_ROWS,
+      (row, col) => {
+        if (row < HEADER_ROWS - 2) return AMBER_GHOST
+        if (col < 0 || col >= GRID_COLS) return AMBER_GHOST
+        const colInColumn = col % (COLUMN_COLS + COLUMN_GAP)
+        return colInColumn >= NAME_COLS + GAP_COLS ? SCORE_GHOST : AMBER_GHOST
+      },
+      MARGIN / CELL
+    )
+    ctx.restore()
 
     drawGlyphRow(
       ctx,

--- a/src/components/basketball/led-leaderboard.tsx
+++ b/src/components/basketball/led-leaderboard.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+import { cn } from "@/utils/cn"
+
+import {
+  AMBER,
+  AMBER_GHOST,
+  drawGhostGrid,
+  drawGlyphRow,
+  drawPanel,
+  MatrixSpec,
+  SCORE_COLOR,
+  SCORE_GHOST,
+  textCols
+} from "./led-matrix"
+import { useLeaderboardScores } from "./scoreboard"
+
+const MAX_ENTRIES = 10
+
+const CELL = 8
+const BEZEL = 6
+const MARGIN = 12
+const CORNER_RADIUS = 12
+const PAD = BEZEL + MARGIN
+
+// 3-letter name block (17 cols), 2-col gap, right-aligned 3-digit score block
+const NAME_COLS = 17
+const GAP_COLS = 2
+const SCORE_COLS = 17
+const GRID_COLS = NAME_COLS + GAP_COLS + SCORE_COLS
+const HEADER_ROWS = 9
+const ROW_STRIDE = 9
+const GRID_ROWS = HEADER_ROWS + MAX_ENTRIES * ROW_STRIDE - 2
+
+const CANVAS_WIDTH = GRID_COLS * CELL + PAD * 2
+const CANVAS_HEIGHT = GRID_ROWS * CELL + PAD * 2
+
+const SPEC: MatrixSpec = { cell: CELL, pad: PAD }
+
+const HEADER = "TOP 10"
+
+interface LedLeaderboardProps {
+  className?: string
+}
+
+export const LedLeaderboard = ({ className }: LedLeaderboardProps) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const highScores = useLeaderboardScores()
+
+  useEffect(() => {
+    const ctx = canvasRef.current?.getContext("2d")
+    if (!ctx) return
+
+    drawPanel(ctx, CANVAS_WIDTH, CANVAS_HEIGHT, BEZEL, CORNER_RADIUS)
+    drawGhostGrid(ctx, SPEC, GRID_COLS, GRID_ROWS, (row, col) =>
+      row < HEADER_ROWS - 2 || col < NAME_COLS + GAP_COLS
+        ? AMBER_GHOST
+        : SCORE_GHOST
+    )
+
+    drawGlyphRow(
+      ctx,
+      SPEC,
+      HEADER,
+      0,
+      AMBER,
+      Math.floor((GRID_COLS - textCols(HEADER)) / 2)
+    )
+
+    highScores.slice(0, MAX_ENTRIES).forEach((entry, i) => {
+      const row = HEADER_ROWS + i * ROW_STRIDE
+      const name = entry.player_name.toUpperCase().slice(0, 3)
+      const score = String(Math.max(0, Math.min(Math.floor(entry.score), 999)))
+      drawGlyphRow(ctx, SPEC, name, row, AMBER, 0)
+      drawGlyphRow(
+        ctx,
+        SPEC,
+        score,
+        row,
+        SCORE_COLOR,
+        GRID_COLS - textCols(score)
+      )
+    })
+  }, [highScores])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={CANVAS_WIDTH}
+      height={CANVAS_HEIGHT}
+      className={cn("h-auto select-none", className)}
+      style={{ width: CANVAS_WIDTH / 2 }}
+    />
+  )
+}

--- a/src/components/basketball/led-leaderboard.tsx
+++ b/src/components/basketball/led-leaderboard.tsx
@@ -7,9 +7,9 @@ import { useNavigationStore } from "@/components/navigation-handler/navigation-s
 import {
   AMBER,
   AMBER_GHOST,
-  drawGhostGrid,
   drawGlyphRow,
   drawPanel,
+  drawScreenDotField,
   GLYPHS,
   LED_GLOW,
   MatrixSpec,
@@ -75,8 +75,7 @@ export const LedLeaderboard = () => {
   useEffect(() => {
     if (!ctx) return
 
-    // Opaque near-black face (darker than the shared default to offset the
-    // LED_GLOW multiplier): the animated white lamp doodle sits right behind
+    // Opaque black face: the animated white lamp doodle sits right behind
     // this wall band and would glow through a translucent panel
     drawPanel(
       ctx,
@@ -84,23 +83,15 @@ export const LedLeaderboard = () => {
       CANVAS_HEIGHT,
       BEZEL,
       CORNER_RADIUS,
-      "rgba(1, 1, 2, 1)"
+      "rgba(0, 0, 0, 1)"
     )
-    // Continue the dot lattice through the margin so the screen reaches the
-    // bezel with no dead black band; clip keeps dots inside the rounded face
-    ctx.save()
-    ctx.beginPath()
-    ctx.roundRect(
-      BEZEL,
-      BEZEL,
-      CANVAS_WIDTH - BEZEL * 2,
-      CANVAS_HEIGHT - BEZEL * 2,
-      CORNER_RADIUS - BEZEL
-    )
-    ctx.clip()
-    drawGhostGrid(
+    drawScreenDotField(
       ctx,
       SPEC,
+      CANVAS_WIDTH,
+      CANVAS_HEIGHT,
+      BEZEL,
+      CORNER_RADIUS,
       GRID_COLS,
       GRID_ROWS,
       (row, col) => {
@@ -108,10 +99,8 @@ export const LedLeaderboard = () => {
         if (col < 0 || col >= GRID_COLS) return AMBER_GHOST
         const colInColumn = col % (COLUMN_COLS + COLUMN_GAP)
         return colInColumn >= NAME_COLS + GAP_COLS ? SCORE_GHOST : AMBER_GHOST
-      },
-      MARGIN / CELL
+      }
     )
-    ctx.restore()
 
     drawGlyphRow(
       ctx,

--- a/src/components/basketball/led-leaderboard.tsx
+++ b/src/components/basketball/led-leaderboard.tsx
@@ -1,8 +1,8 @@
-"use client"
+import { useThree } from "@react-three/fiber"
+import { useEffect, useMemo } from "react"
+import { CanvasTexture, SRGBColorSpace } from "three"
 
-import { useEffect, useRef } from "react"
-
-import { cn } from "@/utils/cn"
+import { useNavigationStore } from "@/components/navigation-handler/navigation-store"
 
 import {
   AMBER,
@@ -19,10 +19,17 @@ import { useLeaderboardScores } from "./scoreboard"
 
 const MAX_ENTRIES = 10
 
-const CELL = 8
-const BEZEL = 6
-const MARGIN = 12
-const CORNER_RADIUS = 12
+// Hangs from the mezzanine railing to the right of the hoop
+const PANEL_POSITION: [number, number, number] = [7.05, 3.52, -14.412]
+const PANEL_HEIGHT = 1.45
+const ROD_HEIGHT = 0.22
+const ROD_RADIUS = 0.008
+const ROD_INSET = 0.09
+
+const CELL = 16
+const BEZEL = 12
+const MARGIN = 24
+const CORNER_RADIUS = 24
 const PAD = BEZEL + MARGIN
 
 // 3-letter name block (17 cols), 2-col gap, right-aligned 3-digit score block
@@ -36,21 +43,30 @@ const GRID_ROWS = HEADER_ROWS + MAX_ENTRIES * ROW_STRIDE - 2
 
 const CANVAS_WIDTH = GRID_COLS * CELL + PAD * 2
 const CANVAS_HEIGHT = GRID_ROWS * CELL + PAD * 2
+const PANEL_WIDTH = PANEL_HEIGHT * (CANVAS_WIDTH / CANVAS_HEIGHT)
 
 const SPEC: MatrixSpec = { cell: CELL, pad: PAD }
 
 const HEADER = "TOP 10"
 
-interface LedLeaderboardProps {
-  className?: string
-}
-
-export const LedLeaderboard = ({ className }: LedLeaderboardProps) => {
-  const canvasRef = useRef<HTMLCanvasElement>(null)
+export const LedLeaderboard = () => {
+  const isBasketball = useNavigationStore(
+    (state) => state.currentScene?.name === "basketball"
+  )
+  const invalidate = useThree((state) => state.invalidate)
   const highScores = useLeaderboardScores()
 
+  const { ctx, texture } = useMemo(() => {
+    const canvas = document.createElement("canvas")
+    canvas.width = CANVAS_WIDTH
+    canvas.height = CANVAS_HEIGHT
+    const texture = new CanvasTexture(canvas)
+    texture.colorSpace = SRGBColorSpace
+    texture.anisotropy = 16
+    return { ctx: canvas.getContext("2d"), texture }
+  }, [])
+
   useEffect(() => {
-    const ctx = canvasRef.current?.getContext("2d")
     if (!ctx) return
 
     drawPanel(ctx, CANVAS_WIDTH, CANVAS_HEIGHT, BEZEL, CORNER_RADIUS)
@@ -83,15 +99,34 @@ export const LedLeaderboard = ({ className }: LedLeaderboardProps) => {
         GRID_COLS - textCols(score)
       )
     })
-  }, [highScores])
+
+    texture.needsUpdate = true
+    invalidate()
+  }, [ctx, texture, highScores, invalidate])
+
+  useEffect(() => () => texture.dispose(), [texture])
+
+  if (!isBasketball) return null
 
   return (
-    <canvas
-      ref={canvasRef}
-      width={CANVAS_WIDTH}
-      height={CANVAS_HEIGHT}
-      className={cn("h-auto select-none", className)}
-      style={{ width: CANVAS_WIDTH / 2 }}
-    />
+    <group position={PANEL_POSITION}>
+      <mesh>
+        <planeGeometry args={[PANEL_WIDTH, PANEL_HEIGHT]} />
+        <meshBasicMaterial map={texture} transparent />
+      </mesh>
+      {[-1, 1].map((side) => (
+        <mesh
+          key={side}
+          position={[
+            side * (PANEL_WIDTH / 2 - ROD_INSET),
+            PANEL_HEIGHT / 2 + ROD_HEIGHT / 2,
+            0
+          ]}
+        >
+          <cylinderGeometry args={[ROD_RADIUS, ROD_RADIUS, ROD_HEIGHT, 6]} />
+          <meshBasicMaterial color="#ffffff" />
+        </mesh>
+      ))}
+    </group>
   )
 }

--- a/src/components/basketball/led-leaderboard.tsx
+++ b/src/components/basketball/led-leaderboard.tsx
@@ -17,21 +17,21 @@ import {
 } from "./led-matrix"
 import { useLeaderboardScores } from "./scoreboard"
 
-const MAX_ENTRIES = 10
+const MAX_ENTRIES = 12
 
 // Wide three-column board on the wall band above the neon basement sign
 // (SM_LogoBasement sits at [8.44, 2.6, -14.6]; the panel floats just proud
 // of that wall)
-const PANEL_POSITION: [number, number, number] = [8.3, 3.33, -14.35]
+const PANEL_POSITION: [number, number, number] = [8.3, 3.45, -14.35]
 const PANEL_WIDTH = 2.2
 
 const CELL = 16
 const BEZEL = 12
-const MARGIN = 24
+const MARGIN = 44
 const CORNER_RADIUS = 24
 const PAD = BEZEL + MARGIN
 
-// Three columns of four entry slots (10 filled); each column is a 3-letter
+// Three columns of four entry slots; each column is a 3-letter
 // name block (17 cols), 2-col gap, right-aligned 3-digit score block
 const NAME_COLS = 17
 const GAP_COLS = 2
@@ -51,7 +51,7 @@ const PANEL_HEIGHT = PANEL_WIDTH * (CANVAS_HEIGHT / CANVAS_WIDTH)
 
 const SPEC: MatrixSpec = { cell: CELL, pad: PAD }
 
-const HEADER = "TOP 10"
+const HEADER = "HIGH SCORES"
 
 export const LedLeaderboard = () => {
   const isBasketball = useNavigationStore(

--- a/src/components/basketball/led-matrix.ts
+++ b/src/components/basketball/led-matrix.ts
@@ -1,5 +1,12 @@
 // Shared 5x7 dot-matrix drawing helpers for the LED scoreboard and
 // leaderboard panels.
+import { Color } from "three"
+
+// Over-bright material multiplier: pushes lit dots and the bezel past the
+// postprocessing bloom luminance threshold so panels glow like the neon
+// basement sign, whose GLB material is white emissive with
+// KHR_materials_emissive_strength 10
+export const LED_GLOW = new Color(10, 10, 10)
 
 // prettier-ignore
 export const GLYPHS: Record<string, string[]> = {
@@ -14,6 +21,7 @@ export const GLYPHS: Record<string, string[]> = {
   "8": ["01110", "10001", "10001", "01110", "10001", "10001", "01110"],
   "9": ["01110", "10001", "10001", "01111", "00001", "00010", "01100"],
   ":": ["000", "010", "000", "000", "000", "010", "000"],
+  "-": ["000", "000", "000", "111", "000", "000", "000"],
   " ": ["00", "00", "00", "00", "00", "00", "00"],
   A: ["01110", "10001", "10001", "11111", "10001", "10001", "10001"],
   B: ["11110", "10001", "10001", "11110", "10001", "10001", "11110"],
@@ -119,7 +127,8 @@ export const drawPanel = (
   width: number,
   height: number,
   bezel: number,
-  cornerRadius: number
+  cornerRadius: number,
+  background: string = PANEL_BACKGROUND
 ) => {
   const innerRect = [
     bezel,
@@ -141,7 +150,7 @@ export const drawPanel = (
   ctx.fill()
   ctx.globalCompositeOperation = "source-over"
 
-  ctx.fillStyle = PANEL_BACKGROUND
+  ctx.fillStyle = background
   ctx.beginPath()
   ctx.roundRect(...innerRect, innerRadius)
   ctx.fill()

--- a/src/components/basketball/led-matrix.ts
+++ b/src/components/basketball/led-matrix.ts
@@ -1,0 +1,163 @@
+// Shared 5x7 dot-matrix drawing helpers for the LED scoreboard and
+// leaderboard panels.
+
+// prettier-ignore
+export const GLYPHS: Record<string, string[]> = {
+  "0": ["01110", "10001", "10011", "10101", "11001", "10001", "01110"],
+  "1": ["00100", "01100", "00100", "00100", "00100", "00100", "01110"],
+  "2": ["01110", "10001", "00001", "00010", "00100", "01000", "11111"],
+  "3": ["11111", "00010", "00100", "00010", "00001", "10001", "01110"],
+  "4": ["00010", "00110", "01010", "10010", "11111", "00010", "00010"],
+  "5": ["11111", "10000", "11110", "00001", "00001", "10001", "01110"],
+  "6": ["00110", "01000", "10000", "11110", "10001", "10001", "01110"],
+  "7": ["11111", "00001", "00010", "00100", "01000", "01000", "01000"],
+  "8": ["01110", "10001", "10001", "01110", "10001", "10001", "01110"],
+  "9": ["01110", "10001", "10001", "01111", "00001", "00010", "01100"],
+  ":": ["000", "010", "000", "000", "000", "010", "000"],
+  " ": ["00", "00", "00", "00", "00", "00", "00"],
+  A: ["01110", "10001", "10001", "11111", "10001", "10001", "10001"],
+  B: ["11110", "10001", "10001", "11110", "10001", "10001", "11110"],
+  C: ["01110", "10001", "10000", "10000", "10000", "10001", "01110"],
+  D: ["11100", "10010", "10001", "10001", "10001", "10010", "11100"],
+  E: ["11111", "10000", "10000", "11110", "10000", "10000", "11111"],
+  F: ["11111", "10000", "10000", "11110", "10000", "10000", "10000"],
+  G: ["01110", "10001", "10000", "10111", "10001", "10001", "01111"],
+  H: ["10001", "10001", "10001", "11111", "10001", "10001", "10001"],
+  I: ["01110", "00100", "00100", "00100", "00100", "00100", "01110"],
+  J: ["00111", "00010", "00010", "00010", "00010", "10010", "01100"],
+  K: ["10001", "10010", "10100", "11000", "10100", "10010", "10001"],
+  L: ["10000", "10000", "10000", "10000", "10000", "10000", "11111"],
+  M: ["10001", "11011", "10101", "10101", "10001", "10001", "10001"],
+  N: ["10001", "10001", "11001", "10101", "10011", "10001", "10001"],
+  O: ["01110", "10001", "10001", "10001", "10001", "10001", "01110"],
+  P: ["11110", "10001", "10001", "11110", "10000", "10000", "10000"],
+  Q: ["01110", "10001", "10001", "10001", "10101", "10010", "01101"],
+  R: ["11110", "10001", "10001", "11110", "10100", "10010", "10001"],
+  S: ["01111", "10000", "10000", "01110", "00001", "00001", "11110"],
+  T: ["11111", "00100", "00100", "00100", "00100", "00100", "00100"],
+  U: ["10001", "10001", "10001", "10001", "10001", "10001", "01110"],
+  V: ["10001", "10001", "10001", "10001", "10001", "01010", "00100"],
+  W: ["10001", "10001", "10001", "10101", "10101", "10101", "01010"],
+  X: ["10001", "10001", "01010", "00100", "01010", "10001", "10001"],
+  Y: ["10001", "10001", "01010", "00100", "00100", "00100", "00100"],
+  Z: ["11111", "00001", "00010", "00100", "01000", "10000", "11111"]
+}
+
+export const GLYPH_GAP = 1
+export const GLYPH_ROWS = 7
+
+export const AMBER = "#ffb020"
+export const AMBER_GHOST = "#241804"
+export const SCORE_COLOR = "#ff4d00"
+export const SCORE_GHOST = "#261000"
+export const PANEL_BACKGROUND = "rgba(10, 10, 12, 0.6)"
+export const BEZEL_COLOR = "#ffffff"
+
+/** Pixel geometry of a dot-matrix panel: dot cell size and inner padding. */
+export interface MatrixSpec {
+  cell: number
+  pad: number
+}
+
+export const textCols = (text: string) => {
+  const glyphs = [...text].map((char) => GLYPHS[char]).filter(Boolean)
+  return (
+    glyphs.reduce((cols, glyph) => cols + glyph[0].length, 0) +
+    (glyphs.length - 1) * GLYPH_GAP
+  )
+}
+
+export const drawDot = (
+  ctx: CanvasRenderingContext2D,
+  spec: MatrixSpec,
+  col: number,
+  row: number,
+  radius: number,
+  color: string,
+  alpha = 1
+) => {
+  ctx.globalAlpha = alpha
+  ctx.fillStyle = color
+  ctx.beginPath()
+  ctx.arc(
+    spec.pad + (col + 0.5) * spec.cell,
+    spec.pad + (row + 0.5) * spec.cell,
+    radius,
+    0,
+    Math.PI * 2
+  )
+  ctx.fill()
+  ctx.globalAlpha = 1
+}
+
+export const drawGlyphRow = (
+  ctx: CanvasRenderingContext2D,
+  spec: MatrixSpec,
+  text: string,
+  gridRow: number,
+  color: string,
+  startCol: number
+) => {
+  const glyphs = [...text].map((char) => GLYPHS[char]).filter(Boolean)
+
+  let col = startCol
+
+  for (const glyph of glyphs) {
+    glyph.forEach((bits, row) => {
+      for (let i = 0; i < bits.length; i++) {
+        if (bits[i] !== "1") continue
+        drawDot(ctx, spec, col + i, gridRow + row, spec.cell * 0.38, color)
+      }
+    })
+    col += glyph[0].length + GLYPH_GAP
+  }
+}
+
+/** White rounded bezel with a translucent dark inner face. */
+export const drawPanel = (
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  bezel: number,
+  cornerRadius: number
+) => {
+  const innerRect = [
+    bezel,
+    bezel,
+    width - bezel * 2,
+    height - bezel * 2
+  ] as const
+  const innerRadius = cornerRadius - bezel
+
+  ctx.clearRect(0, 0, width, height)
+  ctx.fillStyle = BEZEL_COLOR
+  ctx.beginPath()
+  ctx.roundRect(0, 0, width, height, cornerRadius)
+  ctx.fill()
+
+  ctx.globalCompositeOperation = "destination-out"
+  ctx.beginPath()
+  ctx.roundRect(...innerRect, innerRadius)
+  ctx.fill()
+  ctx.globalCompositeOperation = "source-over"
+
+  ctx.fillStyle = PANEL_BACKGROUND
+  ctx.beginPath()
+  ctx.roundRect(...innerRect, innerRadius)
+  ctx.fill()
+}
+
+/** Unlit-dot grid; color decided per cell so regions can differ. */
+export const drawGhostGrid = (
+  ctx: CanvasRenderingContext2D,
+  spec: MatrixSpec,
+  cols: number,
+  rows: number,
+  colorFor: (row: number, col: number) => string
+) => {
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      drawDot(ctx, spec, col, row, spec.cell * 0.32, colorFor(row, col))
+    }
+  }
+}

--- a/src/components/basketball/led-matrix.ts
+++ b/src/components/basketball/led-matrix.ts
@@ -156,16 +156,21 @@ export const drawPanel = (
   ctx.fill()
 }
 
-/** Unlit-dot grid; color decided per cell so regions can differ. */
+/**
+ * Unlit-dot grid; color decided per cell so regions can differ. `extend`
+ * continues the lattice that many cells beyond the content grid (clip the
+ * canvas to the panel face first so dots stop at the bezel).
+ */
 export const drawGhostGrid = (
   ctx: CanvasRenderingContext2D,
   spec: MatrixSpec,
   cols: number,
   rows: number,
-  colorFor: (row: number, col: number) => string
+  colorFor: (row: number, col: number) => string,
+  extend = 0
 ) => {
-  for (let row = 0; row < rows; row++) {
-    for (let col = 0; col < cols; col++) {
+  for (let row = -extend; row < rows + extend; row++) {
+    for (let col = -extend; col < cols + extend; col++) {
       drawDot(ctx, spec, col, row, spec.cell * 0.32, colorFor(row, col))
     }
   }

--- a/src/components/basketball/led-matrix.ts
+++ b/src/components/basketball/led-matrix.ts
@@ -157,21 +157,37 @@ export const drawPanel = (
 }
 
 /**
- * Unlit-dot grid; color decided per cell so regions can differ. `extend`
- * continues the lattice that many cells beyond the content grid (clip the
- * canvas to the panel face first so dots stop at the bezel).
+ * Unlit-dot field covering the whole panel face: the lattice extends past
+ * the content grid through the padding right up to the bezel (clipped to
+ * the rounded face), so there is no dead band between screen and frame.
+ * Color decided per cell so regions can differ.
  */
-export const drawGhostGrid = (
+export const drawScreenDotField = (
   ctx: CanvasRenderingContext2D,
   spec: MatrixSpec,
+  width: number,
+  height: number,
+  bezel: number,
+  cornerRadius: number,
   cols: number,
   rows: number,
-  colorFor: (row: number, col: number) => string,
-  extend = 0
+  colorFor: (row: number, col: number) => string
 ) => {
+  const extend = Math.ceil(spec.pad / spec.cell)
+  ctx.save()
+  ctx.beginPath()
+  ctx.roundRect(
+    bezel,
+    bezel,
+    width - bezel * 2,
+    height - bezel * 2,
+    cornerRadius - bezel
+  )
+  ctx.clip()
   for (let row = -extend; row < rows + extend; row++) {
     for (let col = -extend; col < cols + extend; col++) {
       drawDot(ctx, spec, col, row, spec.cell * 0.32, colorFor(row, col))
     }
   }
+  ctx.restore()
 }

--- a/src/components/basketball/led-scoreboard.tsx
+++ b/src/components/basketball/led-scoreboard.tsx
@@ -1,0 +1,192 @@
+import { useThree } from "@react-three/fiber"
+import { useEffect, useMemo } from "react"
+import { CanvasTexture, SRGBColorSpace } from "three"
+
+import { useNavigationStore } from "@/components/navigation-handler/navigation-store"
+import { useMinigameStore } from "@/store/minigame-store"
+
+const BOARD_POSITION: [number, number, number] = [5.198, 4.46, -14.414]
+const FACE_SIZE: [number, number] = [0.693, 0.52]
+
+const CELL = 32
+const MARGIN = 88
+const BEZEL = 24
+const CORNER_RADIUS = 48
+const GRID_COLS = 25
+const GRID_ROWS = 17
+const CLOCK_ROW = 0
+const SCORE_ROW = 10
+const GLYPH_GAP = 1
+const PAD = BEZEL + MARGIN
+const CANVAS_WIDTH = GRID_COLS * CELL + PAD * 2
+const CANVAS_HEIGHT = GRID_ROWS * CELL + PAD * 2
+
+const BACKGROUND = "rgba(10, 10, 12, 0.6)"
+const BEZEL_COLOR = "#ffffff"
+const AMBER = "#ffb020"
+const AMBER_GHOST = "#241804"
+const SCORE_COLOR = "#ff4d00"
+const SCORE_GHOST = "#261000"
+
+// prettier-ignore
+const GLYPHS: Record<string, string[]> = {
+  "0": ["01110", "10001", "10011", "10101", "11001", "10001", "01110"],
+  "1": ["00100", "01100", "00100", "00100", "00100", "00100", "01110"],
+  "2": ["01110", "10001", "00001", "00010", "00100", "01000", "11111"],
+  "3": ["11111", "00010", "00100", "00010", "00001", "10001", "01110"],
+  "4": ["00010", "00110", "01010", "10010", "11111", "00010", "00010"],
+  "5": ["11111", "10000", "11110", "00001", "00001", "10001", "01110"],
+  "6": ["00110", "01000", "10000", "11110", "10001", "10001", "01110"],
+  "7": ["11111", "00001", "00010", "00100", "01000", "01000", "01000"],
+  "8": ["01110", "10001", "10001", "01110", "10001", "10001", "01110"],
+  "9": ["01110", "10001", "10001", "01111", "00001", "00010", "01100"],
+  ":": ["000", "010", "000", "000", "000", "010", "000"]
+}
+
+const formatClock = (t: number) => {
+  const s = Math.max(0, Math.floor(t))
+  return `${Math.floor(s / 60)}:${(s % 60).toString().padStart(2, "0")}`
+}
+
+const drawDot = (
+  ctx: CanvasRenderingContext2D,
+  col: number,
+  row: number,
+  radius: number,
+  color: string,
+  alpha = 1
+) => {
+  ctx.globalAlpha = alpha
+  ctx.fillStyle = color
+  ctx.beginPath()
+  ctx.arc(
+    PAD + (col + 0.5) * CELL,
+    PAD + (row + 0.5) * CELL,
+    radius,
+    0,
+    Math.PI * 2
+  )
+  ctx.fill()
+  ctx.globalAlpha = 1
+}
+
+const textCols = (text: string) => {
+  const glyphs = [...text].map((char) => GLYPHS[char]).filter(Boolean)
+  return (
+    glyphs.reduce((cols, glyph) => cols + glyph[0].length, 0) +
+    (glyphs.length - 1) * GLYPH_GAP
+  )
+}
+
+const drawGlyphRow = (
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  gridRow: number,
+  color: string,
+  startCol: number
+) => {
+  const glyphs = [...text].map((char) => GLYPHS[char]).filter(Boolean)
+
+  let col = startCol
+
+  for (const glyph of glyphs) {
+    glyph.forEach((bits, row) => {
+      for (let i = 0; i < bits.length; i++) {
+        if (bits[i] !== "1") continue
+        drawDot(ctx, col + i, gridRow + row, CELL * 0.38, color)
+      }
+    })
+    col += glyph[0].length + GLYPH_GAP
+  }
+}
+
+const drawBoard = (
+  ctx: CanvasRenderingContext2D,
+  clockText: string,
+  scoreText: string
+) => {
+  const innerRect = [
+    BEZEL,
+    BEZEL,
+    CANVAS_WIDTH - BEZEL * 2,
+    CANVAS_HEIGHT - BEZEL * 2
+  ] as const
+  const innerRadius = CORNER_RADIUS - BEZEL
+
+  ctx.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT)
+  ctx.fillStyle = BEZEL_COLOR
+  ctx.beginPath()
+  ctx.roundRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT, CORNER_RADIUS)
+  ctx.fill()
+
+  ctx.globalCompositeOperation = "destination-out"
+  ctx.beginPath()
+  ctx.roundRect(...innerRect, innerRadius)
+  ctx.fill()
+  ctx.globalCompositeOperation = "source-over"
+
+  ctx.fillStyle = BACKGROUND
+  ctx.beginPath()
+  ctx.roundRect(...innerRect, innerRadius)
+  ctx.fill()
+
+  for (let row = 0; row < GRID_ROWS; row++) {
+    const ghost = row < SCORE_ROW - 1 ? AMBER_GHOST : SCORE_GHOST
+    for (let col = 0; col < GRID_COLS; col++) {
+      drawDot(ctx, col, row, CELL * 0.32, ghost)
+    }
+  }
+
+  const clockStart = Math.floor((GRID_COLS - textCols(clockText)) / 2)
+  const clockEnd = clockStart + textCols(clockText)
+
+  drawGlyphRow(ctx, clockText, CLOCK_ROW, AMBER, clockStart)
+  drawGlyphRow(
+    ctx,
+    scoreText,
+    SCORE_ROW,
+    SCORE_COLOR,
+    clockEnd - textCols(scoreText)
+  )
+}
+
+export const LedScoreboard = () => {
+  const isBasketball = useNavigationStore(
+    (state) => state.currentScene?.name === "basketball"
+  )
+  const invalidate = useThree((state) => state.invalidate)
+  const clockText = useMinigameStore((state) =>
+    formatClock(state.timeRemaining)
+  )
+  const scoreText = useMinigameStore((state) =>
+    String(Math.min(Math.floor(state.score), 999))
+  )
+
+  const { ctx, texture } = useMemo(() => {
+    const canvas = document.createElement("canvas")
+    canvas.width = CANVAS_WIDTH
+    canvas.height = CANVAS_HEIGHT
+    const texture = new CanvasTexture(canvas)
+    texture.colorSpace = SRGBColorSpace
+    texture.anisotropy = 16
+    return { ctx: canvas.getContext("2d"), texture }
+  }, [])
+
+  useEffect(() => {
+    if (!ctx) return
+    drawBoard(ctx, clockText, scoreText)
+    texture.needsUpdate = true
+    invalidate()
+  }, [ctx, texture, clockText, scoreText, invalidate])
+
+  useEffect(() => () => texture.dispose(), [texture])
+
+  if (!isBasketball) return null
+
+  return (
+    <mesh position={BOARD_POSITION}>
+      <planeGeometry args={FACE_SIZE} />
+      <meshBasicMaterial map={texture} transparent />
+    </mesh>
+  )
+}

--- a/src/components/basketball/led-scoreboard.tsx
+++ b/src/components/basketball/led-scoreboard.tsx
@@ -5,6 +5,18 @@ import { CanvasTexture, SRGBColorSpace } from "three"
 import { useNavigationStore } from "@/components/navigation-handler/navigation-store"
 import { useMinigameStore } from "@/store/minigame-store"
 
+import {
+  AMBER,
+  AMBER_GHOST,
+  drawGhostGrid,
+  drawGlyphRow,
+  drawPanel,
+  MatrixSpec,
+  SCORE_COLOR,
+  SCORE_GHOST,
+  textCols
+} from "./led-matrix"
+
 const BOARD_POSITION: [number, number, number] = [5.198, 4.46, -14.414]
 const FACE_SIZE: [number, number] = [0.693, 0.52]
 
@@ -16,88 +28,15 @@ const GRID_COLS = 25
 const GRID_ROWS = 17
 const CLOCK_ROW = 0
 const SCORE_ROW = 10
-const GLYPH_GAP = 1
 const PAD = BEZEL + MARGIN
 const CANVAS_WIDTH = GRID_COLS * CELL + PAD * 2
 const CANVAS_HEIGHT = GRID_ROWS * CELL + PAD * 2
 
-const BACKGROUND = "rgba(10, 10, 12, 0.6)"
-const BEZEL_COLOR = "#ffffff"
-const AMBER = "#ffb020"
-const AMBER_GHOST = "#241804"
-const SCORE_COLOR = "#ff4d00"
-const SCORE_GHOST = "#261000"
-
-// prettier-ignore
-const GLYPHS: Record<string, string[]> = {
-  "0": ["01110", "10001", "10011", "10101", "11001", "10001", "01110"],
-  "1": ["00100", "01100", "00100", "00100", "00100", "00100", "01110"],
-  "2": ["01110", "10001", "00001", "00010", "00100", "01000", "11111"],
-  "3": ["11111", "00010", "00100", "00010", "00001", "10001", "01110"],
-  "4": ["00010", "00110", "01010", "10010", "11111", "00010", "00010"],
-  "5": ["11111", "10000", "11110", "00001", "00001", "10001", "01110"],
-  "6": ["00110", "01000", "10000", "11110", "10001", "10001", "01110"],
-  "7": ["11111", "00001", "00010", "00100", "01000", "01000", "01000"],
-  "8": ["01110", "10001", "10001", "01110", "10001", "10001", "01110"],
-  "9": ["01110", "10001", "10001", "01111", "00001", "00010", "01100"],
-  ":": ["000", "010", "000", "000", "000", "010", "000"]
-}
+const SPEC: MatrixSpec = { cell: CELL, pad: PAD }
 
 const formatClock = (t: number) => {
   const s = Math.max(0, Math.floor(t))
   return `${Math.floor(s / 60)}:${(s % 60).toString().padStart(2, "0")}`
-}
-
-const drawDot = (
-  ctx: CanvasRenderingContext2D,
-  col: number,
-  row: number,
-  radius: number,
-  color: string,
-  alpha = 1
-) => {
-  ctx.globalAlpha = alpha
-  ctx.fillStyle = color
-  ctx.beginPath()
-  ctx.arc(
-    PAD + (col + 0.5) * CELL,
-    PAD + (row + 0.5) * CELL,
-    radius,
-    0,
-    Math.PI * 2
-  )
-  ctx.fill()
-  ctx.globalAlpha = 1
-}
-
-const textCols = (text: string) => {
-  const glyphs = [...text].map((char) => GLYPHS[char]).filter(Boolean)
-  return (
-    glyphs.reduce((cols, glyph) => cols + glyph[0].length, 0) +
-    (glyphs.length - 1) * GLYPH_GAP
-  )
-}
-
-const drawGlyphRow = (
-  ctx: CanvasRenderingContext2D,
-  text: string,
-  gridRow: number,
-  color: string,
-  startCol: number
-) => {
-  const glyphs = [...text].map((char) => GLYPHS[char]).filter(Boolean)
-
-  let col = startCol
-
-  for (const glyph of glyphs) {
-    glyph.forEach((bits, row) => {
-      for (let i = 0; i < bits.length; i++) {
-        if (bits[i] !== "1") continue
-        drawDot(ctx, col + i, gridRow + row, CELL * 0.38, color)
-      }
-    })
-    col += glyph[0].length + GLYPH_GAP
-  }
 }
 
 const drawBoard = (
@@ -105,44 +44,19 @@ const drawBoard = (
   clockText: string,
   scoreText: string
 ) => {
-  const innerRect = [
-    BEZEL,
-    BEZEL,
-    CANVAS_WIDTH - BEZEL * 2,
-    CANVAS_HEIGHT - BEZEL * 2
-  ] as const
-  const innerRadius = CORNER_RADIUS - BEZEL
+  drawPanel(ctx, CANVAS_WIDTH, CANVAS_HEIGHT, BEZEL, CORNER_RADIUS)
 
-  ctx.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT)
-  ctx.fillStyle = BEZEL_COLOR
-  ctx.beginPath()
-  ctx.roundRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT, CORNER_RADIUS)
-  ctx.fill()
-
-  ctx.globalCompositeOperation = "destination-out"
-  ctx.beginPath()
-  ctx.roundRect(...innerRect, innerRadius)
-  ctx.fill()
-  ctx.globalCompositeOperation = "source-over"
-
-  ctx.fillStyle = BACKGROUND
-  ctx.beginPath()
-  ctx.roundRect(...innerRect, innerRadius)
-  ctx.fill()
-
-  for (let row = 0; row < GRID_ROWS; row++) {
-    const ghost = row < SCORE_ROW - 1 ? AMBER_GHOST : SCORE_GHOST
-    for (let col = 0; col < GRID_COLS; col++) {
-      drawDot(ctx, col, row, CELL * 0.32, ghost)
-    }
-  }
+  drawGhostGrid(ctx, SPEC, GRID_COLS, GRID_ROWS, (row) =>
+    row < SCORE_ROW - 1 ? AMBER_GHOST : SCORE_GHOST
+  )
 
   const clockStart = Math.floor((GRID_COLS - textCols(clockText)) / 2)
   const clockEnd = clockStart + textCols(clockText)
 
-  drawGlyphRow(ctx, clockText, CLOCK_ROW, AMBER, clockStart)
+  drawGlyphRow(ctx, SPEC, clockText, CLOCK_ROW, AMBER, clockStart)
   drawGlyphRow(
     ctx,
+    SPEC,
     scoreText,
     SCORE_ROW,
     SCORE_COLOR,

--- a/src/components/basketball/led-scoreboard.tsx
+++ b/src/components/basketball/led-scoreboard.tsx
@@ -11,6 +11,7 @@ import {
   drawGhostGrid,
   drawGlyphRow,
   drawPanel,
+  LED_GLOW,
   MatrixSpec,
   SCORE_COLOR,
   SCORE_GHOST,
@@ -100,7 +101,7 @@ export const LedScoreboard = () => {
   return (
     <mesh position={BOARD_POSITION}>
       <planeGeometry args={FACE_SIZE} />
-      <meshBasicMaterial map={texture} transparent />
+      <meshBasicMaterial map={texture} transparent color={LED_GLOW} />
     </mesh>
   )
 }

--- a/src/components/basketball/led-scoreboard.tsx
+++ b/src/components/basketball/led-scoreboard.tsx
@@ -8,9 +8,9 @@ import { useMinigameStore } from "@/store/minigame-store"
 import {
   AMBER,
   AMBER_GHOST,
-  drawGhostGrid,
   drawGlyphRow,
   drawPanel,
+  drawScreenDotField,
   LED_GLOW,
   MatrixSpec,
   SCORE_COLOR,
@@ -45,10 +45,27 @@ const drawBoard = (
   clockText: string,
   scoreText: string
 ) => {
-  drawPanel(ctx, CANVAS_WIDTH, CANVAS_HEIGHT, BEZEL, CORNER_RADIUS)
+  // Near-black face, mostly opaque so the timer stays legible against the
+  // bright hallway behind it (the LED_GLOW multiplier lifts whatever shows)
+  drawPanel(
+    ctx,
+    CANVAS_WIDTH,
+    CANVAS_HEIGHT,
+    BEZEL,
+    CORNER_RADIUS,
+    "rgba(2, 2, 3, 0.85)"
+  )
 
-  drawGhostGrid(ctx, SPEC, GRID_COLS, GRID_ROWS, (row) =>
-    row < SCORE_ROW - 1 ? AMBER_GHOST : SCORE_GHOST
+  drawScreenDotField(
+    ctx,
+    SPEC,
+    CANVAS_WIDTH,
+    CANVAS_HEIGHT,
+    BEZEL,
+    CORNER_RADIUS,
+    GRID_COLS,
+    GRID_ROWS,
+    (row) => (row < SCORE_ROW - 1 ? AMBER_GHOST : SCORE_GHOST)
   )
 
   const clockStart = Math.floor((GRID_COLS - textCols(clockText)) / 2)

--- a/src/components/basketball/scoreboard.tsx
+++ b/src/components/basketball/scoreboard.tsx
@@ -6,24 +6,15 @@ import { onScoreUpdate } from "@/service/supabase/client"
 import { useMinigameStore } from "@/store/minigame-store"
 import { cn } from "@/utils/cn"
 
-interface Score {
+export interface Score {
   player_name: string
   score: number
   created_at: string
   country: string
 }
 
-interface ScoreboardProps {
-  className?: string
-  initialScores?: Score[]
-  isMobile?: boolean
-}
-
-export const Scoreboard = ({
-  className,
-  initialScores = [],
-  isMobile
-}: ScoreboardProps) => {
+/** Leaderboard entries, refetched on score submissions and game end. */
+export const useLeaderboardScores = (initialScores: Score[] = []) => {
   const isGameActive = useMinigameStore((s) => s.isGameActive)
   const hasPlayed = useMinigameStore((s) => s.hasPlayed)
   const [highScores, setHighScores] = useState<Score[]>(initialScores)
@@ -61,6 +52,22 @@ export const Scoreboard = ({
       fetchScores()
     }
   }, [isGameActive, hasPlayed, fetchScores])
+
+  return highScores
+}
+
+interface ScoreboardProps {
+  className?: string
+  initialScores?: Score[]
+  isMobile?: boolean
+}
+
+export const Scoreboard = ({
+  className,
+  initialScores = [],
+  isMobile
+}: ScoreboardProps) => {
+  const highScores = useLeaderboardScores(initialScores)
 
   const mobileScores = highScores.slice(0, 6)
   const topScores = isMobile ? mobileScores : highScores

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -7,6 +7,7 @@ import * as THREE from "three"
 import { ArcadeBoard } from "@/components/arcade-board"
 import { ArcadeScreen } from "@/components/arcade-screen"
 import { useAssets } from "@/components/assets-provider"
+import { LedLeaderboard } from "@/components/basketball/led-leaderboard"
 import { LedScoreboard } from "@/components/basketball/led-scoreboard"
 import { Net } from "@/components/basketball/net"
 import { BlogDoor } from "@/components/blog-door"
@@ -254,6 +255,7 @@ export const Map = memo(() => {
       )}
       <Net />
       <LedScoreboard />
+      <LedLeaderboard />
 
       {/* Routing */}
       {tabs?.map((tab) => {

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -7,6 +7,7 @@ import * as THREE from "three"
 import { ArcadeBoard } from "@/components/arcade-board"
 import { ArcadeScreen } from "@/components/arcade-screen"
 import { useAssets } from "@/components/assets-provider"
+import { LedScoreboard } from "@/components/basketball/led-scoreboard"
 import { Net } from "@/components/basketball/net"
 import { BlogDoor } from "@/components/blog-door"
 import { ChristmasTree } from "@/components/christmas-tree"
@@ -252,6 +253,7 @@ export const Map = memo(() => {
         <primitive object={useMesh.getState().basketball.hoop as Mesh} />
       )}
       <Net />
+      <LedScoreboard />
 
       {/* Routing */}
       {tabs?.map((tab) => {

--- a/src/components/realtime/realtime-impl.tsx
+++ b/src/components/realtime/realtime-impl.tsx
@@ -8,14 +8,9 @@ import { useEffect, useMemo, useRef } from "react"
 import { createClient } from "@/service/supabase/client"
 
 import { censor } from "./censor"
-import { getClientId, useRealtimeStore } from "./realtime-store"
+import { getClientId, REALTIME_ENV, useRealtimeStore } from "./realtime-store"
 
 const CURSOR_BROADCAST_MS = 80
-
-// Scope channel topics by environment so local dev and preview sessions don't
-// mingle with real production visitors in the same rooms. Vercel system env;
-// unset locally.
-const REALTIME_ENV = process.env.NEXT_PUBLIC_VERCEL_ENV ?? "dev"
 
 // Public (non-private) Broadcast/Presence channels: anon key only, no tables
 // or RLS involved. Hardening to private channels + RLS on realtime.messages

--- a/src/components/realtime/realtime-store.ts
+++ b/src/components/realtime/realtime-store.ts
@@ -3,6 +3,11 @@ import { create } from "zustand"
 
 export const REALTIME_ENABLED = process.env.NEXT_PUBLIC_FEATURE_REALTIME === "1"
 
+// Scope channel topics by environment so local dev and preview sessions don't
+// mingle with real production visitors in the same rooms. Vercel system env;
+// unset locally.
+export const REALTIME_ENV = process.env.NEXT_PUBLIC_VERCEL_ENV ?? "dev"
+
 // Per-tab identity: two tabs count as two visitors, which is acceptable here.
 // Kept in sessionStorage so full-document navigations (e.g. the machine-view
 // toggle roundtrip) come back with the same key and color instead of


### PR DESCRIPTION
## What

When someone else is playing /basketball at the same time as you, you now see their basketball as a translucent **ghost ball** arcing through your court in real time (and they see yours) — like ghost cars in a racing game, but live.


## How

Extends the existing Supabase Realtime infra (live cursors / online count) with one new env-scoped channel, `{env}:basketball`, on the same shared WebSocket:

- **`GhostBalls`** (new, mounted inside `HoopMinigame`) samples the local rapier ball per-frame and broadcasts position + rotation quaternion at 10Hz (`lodash.throttle`, cursor-style compact payload `{id, p, q}`).
- **Quota-conscious sending**: nothing is broadcast unless presence shows a second player in the room, and nothing while the ball rests at spawn (one trailing packet, then silence). Solo visitors cost zero realtime messages.
- **Ghost rendering**: fixed pool of 5 plain meshes reusing the ball GLB + a transparent `createGlobalShaderMaterial` variant (`opacity 0.35`, `depthWrite false`). No `RigidBody`, raycast disabled — ghosts can't perturb local physics or steal the drag gesture. Per-frame exponential damping toward the latest network target; first packet snaps.
- **Lifecycle**: presence `leave` frees the ghost instantly; stale timeout (2.5s) hides it when a sender goes quiet (idle ball / tab-out); eviction at 10s frees the pool slot.
- **Untrusted input**: public channel (same POC tradeoff as cursors), so payloads are shape/finite-checked and clamped to a bounding box around the court; ghost count capped at 5.
- `REALTIME_ENV` moved from `realtime-impl` to `realtime-store` so the basketball chunk doesn't drag in `bad-words`.

## Testing

- Two tabs on `localhost:3001/basketball` + a synthetic Node peer on the channel: ghost renders and tracks the arc; browser sends only while its ball is in play; zero `ball` frames when alone in the room (verified via WS frame capture).
- Presence leave removes the ghost; ball at rest goes silent and the ghost fades via the stale path.
- Requires `NEXT_PUBLIC_FEATURE_REALTIME=1` (same gate as cursors), so preview/prod pick it up wherever that's already set.

## Notes

- v2 candidates: score pulse on ghosts (window `basketball-score` event already exists), name/flag labels reusing cursor identity helpers, private channels + RLS.
