### PR TITLE
fix(basketball): single ghost tint on LED boards

### DIFF
--- a/src/components/basketball/led-leaderboard.tsx
+++ b/src/components/basketball/led-leaderboard.tsx
@@ -14,7 +14,6 @@ import {
   LED_GLOW,
   MatrixSpec,
   SCORE_COLOR,
-  SCORE_GHOST,
   textCols
 } from "./led-matrix"
 import { useLeaderboardScores } from "./scoreboard"
@@ -94,12 +93,7 @@ export const LedLeaderboard = () => {
       CORNER_RADIUS,
       GRID_COLS,
       GRID_ROWS,
-      (row, col) => {
-        if (row < HEADER_ROWS - 2) return AMBER_GHOST
-        if (col < 0 || col >= GRID_COLS) return AMBER_GHOST
-        const colInColumn = col % (COLUMN_COLS + COLUMN_GAP)
-        return colInColumn >= NAME_COLS + GAP_COLS ? SCORE_GHOST : AMBER_GHOST
-      }
+      () => AMBER_GHOST
     )
 
     drawGlyphRow(

--- a/src/components/basketball/led-matrix.ts
+++ b/src/components/basketball/led-matrix.ts
@@ -57,7 +57,6 @@ export const GLYPH_ROWS = 7
 export const AMBER = "#ffb020"
 export const AMBER_GHOST = "#241804"
 export const SCORE_COLOR = "#ff4d00"
-export const SCORE_GHOST = "#261000"
 export const PANEL_BACKGROUND = "rgba(10, 10, 12, 0.6)"
 export const BEZEL_COLOR = "#ffffff"
 

--- a/src/components/basketball/led-matrix.ts
+++ b/src/components/basketball/led-matrix.ts
@@ -55,7 +55,7 @@ export const GLYPH_GAP = 1
 export const GLYPH_ROWS = 7
 
 export const AMBER = "#ffb020"
-export const AMBER_GHOST = "#241804"
+export const AMBER_GHOST = "#0b0703"
 export const SCORE_COLOR = "#ff4d00"
 export const PANEL_BACKGROUND = "rgba(10, 10, 12, 0.6)"
 export const BEZEL_COLOR = "#ffffff"

--- a/src/components/basketball/led-scoreboard.tsx
+++ b/src/components/basketball/led-scoreboard.tsx
@@ -14,7 +14,6 @@ import {
   LED_GLOW,
   MatrixSpec,
   SCORE_COLOR,
-  SCORE_GHOST,
   textCols
 } from "./led-matrix"
 
@@ -65,7 +64,7 @@ const drawBoard = (
     CORNER_RADIUS,
     GRID_COLS,
     GRID_ROWS,
-    (row) => (row < SCORE_ROW - 1 ? AMBER_GHOST : SCORE_GHOST)
+    () => AMBER_GHOST
   )
 
   const clockStart = Math.floor((GRID_COLS - textCols(clockText)) / 2)


### PR DESCRIPTION
The LED boards' unlit dot field had two tints — amber for the clock/name zones and a reddish brown for the score zones — with a visible seam between them. Both the hoop timer and the HIGH-SCORES board now use a single amber ghost tint across the whole screen; the unused `SCORE_GHOST` constant is removed. Follow-up to #485.