### PR TITLE
fix(basketball): guard ghost-ball reads against freed rapier handle

### DIFF
--- a/src/components/basketball/ghost-balls.tsx
+++ b/src/components/basketball/ghost-balls.tsx
@@ -222,9 +222,16 @@ const GhostBallsImpl = ({ ballRef }: GhostBallsProps) => {
 
   useFrameCallback((_, delta) => {
     // Send: sample the local rapier ball, but only when someone is listening
-    // and the ball is actually in play (quota stays at zero for solo visitors)
+    // and the ball is actually in play (quota stays at zero for solo visitors).
+    // isValid() guards against a stale handle around the ball's unmount at
+    // game end — reading a freed body panics the rapier WASM.
     const ball = ballRef.current
-    if (subscribedRef.current && ball && peerCountRef.current > 1) {
+    if (
+      subscribedRef.current &&
+      ball &&
+      ball.isValid() &&
+      peerCountRef.current > 1
+    ) {
       const t = ball.translation()
       if (
         Number.isFinite(t.x) &&


### PR DESCRIPTION
Playing a full game on the dev server crashed the rapier WASM at the buzzer: `GhostBalls`' frame loop could read `translation()` on the ball's just-freed body handle during its game-end unmount (the ref outlives the handle for a beat). One bad read panics the WASM (`RuntimeError: unreachable`) and poisons the world — every subsequent call throws "recursive use of an object", which surfaced as a page reload after saving your name (ErrorBoundary) or a lost WebGL context when exiting with ESC.

`isValid()` now guards the read. Verified with an automated full-game repro (throw → 24s timer → name screen → ESC/Enter): previously ~300 errors + context loss on dev, now zero errors and clean navigation in repeated runs. Production was never affected (verified clean before and after).

Follow-up to #485.