### PR TITLE
feat(basketball): net visual quality, earlier swish audio, curveball spin shots

### DIFF
--- a/src/components/basketball/basketball-utils.ts
+++ b/src/components/basketball/basketball-utils.ts
@@ -242,6 +242,7 @@ export const handlePointerMove = ({
   }
 }
 
+// returns true only when the release actually launched a throw
 export const handlePointerUp = ({
   ballRef,
   dragStartPos,
@@ -255,7 +256,8 @@ export const handlePointerUp = ({
   forwardStrength,
   playSoundFX,
   throwVelocity
-}: HandlePointerUpParams) => {
+}: HandlePointerUpParams): boolean => {
+  let threw = false
   if (ballRef.current && isThrowable.current) {
     if (!isGameActive) {
       startGame()
@@ -305,10 +307,12 @@ export const handlePointerUp = ({
       )
       ball.applyImpulse(assistedVelocity, true)
       ball.applyTorqueImpulse({ x: 0.005, y: 0, z: 0 }, true)
+      threw = true
     } else {
       ball.setBodyType(0, true)
     }
 
     setIsDragging(false)
   }
+  return threw
 }

--- a/src/components/basketball/curveball.tsx
+++ b/src/components/basketball/curveball.tsx
@@ -1,0 +1,150 @@
+import { RapierRigidBody, useAfterPhysicsStep } from "@react-three/rapier"
+import { RefObject, useRef } from "react"
+
+// Pokémon-GO-style curveball: spin the ball in circles while holding it,
+// then release — the shot curves sideways (Magnus force perpendicular to
+// the flight path) and, as it descends, bends back toward the rim. More
+// spin = more curve and more magic.
+
+// gesture
+const SPIN_MIN_TURNS = 1.25
+const SPIN_MAX_TURNS = 3
+const SAMPLE_MIN_PX = 3
+
+// flight
+const MAGNUS_ACCEL = 1.4 // m/s² per spin turn, ⊥ to horizontal velocity
+const HOMING_ACCEL = 3.0 // m/s² toward the rim axis while descending
+const HOMING_RANGE = 1.4 // only bend shots already missing by less than this
+const CURVE_SECONDS = 1.8
+const SPIN_TORQUE = 0.004 // visible sidespin on the ball mesh
+const STEP_DT = 1 / 60
+
+// rim axis from the net GLB (see net-physics.tsx binding derivation)
+const RIM_AXIS_X = 5.197
+const RIM_AXIS_Z = -14.069
+const RIM_Y = 3.232
+
+// --- spin gesture tracking (fed by hoop-minigame's pointer handlers) ---
+
+let lastX = 0
+let lastY = 0
+let vecX = 0
+let vecY = 0
+let hasVec = false
+let hasPoint = false
+let accumulated = 0
+
+export const resetSpinTracking = () => {
+  hasPoint = false
+  hasVec = false
+  accumulated = 0
+}
+
+export const trackSpin = (clientX: number, clientY: number) => {
+  if (!hasPoint) {
+    lastX = clientX
+    lastY = clientY
+    hasPoint = true
+    return
+  }
+  const dx = clientX - lastX
+  const dy = clientY - lastY
+  if (Math.hypot(dx, dy) < SAMPLE_MIN_PX) return
+  lastX = clientX
+  lastY = clientY
+
+  if (hasVec) {
+    const cross = vecX * dy - vecY * dx
+    const dot = vecX * dx + vecY * dy
+    accumulated += Math.atan2(cross, dot)
+  }
+  vecX = dx
+  vecY = dy
+  hasVec = true
+}
+
+// signed spin turns for the shot being released; consumed by CurveballForce
+export const spinCharge = { current: 0 }
+
+export const armCurveball = () => {
+  const turns = accumulated / (Math.PI * 2)
+  resetSpinTracking()
+  spinCharge.current =
+    Math.abs(turns) < SPIN_MIN_TURNS
+      ? 0
+      : Math.sign(turns) * Math.min(Math.abs(turns), SPIN_MAX_TURNS)
+  return spinCharge.current
+}
+
+// --- in-flight curve forces ---
+
+interface CurveballForceProps {
+  ballRef: RefObject<RapierRigidBody | null>
+}
+
+export const CurveballForce = ({ ballRef }: CurveballForceProps) => {
+  const age = useRef(0)
+  const spun = useRef(false)
+
+  useAfterPhysicsStep(() => {
+    if (spinCharge.current === 0) {
+      age.current = 0
+      spun.current = false
+      return
+    }
+    const ball = ballRef.current
+    if (!ball || !ball.isValid() || ball.bodyType() !== 0) {
+      spinCharge.current = 0
+      age.current = 0
+      spun.current = false
+      return
+    }
+
+    age.current += STEP_DT
+    if (age.current > CURVE_SECONDS) {
+      spinCharge.current = 0
+      age.current = 0
+      spun.current = false
+      return
+    }
+
+    const spin = spinCharge.current
+    const m = ball.mass()
+
+    if (!spun.current) {
+      spun.current = true
+      ball.applyTorqueImpulse(
+        { x: 0, y: SPIN_TORQUE * Math.sign(spin), z: 0 },
+        true
+      )
+    }
+
+    const v = ball.linvel()
+    const horizontalSpeed = Math.hypot(v.x, v.z)
+
+    // Magnus: push ⊥ to the horizontal flight direction
+    if (horizontalSpeed > 0.3) {
+      const px = -v.z / horizontalSpeed
+      const pz = v.x / horizontalSpeed
+      const f = m * MAGNUS_ACCEL * spin * STEP_DT
+      ball.applyImpulse({ x: px * f, y: 0, z: pz * f }, true)
+    }
+
+    // the magic: on the way down, bend near-misses back into the rim
+    const p = ball.translation()
+    if (v.y < 0 && p.y > RIM_Y - 0.1) {
+      const dx = RIM_AXIS_X - p.x
+      const dz = RIM_AXIS_Z - p.z
+      const miss = Math.hypot(dx, dz)
+      if (miss > 0.02 && miss < HOMING_RANGE) {
+        const strength =
+          (Math.min(Math.abs(spin), SPIN_MAX_TURNS) / SPIN_MAX_TURNS) *
+          HOMING_ACCEL
+        const g = (m * strength * STEP_DT) / miss
+        ball.applyImpulse({ x: dx * g, y: 0, z: dz * g }, true)
+      }
+    }
+  })
+
+  return null
+}

--- a/src/components/basketball/hoop-minigame.tsx
+++ b/src/components/basketball/hoop-minigame.tsx
@@ -22,6 +22,12 @@ import { easeInOutCubic } from "@/utils/animations"
 import { Basketball } from "./basketball"
 import { STATIC_GROUP } from "./collision"
 import { GhostBalls } from "./ghost-balls"
+import {
+  armCurveball,
+  CurveballForce,
+  resetSpinTracking,
+  trackSpin
+} from "./curveball"
 import { NetPhysics } from "./net-physics"
 import { RigidBodies } from "./rigid-bodies"
 
@@ -399,6 +405,7 @@ const HoopMinigameInner = () => {
   ])
 
   const handlePointerUp = useCallback(() => {
+    armCurveball()
     utilsHandlePointerUp({
       ballRef,
       dragStartPos: positionVectors.dragStartPos,
@@ -604,6 +611,7 @@ const HoopMinigameInner = () => {
       // Don't allow grabbing the ball when timer is low
       if (isTimerLow.current) return
 
+      resetSpinTracking()
       utilsHandlePointerDown({
         event,
         ballRef,
@@ -625,6 +633,7 @@ const HoopMinigameInner = () => {
     (event: any) => {
       if (!isDragging) return
 
+      trackSpin(event.clientX, event.clientY)
       utilsHandlePointerMove({
         event,
         ballRef,
@@ -689,6 +698,8 @@ const HoopMinigameInner = () => {
       )}
 
       <NetPhysics ballRef={ballRef} />
+
+      <CurveballForce ballRef={ballRef} />
 
       {readyToPlay && (
         <>

--- a/src/components/basketball/hoop-minigame.tsx
+++ b/src/components/basketball/hoop-minigame.tsx
@@ -21,13 +21,13 @@ import { easeInOutCubic } from "@/utils/animations"
 
 import { Basketball } from "./basketball"
 import { STATIC_GROUP } from "./collision"
-import { GhostBalls } from "./ghost-balls"
 import {
   armCurveball,
   CurveballForce,
   resetSpinTracking,
   trackSpin
 } from "./curveball"
+import { GhostBalls } from "./ghost-balls"
 import { NetPhysics } from "./net-physics"
 import { RigidBodies } from "./rigid-bodies"
 
@@ -405,8 +405,7 @@ const HoopMinigameInner = () => {
   ])
 
   const handlePointerUp = useCallback(() => {
-    armCurveball()
-    utilsHandlePointerUp({
+    const threw = utilsHandlePointerUp({
       ballRef,
       dragStartPos: positionVectors.dragStartPos,
       hasMovedSignificantly,
@@ -420,6 +419,14 @@ const HoopMinigameInner = () => {
       playSoundFX,
       throwVelocity: throwVelocity.current
     })
+
+    // only a release that actually launched a throw may charge the
+    // curveball — a dropped ball must not receive spin/curve forces
+    if (threw) {
+      armCurveball()
+    } else {
+      resetSpinTracking()
+    }
   }, [
     isGameActive,
     hoopPosition,

--- a/src/components/basketball/net-physics.tsx
+++ b/src/components/basketball/net-physics.tsx
@@ -7,7 +7,7 @@ import {
   useSpringJoint
 } from "@react-three/rapier"
 import { createRef, RefObject, useEffect, useMemo, useRef } from "react"
-import { Matrix4, Mesh, Vector3 } from "three"
+import { BufferAttribute, Matrix4, Mesh, Vector3 } from "three"
 
 import { useMesh } from "@/hooks/use-mesh"
 import { useFrameCallback } from "@/hooks/use-pausable-time"
@@ -24,6 +24,10 @@ export const ballThroughRim = { current: false }
 // rapier sensor enter/exit events race the ballThroughRim flag under
 // clamped deltas and can swallow legitimate goals.
 export const netGoalHandler = { current: null as (() => void) | null }
+
+// Fired the moment the ball crosses the rim plane into the net — the swish
+// sound belongs here, at first net contact, not at the later score confirm.
+export const netTouchHandler = { current: null as (() => void) | null }
 
 // Lattice resolution: COLS columns around the rim, RINGS height rings.
 // Ring 0 is welded to the rim (part of the fixed anchor); rings 1..RINGS-1
@@ -60,19 +64,81 @@ interface NetBinding {
   restLocal: Float32Array
   nodeIndices: Uint16Array
   nodeWeights: Float32Array
-  residuals: Float32Array
+}
+
+// The authored net is only ~170 vertices, so skinned deformation bends in
+// long straight segments. Midpoint-subdividing the indexed geometry is
+// invisible at rest (linear midpoints) but each new vertex gets its own
+// skinning weights, so motion curves smoothly.
+const SUBDIVISIONS = 2
+
+const subdivideNetGeometry = (net: Mesh) => {
+  const geometry = net.geometry
+  if (net.userData.netSubdivided || !geometry.index) return
+  net.userData.netSubdivided = true
+
+  for (let pass = 0; pass < SUBDIVISIONS; pass++) {
+    const index = geometry.index!.array
+    const attrs = Object.entries(geometry.attributes)
+    const oldCount = geometry.attributes.position.count
+    const arrays = attrs.map(([, attr]) => ({
+      itemSize: attr.itemSize,
+      data: Array.from(attr.array as ArrayLike<number>)
+    }))
+
+    const edgeMidpoints = new Map<string, number>()
+    let nextIndex = oldCount
+    const midpoint = (a: number, b: number) => {
+      const key = a < b ? `${a}_${b}` : `${b}_${a}`
+      const existing = edgeMidpoints.get(key)
+      if (existing !== undefined) return existing
+      for (const { itemSize, data } of arrays) {
+        for (let k = 0; k < itemSize; k++) {
+          data.push((data[a * itemSize + k] + data[b * itemSize + k]) / 2)
+        }
+      }
+      edgeMidpoints.set(key, nextIndex)
+      return nextIndex++
+    }
+
+    const newIndex: number[] = []
+    for (let t = 0; t < index.length; t += 3) {
+      const a = index[t]
+      const b = index[t + 1]
+      const c = index[t + 2]
+      const ab = midpoint(a, b)
+      const bc = midpoint(b, c)
+      const ca = midpoint(c, a)
+      newIndex.push(a, ab, ca, ab, b, bc, ca, bc, c, ab, bc, ca)
+    }
+
+    attrs.forEach(([name], i) => {
+      geometry.setAttribute(
+        name,
+        new BufferAttribute(
+          Float32Array.from(arrays[i].data),
+          arrays[i].itemSize
+        )
+      )
+    })
+    geometry.setIndex(newIndex)
+  }
 }
 
 // Derive the lattice rest pose and per-vertex bilinear skinning weights from
 // the render geometry itself, so the physics net matches the authored mesh
 // exactly at rest.
 const buildNetBinding = (net: Mesh): NetBinding => {
+  subdivideNetGeometry(net)
   net.updateWorldMatrix(true, false)
   const matrixWorld = net.matrixWorld.clone()
   const inverseMatrixWorld = matrixWorld.clone().invert()
 
   const positionAttr = net.geometry.attributes.position
-  if (!net.userData.originalPositions) {
+  if (
+    !net.userData.originalPositions ||
+    net.userData.originalPositions.length !== positionAttr.array.length
+  ) {
     net.userData.originalPositions = Float32Array.from(
       positionAttr.array as Float32Array
     )
@@ -119,11 +185,11 @@ const buildNetBinding = (net: Mesh): NetBinding => {
     }
   }
 
-  // Bilinear bind of every vertex to its 4 surrounding lattice nodes, plus a
-  // residual offset that preserves the diamond-pattern detail inside a cell.
+  // Bilinear bind of every vertex to its 4 surrounding lattice nodes. The
+  // mesh is skinned by node OFFSETS from the settled pose, so the authored
+  // diamond detail is carried by the original positions themselves.
   const nodeIndices = new Uint16Array(vertexCount * 4)
   const nodeWeights = new Float32Array(vertexCount * 4)
-  const residuals = new Float32Array(vertexCount * 3)
   for (let i = 0; i < vertexCount; i++) {
     const x = original[i * 3]
     const y = original[i * 3 + 1]
@@ -133,11 +199,17 @@ const buildNetBinding = (net: Mesh): NetBinding => {
     if (colF < 0) colF += NET_COLS
     const c0 = Math.floor(colF) % NET_COLS
     const c1 = (c0 + 1) % NET_COLS
-    const fc = colF - Math.floor(colF)
+    const rawFc = colF - Math.floor(colF)
 
     const rowF = Math.min(Math.max((yTop - y) / spacing, 0), NET_RINGS - 1)
     const r0 = Math.min(Math.floor(rowF), NET_RINGS - 2)
-    const fr = rowF - r0
+    const rawFr = rowF - r0
+
+    // smoothstep the cell fractions so deformation eases across lattice
+    // cells instead of creasing at cell borders (offset skinning keeps the
+    // authored pose exact regardless of the weighting)
+    const fc = rawFc * rawFc * (3 - 2 * rawFc)
+    const fr = rawFr * rawFr * (3 - 2 * rawFr)
 
     const indices = [
       r0 * NET_COLS + c0,
@@ -147,20 +219,10 @@ const buildNetBinding = (net: Mesh): NetBinding => {
     ]
     const weights = [(1 - fr) * (1 - fc), (1 - fr) * fc, fr * (1 - fc), fr * fc]
 
-    let bx = 0
-    let by = 0
-    let bz = 0
     for (let k = 0; k < 4; k++) {
       nodeIndices[i * 4 + k] = indices[k]
       nodeWeights[i * 4 + k] = weights[k]
-      const j = indices[k] * 3
-      bx += weights[k] * restLocal[j]
-      by += weights[k] * restLocal[j + 1]
-      bz += weights[k] * restLocal[j + 2]
     }
-    residuals[i * 3] = x - bx
-    residuals[i * 3 + 1] = y - by
-    residuals[i * 3 + 2] = z - bz
   }
 
   return {
@@ -171,8 +233,7 @@ const buildNetBinding = (net: Mesh): NetBinding => {
     yTop,
     restLocal,
     nodeIndices,
-    nodeWeights,
-    residuals
+    nodeWeights
   }
 }
 
@@ -223,6 +284,8 @@ const STUCK_PUSH = 8
 const SWISH_EXIT_SPEED = 2.5
 // the shared <Physics> world steps at rapier's fixed default
 const STEP_DT = 1 / 60
+// worst-case wait for the initial lattice settle before baselining anyway
+const SETTLE_TIMEOUT = 3
 
 const NetPhysicsInner = ({ net, ballRef }: NetPhysicsProps & { net: Mesh }) => {
   const binding = useMemo(() => buildNetBinding(net), [net])
@@ -331,6 +394,8 @@ const NetPhysicsInner = ({ net, ballRef }: NetPhysicsProps & { net: Mesh }) => {
   )
   const tmp = useMemo(() => new Vector3(), [])
   const stuckTime = useRef(0)
+  const settled = useRef<Float32Array | null>(null)
+  const settleTime = useRef(0)
 
   useEffect(() => {
     const geometry = net.geometry
@@ -376,6 +441,7 @@ const NetPhysicsInner = ({ net, ballRef }: NetPhysicsProps & { net: Mesh }) => {
           v.y < 0
         ) {
           ballThroughRim.current = true
+          netTouchHandler.current?.()
         }
       } else if (p.y < rimY - 0.65) {
         ballThroughRim.current = false
@@ -422,7 +488,7 @@ const NetPhysicsInner = ({ net, ballRef }: NetPhysicsProps & { net: Mesh }) => {
     }
   })
 
-  useFrameCallback(() => {
+  useFrameCallback((_, delta) => {
     let allAsleep = true
     for (let d = 0; d < nodeRefs.length; d++) {
       const body = nodeRefs[d].current
@@ -431,8 +497,6 @@ const NetPhysicsInner = ({ net, ballRef }: NetPhysicsProps & { net: Mesh }) => {
       if (!body || !body.isValid()) return
       if (!body.isSleeping()) allAsleep = false
     }
-    // Geometry already matches the settled lattice — skip the writes.
-    if (allAsleep) return
 
     for (let d = 0; d < nodeRefs.length; d++) {
       const t = nodeRefs[d].current!.translation()
@@ -443,19 +507,35 @@ const NetPhysicsInner = ({ net, ballRef }: NetPhysicsProps & { net: Mesh }) => {
       nodeCurrent[j + 2] = tmp.z
     }
 
+    // The joints have slack, so the lattice sags a touch below the analytic
+    // rest pose right after spawning. Hold the authored mesh until that
+    // first settle finishes, then skin the mesh by the nodes' offset FROM
+    // the settled pose — settled lattice therefore displays the authored
+    // net exactly, and entering/leaving the scene never pops.
+    if (!settled.current) {
+      settleTime.current += delta
+      if (allAsleep || settleTime.current > SETTLE_TIMEOUT) {
+        settled.current = Float32Array.from(nodeCurrent)
+      }
+      return
+    }
+    // Geometry already matches the settled lattice — skip the writes.
+    if (allAsleep) return
+
     const positionAttr = net.geometry.attributes.position
     const array = positionAttr.array as Float32Array
-    const { nodeIndices, nodeWeights, residuals, vertexCount } = binding
+    const baseline = settled.current
+    const { nodeIndices, nodeWeights, originalPositions, vertexCount } = binding
     for (let i = 0; i < vertexCount; i++) {
-      let x = residuals[i * 3]
-      let y = residuals[i * 3 + 1]
-      let z = residuals[i * 3 + 2]
+      let x = originalPositions[i * 3]
+      let y = originalPositions[i * 3 + 1]
+      let z = originalPositions[i * 3 + 2]
       for (let k = 0; k < 4; k++) {
         const w = nodeWeights[i * 4 + k]
         const j = nodeIndices[i * 4 + k] * 3
-        x += w * nodeCurrent[j]
-        y += w * nodeCurrent[j + 1]
-        z += w * nodeCurrent[j + 2]
+        x += w * (nodeCurrent[j] - baseline[j])
+        y += w * (nodeCurrent[j + 1] - baseline[j + 1])
+        z += w * (nodeCurrent[j + 2] - baseline[j + 2])
       }
       array[i * 3] = x
       array[i * 3 + 1] = y

--- a/src/components/basketball/net.tsx
+++ b/src/components/basketball/net.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from "react"
-import { DoubleSide, MeshBasicMaterial, NearestFilter } from "three"
+import {
+  DoubleSide,
+  LinearFilter,
+  LinearMipmapLinearFilter,
+  MeshBasicMaterial
+} from "three"
 
 import { useMesh } from "@/hooks/use-mesh"
 
@@ -17,8 +22,15 @@ export const Net = () => {
     if (!originalMaterial || !originalMaterial.map) return
 
     const texture = originalMaterial.map.clone()
-    texture.magFilter = NearestFilter
-    texture.minFilter = NearestFilter
+    // Linear filtering + anisotropy keeps the strands from shimmering while
+    // the physics net swings (mipmaps only if the source texture ships them —
+    // KTX2 compressed textures can't generate their own)
+    texture.magFilter = LinearFilter
+    texture.minFilter =
+      texture.mipmaps && texture.mipmaps.length > 1
+        ? LinearMipmapLinearFilter
+        : LinearFilter
+    texture.anisotropy = 8
     texture.generateMipmaps = false
     texture.needsUpdate = true
 

--- a/src/components/basketball/rigid-bodies.tsx
+++ b/src/components/basketball/rigid-bodies.tsx
@@ -7,7 +7,7 @@ import { useSiteAudio } from "@/hooks/use-site-audio"
 import { useMinigameStore } from "@/store/minigame-store"
 
 import { STATIC_GROUP } from "./collision"
-import { netGoalHandler } from "./net-physics"
+import { netGoalHandler, netTouchHandler } from "./net-physics"
 
 interface RigidBodiesProps {
   hoopPosition: { x: number; y: number; z: number }
@@ -31,15 +31,19 @@ export const RigidBodies = ({ hoopPosition }: RigidBodiesProps) => {
 
   const randomPitch = 0.95 + Math.random() * 0.1
 
-  // Called by NetPhysics' frame loop when a full through-the-rim pass is
-  // confirmed (see netGoalHandler) — that tracking replaced the old sensor
-  // collider, whose enter/exit events raced the through-rim flag.
+  // Swish audio plays at first net contact (rim-plane crossing), while the
+  // score waits for the confirmed pass below the net (see netGoalHandler /
+  // netTouchHandler) — that tracking replaced the old sensor collider,
+  // whose enter/exit events raced the through-rim flag.
+  const handleNetTouch = () => {
+    playSoundFX("BASKETBALL_NET", 0.6, randomPitch)
+  }
+
   const handleScore = () => {
     const baseScore = 10
     const multipliedScore = Math.floor(baseScore * scoreMultiplier)
     setScore((prev) => prev + multipliedScore)
     incrementConsecutiveScores()
-    playSoundFX("BASKETBALL_NET", 0.6, randomPitch)
     track("basketball_score")
 
     if (hasHitStreak) playSoundFX("BASKETBALL_STREAK", 0.06)
@@ -47,8 +51,10 @@ export const RigidBodies = ({ hoopPosition }: RigidBodiesProps) => {
 
   useEffect(() => {
     netGoalHandler.current = handleScore
+    netTouchHandler.current = handleNetTouch
     return () => {
       netGoalHandler.current = null
+      netTouchHandler.current = null
     }
   })
 

--- a/src/components/lamp/index.tsx
+++ b/src/components/lamp/index.tsx
@@ -105,8 +105,9 @@ export const Lamp = memo(function LampInner() {
 
   useEffect(() => {
     lightmap.generateMipmaps = false
-    lightmap.minFilter = THREE.NearestFilter
-    lightmap.magFilter = THREE.NearestFilter
+    // linear like the map bakes, so the lamp lighting grades smoothly
+    lightmap.minFilter = THREE.LinearFilter
+    lightmap.magFilter = THREE.LinearFilter
     lightmap.colorSpace = THREE.NoColorSpace
   }, [lightmap])
 

--- a/src/components/map/bakes.tsx
+++ b/src/components/map/bakes.tsx
@@ -4,6 +4,7 @@ import { useLoader, useThree } from "@react-three/fiber"
 import { memo, Suspense, useEffect, useMemo } from "react"
 import {
   Group,
+  LinearFilter,
   Mesh,
   NearestFilter,
   NoColorSpace,
@@ -101,8 +102,10 @@ const useBakes = (): Record<string, Bake> => {
     loadedLightmaps.forEach((map, index) => {
       const meshNames = withLightmap[index].meshes
       map.generateMipmaps = false
-      map.minFilter = NearestFilter
-      map.magFilter = NearestFilter
+      // linear so baked lighting reads as smooth gradients instead of
+      // texel stair-steps
+      map.minFilter = LinearFilter
+      map.magFilter = LinearFilter
       map.colorSpace = NoColorSpace
 
       for (const meshName of meshNames) {


### PR DESCRIPTION
Follow-up to #488 (physics net). Three game-feel improvements, all verified against the dev server with the headless drop/lodge harness (3/3 drops score 32, zero page errors, settled net pixel-identical to the authored pose).

## Net visual quality

- **Smooth deformation**: the authored net is only 170 vertices, so skinned motion bent in long straight facets. The indexed geometry is midpoint-subdivided twice at bind time (~2.5k verts) — exactly invisible at rest, but every new vertex gets its own skinning weights so swishes curve smoothly. Skinning still skips entirely while the lattice sleeps.
- **Cleaner texture**: Nearest → linear filtering with 8× anisotropy (the Nearest setup was a VAT-era leftover); kills strand shimmer in motion.
- **Smoother cell falloff**: skinning cell fractions are smoothstepped so deformation eases across lattice-cell borders instead of creasing.

## Scene-transition pop fix

The rope joints carry intentional slack, so the lattice sags ~1–2% the moment it spawns — and the skinning displayed that sag, making the net visibly change size when entering/leaving the basketball scene. The mesh is now frozen at the authored pose during the initial settle (all-asleep or a 3s timeout), and thereafter skinned by node **offsets from the settled pose** — a settled lattice therefore displays the authored net exactly. Same size from home, during play, and after leaving. This delta formulation also made the old residual-correction arrays unnecessary.

## Earlier swish audio

`BASKETBALL_NET` now fires at first net contact — the per-substep rim-plane crossing that arms the containment tube (`netTouchHandler`) — instead of at the score confirm, which lands ~0.2s after the ball is already through. Score, streak sound, and analytics still wait for the confirmed exit below the net, so scoring reliability is unchanged. Rattle-outs now make a net sound without scoring, as they should.

## Curveball (Pokémon-GO-style spin shot)

Spin the held ball in circles (1¼ full turns minimum, 3 counted) before flicking:

- The shot curves sideways — a real Magnus force perpendicular to the flight path, direction following the spin — with visible sidespin on the ball.
- On descent, a spun near-miss within 1.4m of the rim axis bends back toward the basket, proportionally to spin.
- Straight throws are completely unaffected; the gesture accumulator resets on every grab, and the curve force self-cancels after 1.8s or when the ball is reset.

Tunables at the top of `curveball.tsx` (`MAGNUS_ACCEL`, `HOMING_ACCEL`/`HOMING_RANGE`, `SPIN_MIN_TURNS`).