### PR TITLE
feat(rendering): render the main scene at native pixel ratio

### DIFF
--- a/src/components/postprocessing/renderer.tsx
+++ b/src/components/postprocessing/renderer.tsx
@@ -105,15 +105,21 @@ function RendererInner({ sceneChildren }: RendererProps) {
 
   const screenWidth = useThree((state) => state.size.width)
   const screenHeight = useThree((state) => state.size.height)
+  const dpr = useThree((state) => state.viewport.dpr)
 
   const bloomResolution = useMemo(
     () => bloomSize(screenWidth, screenHeight),
     [screenWidth, screenHeight]
   )
 
+  // Match the canvas's drawing-buffer density (dpr is already capped by the
+  // Canvas: 1 on mobile, ≤2 on desktop). Sizing the target in CSS pixels
+  // rendered the whole scene at 1x on retina displays and nearest-upscaled
+  // it. The `resolution` uniform stays CSS-sized on purpose — the composite
+  // shader's pixelation/dither block sizes are part of the art direction.
   useEffect(() => {
-    mainTarget.setSize(screenWidth, screenHeight)
-  }, [mainTarget, screenWidth, screenHeight])
+    mainTarget.setSize(screenWidth * dpr, screenHeight * dpr)
+  }, [mainTarget, screenWidth, screenHeight, dpr])
 
   useEffect(() => {
     bloomTarget.setSize(bloomResolution.x, bloomResolution.y)


### PR DESCRIPTION
The post-processing pipeline sized its main render target in **CSS pixels** (`state.size`), so on retina displays the entire 3D scene rendered at 1× and was nearest-neighbor upscaled to the 2× canvas by the composite pass — visibly soft/crunchy geometry, most noticeable on thin detail like the basketball net strands.

The target now matches the canvas drawing-buffer density via `viewport.dpr`, which the Canvas already governs: **1 on mobile** (the deliberate INP-era cap — zero cost change there) and **capped at 2 on desktop**.

Deliberately unchanged:
- The composite shader's `resolution` uniform stays CSS-sized — the pixelation/dither block sizes are art direction and keep their exact scale, so the look sharpens without losing the retro grain.
- Bloom target stays at half-of-CSS resolution (it's a blur; density there is wasted).

**Perf tradeoff**: desktop retina pays ~4× the fragment work on the main scene pass. Mobile — the constrained tier — is untouched. Worth watching the Vercel preview on a heavier desktop scene before merging.

Verified with tsc + local play; visual comparison screenshots in the session that produced this change show sharper rim/net/geometry with the dither aesthetic intact.