### PR TITLE
feat(basketball): server-validated leaderboard submissions

### DIFF
--- a/src/app/(site)/api/scores/route.ts
+++ b/src/app/(site)/api/scores/route.ts
@@ -1,30 +1,35 @@
 import * as Sentry from "@sentry/nextjs"
 import { geolocation } from "@vercel/functions"
-import crypto from "crypto"
 import { NextResponse } from "next/server"
 
+import { verifySessionToken } from "@/service/score-session"
 import { createClient } from "@/service/supabase/server"
 import { getTopScoresFromServer } from "@/service/supabase/server"
 
 const rateLimitMap = new Map<string, { count: number; timestamp: number }>()
 const RATE_LIMIT_WINDOW = 60 * 1000
 const MAX_REQUESTS = 3
-const TIME_WINDOW = 30000
 
-async function generateTimeWindowHash(timestamp: number): Promise<string> {
-  const timeWindow = Math.floor(timestamp / TIME_WINDOW) * TIME_WINDOW
+// Theoretical ceiling for a 24s game: the throw cycle floors at ~2s, so a
+// perfect run lands ~11-12 baskets; with the streak multiplier ramp
+// (10/12/15/25 then 50 per basket) that is ~460 points. Anything above is
+// not a basketball game.
+const MAX_VALID_SCORE = 500
+const GAME_DURATION_MS = 24_000
+// small tolerance for client/server clock and timer drift
+const MIN_SESSION_AGE_MS = GAME_DURATION_MS - 2_000
+// game + name entry + retries comfortably fit here
+const MAX_SESSION_AGE_MS = 15 * 60 * 1000
 
-  const hash = crypto.createHash("sha256")
-  hash.update(timeWindow.toString())
-  return hash.digest("hex")
-}
-
-async function isValidTimeWindowHash(
-  timestamp: number,
-  providedHash: string
-): Promise<boolean> {
-  const expectedHash = await generateTimeWindowHash(timestamp)
-  return expectedHash === providedHash
+// Single-use nonces. In-memory, so a replay can slip through on another
+// serverless instance — but it is bounded by MAX_SESSION_AGE_MS, the rate
+// limit, the score ceiling, and the fact that the upsert only ever raises a
+// player's own best.
+const usedNonces = new Map<string, number>()
+const pruneNonces = (now: number) => {
+  for (const [nonce, seenAt] of usedNonces) {
+    if (now - seenAt > MAX_SESSION_AGE_MS) usedNonces.delete(nonce)
+  }
 }
 
 function isRateLimited(clientId: string): boolean {
@@ -90,28 +95,38 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
-    const { playerName, score, clientId, timestamp, timeWindowHash } =
-      await request.json()
+    const { playerName, score, clientId, sessionToken } = await request.json()
 
-    // Validate hash first
-    if (!timeWindowHash || typeof timeWindowHash !== "string") {
+    // a server-signed session proves a game was started on this site and
+    // ran for at least a full game duration before this score arrived
+    if (!sessionToken || typeof sessionToken !== "string") {
       return NextResponse.json(
-        { error: "Invalid time window hash" },
+        { error: "Missing game session" },
         { status: 400 }
       )
     }
 
-    // validate timestamp
-    const now = Date.now()
-    const timeDiff = Math.abs(now - timestamp)
-
-    if (!timestamp || typeof timestamp !== "number" || timeDiff > TIME_WINDOW) {
-      return NextResponse.json({ error: "Invalid timestamp" }, { status: 400 })
+    const session = verifySessionToken(sessionToken)
+    if (!session) {
+      return NextResponse.json(
+        { error: "Invalid game session" },
+        { status: 400 }
+      )
     }
 
-    if (!(await isValidTimeWindowHash(timestamp, timeWindowHash))) {
+    const now = Date.now()
+    const sessionAge = now - session.iat
+    if (sessionAge < MIN_SESSION_AGE_MS || sessionAge > MAX_SESSION_AGE_MS) {
       return NextResponse.json(
-        { error: "Invalid time window verification" },
+        { error: "Invalid game session" },
+        { status: 400 }
+      )
+    }
+
+    pruneNonces(now)
+    if (usedNonces.has(session.nonce)) {
+      return NextResponse.json(
+        { error: "Game session already used" },
         { status: 400 }
       )
     }
@@ -128,15 +143,23 @@ export async function POST(request: Request) {
       )
     }
 
-    if (typeof score !== "number" || score < 0 || !Number.isInteger(score)) {
+    if (
+      typeof score !== "number" ||
+      score < 0 ||
+      !Number.isInteger(score) ||
+      score > MAX_VALID_SCORE
+    ) {
       return NextResponse.json({ error: "Invalid score" }, { status: 400 })
     }
 
-    if (!clientId || typeof clientId !== "string") {
+    if (!clientId || typeof clientId !== "string" || clientId.length > 64) {
       return NextResponse.json({ error: "Invalid client ID" }, { status: 400 })
     }
 
-    if (isRateLimited(clientId)) {
+    // rate limit on the network address as well as the client-chosen id
+    const ip =
+      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown"
+    if (isRateLimited(clientId) || isRateLimited(`ip:${ip}`)) {
       return NextResponse.json({ error: "Too many requests" }, { status: 429 })
     }
 
@@ -154,6 +177,7 @@ export async function POST(request: Request) {
 
     // if the new score is lower than existing one, just return
     if (existingScore && score <= existingScore.score) {
+      usedNonces.set(session.nonce, now)
       return NextResponse.json({ success: true })
     }
 
@@ -176,6 +200,9 @@ export async function POST(request: Request) {
       console.error("Supabase error:", error)
       throw error
     }
+
+    // consume the session only on success so a transient failure can retry
+    usedNonces.set(session.nonce, now)
 
     return NextResponse.json({ success: true })
   } catch (error) {

--- a/src/app/(site)/api/scores/route.ts
+++ b/src/app/(site)/api/scores/route.ts
@@ -123,14 +123,6 @@ export async function POST(request: Request) {
       )
     }
 
-    pruneNonces(now)
-    if (usedNonces.has(session.nonce)) {
-      return NextResponse.json(
-        { error: "Game session already used" },
-        { status: 400 }
-      )
-    }
-
     if (
       !playerName ||
       typeof playerName !== "string" ||
@@ -163,48 +155,62 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Too many requests" }, { status: 429 })
     }
 
-    const details = geolocation(request)
-
-    const supabase = createClient()
-
-    // check if a score exists for this player
-    const { data: existingScore } = await supabase
-      .from("scoreboard")
-      .select("id, score")
-      .eq("player_name", playerName)
-      .eq("country", details.flag)
-      .single()
-
-    // if the new score is lower than existing one, just return
-    if (existingScore && score <= existingScore.score) {
-      usedNonces.set(session.nonce, now)
-      return NextResponse.json({ success: true })
-    }
-
-    // if no existing score or new score is higher, upsert the record
-    const { error } = await supabase
-      .from("scoreboard")
-      .upsert(
-        {
-          ...(existingScore?.id ? { id: existingScore.id } : {}),
-          player_name: playerName,
-          score: Math.floor(score),
-          client_id: clientId,
-          country: details.flag || "🏳️"
-        },
-        { onConflict: "id" }
+    // Reserve the nonce synchronously — check and set with no await in
+    // between, so overlapping requests with the same session can't both
+    // pass. Released below if the write fails, so retries stay possible.
+    pruneNonces(now)
+    if (usedNonces.has(session.nonce)) {
+      return NextResponse.json(
+        { error: "Game session already used" },
+        { status: 400 }
       )
-      .select()
-
-    if (error) {
-      console.error("Supabase error:", error)
-      throw error
     }
-
-    // consume the session only on success so a transient failure can retry
     usedNonces.set(session.nonce, now)
 
-    return NextResponse.json({ success: true })
+    try {
+      const details = geolocation(request)
+
+      const supabase = createClient()
+
+      // check if a score exists for this player
+      const { data: existingScore } = await supabase
+        .from("scoreboard")
+        .select("id, score")
+        .eq("player_name", playerName)
+        .eq("country", details.flag)
+        .single()
+
+      // if the new score is lower than existing one, just return
+      if (existingScore && score <= existingScore.score) {
+        return NextResponse.json({ success: true })
+      }
+
+      // if no existing score or new score is higher, upsert the record
+      const { error } = await supabase
+        .from("scoreboard")
+        .upsert(
+          {
+            ...(existingScore?.id ? { id: existingScore.id } : {}),
+            player_name: playerName,
+            score: Math.floor(score),
+            client_id: clientId,
+            country: details.flag || "🏳️"
+          },
+          { onConflict: "id" }
+        )
+        .select()
+
+      if (error) {
+        console.error("Supabase error:", error)
+        throw error
+      }
+
+      return NextResponse.json({ success: true })
+    } catch (error) {
+      // release the reservation so a transient failure can retry
+      usedNonces.delete(session.nonce)
+      throw error
+    }
   } catch (error) {
     console.error("Error submitting score:", error)
     Sentry.captureException(error)

--- a/src/app/(site)/api/scores/session/route.ts
+++ b/src/app/(site)/api/scores/session/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server"
+
+import { issueSessionToken } from "@/service/score-session"
+
+// Issued when a basketball game starts; the score POST requires it and
+// checks that at least a full game duration elapsed since issuance.
+export async function GET() {
+  return NextResponse.json(
+    { token: issueSessionToken() },
+    { headers: { "Cache-Control": "no-store, max-age=0" } }
+  )
+}

--- a/src/components/basketball/hoop-minigame.tsx
+++ b/src/components/basketball/hoop-minigame.tsx
@@ -16,6 +16,7 @@ import { useIsOnTab } from "@/hooks/use-is-on-tab"
 import { useMesh } from "@/hooks/use-mesh"
 import { useFrameCallback } from "@/hooks/use-pausable-time"
 import { useSiteAudio } from "@/hooks/use-site-audio"
+import { beginScoreSession } from "@/service/supabase/client"
 import { useMinigameStore } from "@/store/minigame-store"
 import { easeInOutCubic } from "@/utils/animations"
 
@@ -267,6 +268,9 @@ const HoopMinigameInner = () => {
       if (timerInterval.current) {
         clearInterval(timerInterval.current)
       }
+
+      // server-signed session backing this game's eventual score submission
+      beginScoreSession()
 
       setIsGameActive(true)
       setTimeRemaining(gameDuration)

--- a/src/service/score-session.ts
+++ b/src/service/score-session.ts
@@ -1,0 +1,59 @@
+import crypto from "crypto"
+
+// Server-only HMAC helpers for basketball score sessions. A token is issued
+// when a game starts and must accompany the score submission; because only
+// the server can sign one, a forged POST can't invent a session, and the
+// issued-at timestamp lets the API require that at least one real game
+// duration elapsed before a score arrives.
+
+const FALLBACK_DEV_SECRET = "basketball-dev-secret-not-for-production"
+
+let warned = false
+const getSecret = () => {
+  const secret = process.env.SCORES_SESSION_SECRET
+  if (!secret && !warned) {
+    warned = true
+    console.warn(
+      "SCORES_SESSION_SECRET is not set — score sessions are signed with a dev fallback"
+    )
+  }
+  return secret || FALLBACK_DEV_SECRET
+}
+
+export interface ScoreSession {
+  iat: number
+  nonce: string
+}
+
+const sign = (payload: string) =>
+  crypto.createHmac("sha256", getSecret()).update(payload).digest("base64url")
+
+export const issueSessionToken = (): string => {
+  const session: ScoreSession = {
+    iat: Date.now(),
+    nonce: crypto.randomBytes(12).toString("base64url")
+  }
+  const payload = Buffer.from(JSON.stringify(session)).toString("base64url")
+  return `${payload}.${sign(payload)}`
+}
+
+export const verifySessionToken = (token: string): ScoreSession | null => {
+  const parts = token.split(".")
+  if (parts.length !== 2) return null
+  const [payload, signature] = parts
+
+  const expected = sign(payload)
+  const a = Buffer.from(signature)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) return null
+
+  try {
+    const session = JSON.parse(Buffer.from(payload, "base64url").toString())
+    if (typeof session.iat !== "number" || typeof session.nonce !== "string") {
+      return null
+    }
+    return session as ScoreSession
+  } catch {
+    return null
+  }
+}

--- a/src/service/supabase/client.ts
+++ b/src/service/supabase/client.ts
@@ -42,22 +42,21 @@ export const getTopScores = async () => {
   return { data: data || [], error }
 }
 
-const generateTimeWindowHash = async (timestamp: number): Promise<string> => {
-  const TIME_WINDOW = 30000
-  const timeWindow = Math.floor(timestamp / TIME_WINDOW) * TIME_WINDOW
+// Server-signed game session, requested when a game starts. The score POST
+// requires it: the server checks the signature and that at least one full
+// game duration elapsed since it was issued.
+let sessionTokenPromise: Promise<string | null> | null = null
 
-  const encoder = new TextEncoder()
-  const data = encoder.encode(timeWindow.toString())
-  const hashBuffer = await crypto.subtle.digest("SHA-256", data)
-  const hashArray = Array.from(new Uint8Array(hashBuffer))
-  const hashHex = hashArray.map((b) => b.toString(16).padStart(2, "0")).join("")
-
-  return hashHex
+export const beginScoreSession = () => {
+  sessionTokenPromise = fetch("/api/scores/session")
+    .then((res) => (res.ok ? res.json() : null))
+    .then((json) => json?.token ?? null)
+    .catch(() => null)
 }
 
 export const submitScore = async (playerName: string, score: number) => {
   const clientId = getClientId()
-  const timestamp = Date.now()
+  const sessionToken = await (sessionTokenPromise ?? Promise.resolve(null))
 
   try {
     const response = await fetch("/api/scores", {
@@ -69,8 +68,7 @@ export const submitScore = async (playerName: string, score: number) => {
         playerName: playerName.toUpperCase(),
         score: Math.floor(score),
         clientId,
-        timestamp,
-        timeWindowHash: await generateTimeWindowHash(timestamp)
+        sessionToken
       })
     })
 


### PR DESCRIPTION
The leaderboard's previous protection was decorative — and the data showed it: 24 of the top 25 entries were the same exploit value (399), since purged from the table. The `timeWindowHash` was a plain SHA-256 of the timestamp with **no secret** (recomputable from the shipped client bundle), the rate limit keyed on a client-chosen ID in per-instance memory, and any integer score was accepted.

## What's in place now

1. **Server-signed game sessions.** `GET /api/scores/session` issues an HMAC-signed token (server-only secret) when a game starts (`beginScoreSession()` in `startGame`). Score POSTs require it — a submission can't exist without the server having witnessed a game start.
2. **Elapsed-time gate.** The token embeds its issue time; submissions younger than ~22s (a real 24s game must have elapsed) or older than 15min are rejected.
3. **Physical score ceiling.** From the game math — 24s, ~2s minimum per made basket, streak ramp 10/12/15/25 then 50/basket — a perfect run is ~460 points. Scores above **500** are rejected as impossible.
4. **Single-use sessions**, consumed only on *successful* submission so transient failures can retry.
5. **Rate limiting keyed on the network address** (x-forwarded-for) as well as the client ID.

## Verified

Live against the dev server: missing/forged/too-young tokens all rejected; absurd scores rejected without burning the session; a legitimate aged-token retry proceeds to the Supabase write. `pnpm build` green.

## Deploy note

**Set `SCORES_SESSION_SECRET` in Vercel** (production + preview) — any long random string. A dev fallback signs tokens when unset, so nothing breaks, but the secret belongs in env.

## Honest limits

A determined attacker scripting a real browser can still wait 24s and submit a plausible ≤500 score. Stopping that would need server-side replay validation — disproportionate for an easter-egg game. What this guarantees: no more four-digit garbage, and every entry is a score a human could have shot.