### PR TITLE
feat(map): linear filtering on ambient occlusion bakes

### DIFF
--- a/src/components/map/bakes.tsx
+++ b/src/components/map/bakes.tsx
@@ -107,6 +107,7 @@ const useBakes = (): Record<string, Bake> => {
       map.minFilter = LinearFilter
       map.magFilter = LinearFilter
       map.colorSpace = NoColorSpace
+      map.needsUpdate = true
 
       for (const meshName of meshNames) {
         if (!maps[meshName]) {
@@ -120,9 +121,12 @@ const useBakes = (): Record<string, Bake> => {
       const meshNames = withAmbientOcclusion[index].meshes
       map.flipY = false
       map.generateMipmaps = false
-      map.minFilter = NearestFilter
-      map.magFilter = NearestFilter
+      // linear like the lightmaps — AO is part of the baked shading and
+      // shows the same texel stair-steps at Nearest
+      map.minFilter = LinearFilter
+      map.magFilter = LinearFilter
       map.colorSpace = NoColorSpace
+      map.needsUpdate = true
 
       for (const meshName of meshNames) {
         if (!maps[meshName]) {


### PR DESCRIPTION
Follow-up to the lightmap filtering in #489: the AO maps are the other half of the baked shading and still rendered with `NearestFilter`, showing the same texel stair-stepping in lighting gradients. They now use `LinearFilter` like the lightmaps, and both groups set `needsUpdate` so the filter change applies even to already-uploaded textures.

Matcaps and glass reflexes intentionally keep `NearestFilter` (stylized).

Verified on the dev server across the office scenes; tsc/lint clean.