### PR TITLE
feat(realtime): animate the online count with NumberFlow

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@million/lint": "^1.0.14",
     "@mux/mux-video-react": "^0.24.3",
     "@notionhq/client": "^5.13.0",
+    "@number-flow/react": "^0.6.2",
     "@phosphor-icons/react": "^2.1.10",
     "@portabletext/react": "^6.0.3",
     "@portabletext/types": "^4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@notionhq/client':
         specifier: ^5.13.0
         version: 5.13.0
+      '@number-flow/react':
+        specifier: ^0.6.2
+        version: 0.6.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -2640,6 +2643,12 @@ packages:
   '@notionhq/client@5.13.0':
     resolution: {integrity: sha512-SWVaqYVNaecLzAAllups4vklxxomaFenEMEkoUs3ylvhK1KFTU5Jevgu9Uwm/TSdhsErV0ru5YHcLd3SNyPi6Q==}
     engines: {node: '>=18'}
+
+  '@number-flow/react@0.6.2':
+    resolution: {integrity: sha512-WjZuV4aA+vhRCgCF+adGLgFVVAJ8vdvq6EchRT2FiBIgElTXtDOA3YgkcMr9UHpvpS9v4H70AB5wZv0D9jc3QA==}
+    peerDependencies:
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
 
   '@oclif/core@4.11.11':
     resolution: {integrity: sha512-LoGzrvkH9I8dwhxuLafcf90MAp+fYfAiAhpyixaVAWaclIgs+vXeMMQwBG90/wqjdygIKcFAqNnNJrfl3s3X8Q==}
@@ -6251,6 +6260,9 @@ packages:
       jiti:
         optional: true
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   esniff@2.0.1:
     resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
     engines: {node: '>=0.10'}
@@ -7774,6 +7786,9 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  number-flow@0.6.2:
+    resolution: {integrity: sha512-MCnImG4Q5vPwhSXnov56nOuyyKn6LC+Qd7II1UiKc+ACRtug5iAtn0+CwXNxM38AC5lSowEY+oYEtZX2qMnUyw==}
 
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
@@ -12608,6 +12623,13 @@ snapshots:
 
   '@notionhq/client@5.13.0': {}
 
+  '@number-flow/react@0.6.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      esm-env: 1.2.2
+      number-flow: 0.6.2
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@oclif/core@4.11.11':
     dependencies:
       ansi-escapes: 4.3.2
@@ -16849,6 +16871,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esm-env@1.2.2: {}
+
   esniff@2.0.1:
     dependencies:
       d: 1.0.2
@@ -18369,6 +18393,10 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  number-flow@0.6.2:
+    dependencies:
+      esm-env: 1.2.2
 
   nwsapi@2.2.23: {}
 

--- a/src/components/realtime/online-count.tsx
+++ b/src/components/realtime/online-count.tsx
@@ -13,7 +13,10 @@ export const OnlineCount = () => {
     <span className="group relative flex items-center gap-1 text-[0.75rem] font-semibold leading-4 text-brand-w2">
       <span className="size-1.5 animate-pulse rounded-full bg-brand-o" />
       Online{" "}
-      <sup className="text-caption text-brand-g1">
+      {/* The navbar group is right-packed, so any width change here shifts
+          "Online" leftward: tabular-nums keeps every digit equal-width and
+          min-w reserves two digits so the badge only grows past 99 */}
+      <sup className="text-caption inline-block min-w-[3ch] tabular-nums text-brand-g1">
         (<NumberFlow value={count} />)
       </sup>
       <span

--- a/src/components/realtime/online-count.tsx
+++ b/src/components/realtime/online-count.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import NumberFlow from "@number-flow/react"
+
 import { useRealtimeStore } from "./realtime-store"
 
 export const OnlineCount = () => {
@@ -10,7 +12,10 @@ export const OnlineCount = () => {
   return (
     <span className="group relative flex items-center gap-1 text-[0.75rem] font-semibold leading-4 text-brand-w2">
       <span className="size-1.5 animate-pulse rounded-full bg-brand-o" />
-      Online <sup className="text-caption text-brand-g1">({count})</sup>
+      Online{" "}
+      <sup className="text-caption text-brand-g1">
+        (<NumberFlow value={count} />)
+      </sup>
       <span
         role="tooltip"
         className="text-caption pointer-events-none absolute right-0 top-full mt-2 whitespace-nowrap border border-brand-g2 bg-brand-k px-2 py-1 font-normal text-brand-w1 opacity-0 transition-opacity duration-200 group-hover:opacity-100"


### PR DESCRIPTION
## What

Swaps the plain `{count}` in the navbar Online indicator for [NumberFlow](https://number-flow.barvian.me/) (`@number-flow/react`, ~4kB), so count changes roll digits instead of snapping.

- Only `online-count.tsx` changes; the presence/debounce logic from #493 is untouched — NumberFlow just animates the value the store already produces (rises instant, drops debounced 3s).
- Respects `prefers-reduced-motion` by default and doesn't animate on first mount, so initial render shows the number immediately.
- Inherits the existing `sup` typography; parentheses stay as plain text around the animated digits.

## Testing

- ESLint + `tsc --noEmit` clean; React 19 is within the package's peer range (`^18 || ^19`).
- Visual check on the Vercel preview with `NEXT_PUBLIC_FEATURE_REALTIME=1`: open a second browser to bump the count and watch the digit roll.