### PR TITLE
fix(realtime): count only active viewers in the online badge

### DIFF
--- a/src/components/realtime/realtime-impl.tsx
+++ b/src/components/realtime/realtime-impl.tsx
@@ -65,9 +65,17 @@ export const RealtimeImpl = () => {
 
     let hiddenTimeout: ReturnType<typeof setTimeout> | null = null
 
+    // Tracks whether this tab currently holds a presence entry: hiding can
+    // race the initial subscription, so "a timer is pending" doesn't imply
+    // "we are tracked" and the visible branch needs its own signal
+    let tracked = false
+
     // No id in the payload: the presence key already identifies the entry,
     // and the payload is broadcast to every subscriber
-    const track = () => channel.track({ joinedAt: Date.now() })
+    const track = () => {
+      tracked = true
+      return channel.track({ joinedAt: Date.now() })
+    }
 
     channel
       .on("presence", { event: "sync" }, () => {
@@ -87,6 +95,7 @@ export const RealtimeImpl = () => {
         if (hiddenTimeout) clearTimeout(hiddenTimeout)
         hiddenTimeout = setTimeout(() => {
           hiddenTimeout = null
+          tracked = false
           channel.untrack()
         }, HIDDEN_UNTRACK_MS)
         return
@@ -94,7 +103,8 @@ export const RealtimeImpl = () => {
       if (hiddenTimeout) {
         clearTimeout(hiddenTimeout)
         hiddenTimeout = null
-      } else if (channel.state === "joined") {
+      }
+      if (!tracked && channel.state === "joined") {
         track()
       }
     }

--- a/src/components/realtime/realtime-impl.tsx
+++ b/src/components/realtime/realtime-impl.tsx
@@ -20,9 +20,10 @@ const BUSY_ROOM_PEERS = 6
 const CURSOR_BROADCAST_BUSY_MS = 500
 const MIN_SEND_DIST_PX = 2
 
-// A reload leaves and rejoins presence, so drops in the online count are held
-// back briefly and cancelled if the count recovers; rises apply immediately.
-const ONLINE_DROP_DEBOUNCE_MS = 3000
+// Grace period before a hidden tab leaves presence: every leave/join is
+// broadcast to all subscribers, so quick tab switches shouldn't churn the
+// channel. Becoming visible again re-tracks immediately.
+const HIDDEN_UNTRACK_MS = 10_000
 
 // Public (non-private) Broadcast/Presence channels: anon key only, no tables
 // or RLS involved. Hardening to private channels + RLS on realtime.messages
@@ -62,38 +63,46 @@ export const RealtimeImpl = () => {
       config: { presence: { key: getBrowserId() } }
     })
 
-    let dropTimeout: ReturnType<typeof setTimeout> | null = null
+    let hiddenTimeout: ReturnType<typeof setTimeout> | null = null
+
+    // No id in the payload: the presence key already identifies the entry,
+    // and the payload is broadcast to every subscriber
+    const track = () => channel.track({ joinedAt: Date.now() })
 
     channel
       .on("presence", { event: "sync" }, () => {
-        const next = Object.keys(channel.presenceState()).length
-        const store = useRealtimeStore.getState()
-        if (next >= store.onlineCount) {
-          if (dropTimeout) {
-            clearTimeout(dropTimeout)
-            dropTimeout = null
-          }
-          store.setOnlineCount(next)
-          return
-        }
-        if (dropTimeout) clearTimeout(dropTimeout)
-        dropTimeout = setTimeout(() => {
-          dropTimeout = null
-          useRealtimeStore
-            .getState()
-            .setOnlineCount(Object.keys(channel.presenceState()).length)
-        }, ONLINE_DROP_DEBOUNCE_MS)
+        useRealtimeStore
+          .getState()
+          .setOnlineCount(Object.keys(channel.presenceState()).length)
       })
       .subscribe(async (status) => {
-        if (status === "SUBSCRIBED") {
-          // No id in the payload: the presence key already identifies the
-          // entry, and the payload is broadcast to every subscriber
-          await channel.track({ joinedAt: Date.now() })
+        if (status === "SUBSCRIBED" && !document.hidden) {
+          await track()
         }
       })
 
+    // Only active viewers count: a tab that stays hidden leaves presence
+    const onVisibilityChange = () => {
+      if (document.hidden) {
+        if (hiddenTimeout) clearTimeout(hiddenTimeout)
+        hiddenTimeout = setTimeout(() => {
+          hiddenTimeout = null
+          channel.untrack()
+        }, HIDDEN_UNTRACK_MS)
+        return
+      }
+      if (hiddenTimeout) {
+        clearTimeout(hiddenTimeout)
+        hiddenTimeout = null
+      } else if (channel.state === "joined") {
+        track()
+      }
+    }
+    document.addEventListener("visibilitychange", onVisibilityChange)
+
     return () => {
-      if (dropTimeout) clearTimeout(dropTimeout)
+      document.removeEventListener("visibilitychange", onVisibilityChange)
+      if (hiddenTimeout) clearTimeout(hiddenTimeout)
       useRealtimeStore.getState().setOnlineCount(0)
       supabase.removeChannel(channel)
     }


### PR DESCRIPTION
## Problem

The navbar online count sat at ~30 while analytics showed ~10 concurrent visitors.

Root cause: the 3s drop-debounce from #493 re-armed its timer on every presence sync that came in below the currently displayed count. The presence channel is site-wide, so a sync fires for every join/leave anywhere on the site — under normal churn one arrives more often than every 3s, so the timer never fired. Joins applied instantly, drops were postponed indefinitely, and the badge effectively displayed the session's running maximum.

## Changes

- **Remove the drop-debounce entirely.** Every sync writes `Object.keys(presenceState()).length` straight to the store, so the badge always mirrors the real presence state. Cost: a brief −1/+1 flicker when a visitor's only tab hard-reloads (tabs share a browser-level presence key, so multi-tab visitors don't flicker).
- **Only active viewers count.** A `visibilitychange` listener untracks presence after a tab has been hidden for 10s (`HIDDEN_UNTRACK_MS`) and re-tracks immediately when it becomes visible; a tab that's hidden when the channel subscribes never tracks until viewed. Background tabs and locked phones — previously counted for as long as their socket lived — no longer inflate the number. The 10s grace period keeps quick tab switches from broadcasting presence leave/join churn to every subscriber (each delivery is billed, per #495).

## Remaining known gaps (no client-side fix)

- Storage-blocked browsers fall back to a per-tab id and count once per tab.
- Abrupt disconnects linger until Supabase's server-side heartbeat reap.

The badge may still read slightly above analytics, but it now tracks reality instead of the daily peak.

## Testing

- ESLint + tsc clean (only the two pre-existing missing-asset errors remain, present on the untouched tree).
- Fake-timer simulation of the sync handler: with 30 online and continuous leave/join churn the displayed count now tracks down correctly (previously pinned at 30).
- Manual check for review: open two browser profiles, hide one tab >10s → count drops on the other; refocus → returns instantly. Reload with a single tab → brief dip only.