### PR TITLE
fix(cursor): keep the clock hover label open while the time ticks

### DIFF
--- a/src/components/clock/index.tsx
+++ b/src/components/clock/index.tsx
@@ -82,6 +82,7 @@ export const Clock = () => {
     eyes.forEach((eye) => (eye.rotation.y = eyeSwing))
   })
 
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null)
   const intervalRef = useRef<NodeJS.Timeout | null>(null)
 
   useEffect(() => {
@@ -97,10 +98,18 @@ export const Clock = () => {
 
       handleTime()
 
-      intervalRef.current = setInterval(handleTime, 1000)
+      // Phase-lock ticks to the wall-clock second so rollovers show on time
+      timeoutRef.current = setTimeout(
+        () => {
+          handleTime()
+          intervalRef.current = setInterval(handleTime, 1000)
+        },
+        1000 - (Date.now() % 1000)
+      )
     } else setCursor("default", null)
 
     return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
       if (intervalRef.current) clearInterval(intervalRef.current)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/clock/index.tsx
+++ b/src/components/clock/index.tsx
@@ -83,7 +83,6 @@ export const Clock = () => {
   })
 
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
-  const intervalRef = useRef<NodeJS.Timeout | null>(null)
 
   useEffect(() => {
     if (hovered) {
@@ -96,21 +95,17 @@ export const Clock = () => {
         setCursor("pointer", message)
       }
 
-      handleTime()
-
-      // Phase-lock ticks to the wall-clock second so rollovers show on time
-      timeoutRef.current = setTimeout(
-        () => {
-          handleTime()
-          intervalRef.current = setInterval(handleTime, 1000)
-        },
-        1000 - (Date.now() % 1000)
-      )
+      // Phase-lock every tick to the wall-clock second so rollovers show on
+      // time, even if a timer fires late (e.g. throttled background tab)
+      const tick = () => {
+        handleTime()
+        timeoutRef.current = setTimeout(tick, 1000 - (Date.now() % 1000))
+      }
+      tick()
     } else setCursor("default", null)
 
     return () => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current)
-      if (intervalRef.current) clearInterval(intervalRef.current)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hovered])

--- a/src/components/custom-cursor/index.tsx
+++ b/src/components/custom-cursor/index.tsx
@@ -472,7 +472,7 @@ export const CustomCursor = memo(() => {
               />
             </m.div>
           ) : hoverText ? (
-            <CursorLabel key={`hover:${hoverText}`}>
+            <CursorLabel key="hover">
               {!marquee ? (
                 `[${hoverText}]`
               ) : (


### PR DESCRIPTION
## Problem

Hovering the cat clock shows the Buenos Aires time in the cursor label, but the label popped out and back in every second instead of staying open with the time ticking.

The time was already recomputed every second — the issue was that the hover label in `custom-cursor/index.tsx` is keyed on its full text inside `AnimatePresence`. Since the clock's hover text includes seconds, the key changed every 1000ms and the label fully unmounted/remounted with its scale-0 pop animation on each tick. Regression from 9a66a4b, where per-text keys were added so *chat messages* re-pop but also captured the hover slot.

## Fix

- **`src/components/custom-cursor/index.tsx`** — stable `key="hover"` for the hover slot, so text updates re-render in place. The chat-message slot keeps its own key, so its re-pop behavior is unchanged.
- **`src/components/clock/index.tsx`** — phase-lock the hover ticker to the wall-clock second boundary. The old interval started at pointer-enter time, so the displayed second lagged by up to ~1s and minute/hour rollovers showed late.

## Testing

- Hover the cat clock in the map scene: the `[HH:MM:SS - GMT-3 🇦🇷]` label pops in once, stays open, and the time ticks in place across minute/hour boundaries.
- Other hover labels still animate in/out on enter/leave; cursor chat messages still re-pop.
- `eslint` clean on both files; `tsc` shows only pre-existing unrelated errors (missing `.jpg` module declarations generated by `next dev`).